### PR TITLE
Add initial `flepimop2.configuration`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,8 @@ authors = [
 requires-python = ">=3.10"
 dependencies = [
     "click>=8.3.0",
+    "pydantic>=2.12.2",
+    "pyyaml>=6.0.3",
 ]
 
 [project.scripts]
@@ -25,6 +27,8 @@ dev = [
     "mypy>=1.18.2",
     "pytest>=8.4.2",
     "ruff>=0.13.3",
+    "types-pyyaml>=6.0.12.20250915",
+    "typing-extensions>=4.15.0",
 ]
 
 [tool.pytest.ini_options]

--- a/src/flepimop2/__init__.py
+++ b/src/flepimop2/__init__.py
@@ -1,7 +1,7 @@
 """flepimop2 modeling pipeline package."""
 
-__all__ = ["__version__", "logging"]
+__all__ = ["__version__", "configuration", "logging"]
 
 __version__ = "0.1.0"
 
-from flepimop2 import logging
+from flepimop2 import configuration, logging

--- a/src/flepimop2/configuration/__init__.py
+++ b/src/flepimop2/configuration/__init__.py
@@ -1,0 +1,19 @@
+"""Representations of parsed configuration files."""
+
+__all__ = [
+    "ConfigurationModel",
+    "EngineModel",
+    "FixedParameterSpecificationModel",
+    "ParameterSpecificationModel",
+    "SimulateSpecificationModel",
+    "SystemModel",
+]
+
+from flepimop2.configuration._configuration import ConfigurationModel
+from flepimop2.configuration._engine import EngineModel
+from flepimop2.configuration._parameters import (
+    FixedParameterSpecificationModel,
+    ParameterSpecificationModel,
+)
+from flepimop2.configuration._simulate import SimulateSpecificationModel
+from flepimop2.configuration._system import SystemModel

--- a/src/flepimop2/configuration/_configuration.py
+++ b/src/flepimop2/configuration/_configuration.py
@@ -1,0 +1,109 @@
+import sys
+from typing import Literal
+
+from pydantic import Field, model_validator
+
+from flepimop2.configuration._engine import EngineModel
+from flepimop2.configuration._parameters import ParameterSpecificationModel
+from flepimop2.configuration._simulate import SimulateSpecificationModel
+from flepimop2.configuration._system import SystemModel
+from flepimop2.configuration._yaml import YamlSerializableBaseModel
+
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
+
+
+class ConfigurationModel(YamlSerializableBaseModel):
+    """
+    Configuration model for flepimop2.
+
+    This model serves as the parent container for a parsed configuration file.
+    """
+
+    name: str | None = None
+    engines: dict[str, EngineModel] = Field(default_factory=dict)
+    systems: dict[str, SystemModel] = Field(default_factory=dict)
+    parameters: dict[str, ParameterSpecificationModel] = Field(default_factory=dict)
+    simulate: dict[str, SimulateSpecificationModel] = Field(default_factory=dict)
+
+    def _check_simulate_engines_or_systems(
+        self, kind: Literal["engine", "system"]
+    ) -> None:
+        """
+        Ensure that all engines or systems referenced in simulate exist.
+
+        Args:
+            kind: Either "engine" or "system" to specify which to check.
+
+        Raises:
+            ValueError: If any referenced engines or systems are not defined.
+        """
+        items = {getattr(sim, kind) for sim in self.simulate.values()}
+        defined = set(getattr(self, f"{kind}s").keys())
+        if missing := items - defined:
+            msg = f"{kind.capitalize()}s referenced in simulate not defined: {missing}"
+            raise ValueError(msg)
+
+    @model_validator(mode="after")
+    def _check_simulate_engines(self) -> Self:
+        """
+        Ensure that all engines referenced in simulate exist.
+
+        Returns:
+            The validated `ConfigurationModel` instance.
+
+        Examples:
+            >>> from flepimop2.configuration import ConfigurationModel
+            >>> config = {
+            ...     "engines": {
+            ...         "foo": {"module": "test"},
+            ...     },
+            ...     "systems": {
+            ...         "bar": {"module": "test"},
+            ...     },
+            ...     "simulate": {
+            ...         "sim1": {"engine": "fizz", "system": "bar"},
+            ...     },
+            ... }
+            >>> configuration = ConfigurationModel.model_validate(config)
+            Traceback (most recent call last):
+                ...
+            pydantic_core._pydantic_core.ValidationError: 1 validation error for ConfigurationModel
+              Value error, Engines referenced in simulate not defined: {'fizz'} [type=value_error, input_value={'engines': {'foo': {'mod...izz', 'system': 'bar'}}}, input_type=dict]
+                For further information visit https://errors.pydantic.dev/2.12/v/value_error
+        """  # noqa: E501
+        self._check_simulate_engines_or_systems("engine")
+        return self
+
+    @model_validator(mode="after")
+    def _check_simulate_systems(self) -> Self:
+        """
+        Ensure that all systems referenced in simulate exist.
+
+        Returns:
+            The validated `ConfigurationModel` instance.
+
+        Examples:
+            >>> from flepimop2.configuration import ConfigurationModel
+            >>> config = {
+            ...     "engines": {
+            ...         "foo": {"module": "test"},
+            ...     },
+            ...     "systems": {
+            ...         "bar": {"module": "test"},
+            ...     },
+            ...     "simulate": {
+            ...         "sim1": {"engine": "foo", "system": "buzz"},
+            ...     },
+            ... }
+            >>> configuration = ConfigurationModel.model_validate(config)
+            Traceback (most recent call last):
+                ...
+            pydantic_core._pydantic_core.ValidationError: 1 validation error for ConfigurationModel
+              Value error, Systems referenced in simulate not defined: {'buzz'} [type=value_error, input_value={'engines': {'foo': {'mod...oo', 'system': 'buzz'}}}, input_type=dict]
+                For further information visit https://errors.pydantic.dev/2.12/v/value_error
+        """  # noqa: E501
+        self._check_simulate_engines_or_systems("system")
+        return self

--- a/src/flepimop2/configuration/_engine.py
+++ b/src/flepimop2/configuration/_engine.py
@@ -1,0 +1,8 @@
+from pydantic import BaseModel, Field
+
+
+class EngineModel(BaseModel):
+    """Engine configuration model for flepimop2."""
+
+    module: str = Field(min_length=1)
+    options: dict[str, str] = Field(default_factory=dict)

--- a/src/flepimop2/configuration/_parameters.py
+++ b/src/flepimop2/configuration/_parameters.py
@@ -1,0 +1,34 @@
+from typing import Any, Literal
+
+from pydantic import BaseModel, model_serializer, model_validator
+
+
+class FixedParameterSpecificationModel(BaseModel):
+    """
+    Fixed parameter specification model.
+
+    This model represents a parameter with a fixed value.
+    """
+
+    type: Literal["fixed"] = "fixed"
+    value: float
+
+    @model_validator(mode="before")
+    @classmethod
+    def _coerce_parameter_specification(cls, value: Any) -> Any:  # noqa: ANN401
+        if isinstance(value, (int, float)):
+            return {"type": "fixed", "value": float(value)}
+        return value
+
+    @model_serializer
+    def _serialize_as_number(self) -> float:
+        """
+        Serialize fixed parameters as just the numeric value.
+
+        Returns:
+            The numeric `value` of the fixed parameter.
+        """
+        return self.value
+
+
+ParameterSpecificationModel = FixedParameterSpecificationModel

--- a/src/flepimop2/configuration/_simulate.py
+++ b/src/flepimop2/configuration/_simulate.py
@@ -1,0 +1,10 @@
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class SimulateSpecificationModel(BaseModel):
+    """Model for specifying a simulation for flepimop2."""
+
+    model_config = ConfigDict(extra="allow")
+
+    engine: str = Field(min_length=1)
+    system: str = Field(min_length=1)

--- a/src/flepimop2/configuration/_system.py
+++ b/src/flepimop2/configuration/_system.py
@@ -1,0 +1,9 @@
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class SystemModel(BaseModel):
+    """Model configuration model for flepimop2."""
+
+    model_config = ConfigDict(extra="allow")
+
+    module: str = Field(min_length=1)

--- a/src/flepimop2/configuration/_yaml.py
+++ b/src/flepimop2/configuration/_yaml.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from pydantic import BaseModel
+from yaml import safe_dump, safe_load
+
+if TYPE_CHECKING:
+    import sys
+
+    if sys.version_info >= (3, 11):
+        from typing import Self
+    else:
+        from typing_extensions import Self
+
+
+class YamlSerializableBaseModel(BaseModel):
+    """Base model with YAML serialization support."""
+
+    @classmethod
+    def from_yaml(cls, file: Path, encoding: str = "utf-8") -> "Self":
+        """
+        Deserialize a YAML string to an instance of the model.
+
+        Args:
+            file: Path to the YAML file to read.
+            encoding: Encoding of the YAML file.
+
+        Returns:
+            An instance of the model.
+        """
+        return cls.model_validate(safe_load(file.read_text(encoding=encoding)))
+
+    def to_yaml(self, file: Path, encoding: str = "utf-8") -> None:
+        """
+        Serialize the model to a YAML string.
+
+        Args:
+            file: Path to the YAML file to read.
+            encoding: Encoding of the YAML file.
+        """
+        with file.open("w", encoding=encoding) as f:
+            safe_dump(self.model_dump(), stream=f, encoding=encoding)

--- a/tests/configuration/_yaml/test_yaml_serializable_base_model.py
+++ b/tests/configuration/_yaml/test_yaml_serializable_base_model.py
@@ -1,0 +1,51 @@
+"""Unit tests for the `YamlSerializableBaseModel` class."""
+
+from pathlib import Path
+
+import pytest
+
+from flepimop2.configuration._yaml import YamlSerializableBaseModel
+
+
+class SimpleModel(YamlSerializableBaseModel):
+    """Simple test model with basic types."""
+
+    name: str
+    count: int
+
+
+class ComplexModel(YamlSerializableBaseModel):
+    """Test model with nested list of models."""
+
+    name: str
+    items: list[SimpleModel]
+    metadata: dict[str, str]
+
+
+@pytest.mark.parametrize(
+    ("model_class", "instance"),
+    [
+        (SimpleModel, SimpleModel(name="test", count=42)),
+        (
+            ComplexModel,
+            ComplexModel(
+                name="complex_test",
+                items=[
+                    SimpleModel(name="item1", count=5),
+                    SimpleModel(name="item2", count=7),
+                ],
+                metadata={"key1": "value1", "key2": "value2"},
+            ),
+        ),
+    ],
+)
+def test_yaml_serialization_round_trip(
+    model_class: type[YamlSerializableBaseModel],
+    instance: YamlSerializableBaseModel,
+    tmp_path: Path,
+) -> None:
+    """Test that serializing and deserializing returns an equivalent object."""
+    yaml_file = tmp_path / "test.yaml"
+    instance.to_yaml(yaml_file)
+    loaded = model_class.from_yaml(yaml_file)
+    assert loaded == instance

--- a/tests/configuration/test_fixed_parameter_specification_model_class.py
+++ b/tests/configuration/test_fixed_parameter_specification_model_class.py
@@ -1,0 +1,25 @@
+"""Unit tests for the `FixedParameterSpecificationModel` class."""
+
+import math
+from pathlib import Path
+
+from yaml import safe_load
+
+from flepimop2.configuration import FixedParameterSpecificationModel
+from flepimop2.configuration._yaml import YamlSerializableBaseModel
+
+
+class SerializedFixedParameterExampleModel(YamlSerializableBaseModel):
+    """Example model for testing serialization of FixedParameterSpecificationModel."""
+
+    parameter: FixedParameterSpecificationModel
+
+
+def test_fixed_parameter_serialized_as_number(tmp_path: Path) -> None:
+    """Test that a fixed parameter specified as a number is correctly serialized."""
+    model = SerializedFixedParameterExampleModel.model_validate({"parameter": math.pi})
+    assert isinstance(model.parameter, FixedParameterSpecificationModel)
+    yaml_path = tmp_path / "fixed_parameter.yaml"
+    model.to_yaml(yaml_path)
+    contents = safe_load(yaml_path.read_text())
+    assert contents == {"parameter": math.pi}


### PR DESCRIPTION
Added an initial outline for the `flepimop2.configuration` module that
will serve as the basis for defining configuration files. Currently the
main elements are:

* The `ConfigurationModel` for defining a complete configuration file.
* The `EngineModel`, `SystemModel`, and `SimulateSpecificationModel` for
  representing the engines, systems, and simulate  sections within a
  `ConfigurationModel`.
* `ParameterSpecificationModel` (currently just an alias for
  `FixedParameterSpecificationModel`), but can be adjusted in the
  future.
* The `FixedParameterSpecificationModel` for representing fixed value
  parameters with convenient short hand for parsed/serialized models.

The current `ConfigurationModel` is very loose and leaves many details
to be filled in. This class subclasses the also added
`YamlSerializableBaseModel` which provides methods for parsing an
instance of this class from a configuration YAML file or serializing a
configuration to a YAML file.

In addition made minor changes:

* Added `pydantic` and `pyyaml` to project dependencies.
* Added `types-PyYAML` and `typing-extensions` to project development
  dependencies.