### PR TITLE
Setup documentation with `mkdocs`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   ci:
-    name: 'CI (Python ${{ matrix.python-version }})'
+    name: 'CI (${{ matrix.python-version }})'
     runs-on: 'ubuntu-latest'
     strategy:
       matrix:
@@ -38,5 +38,31 @@ jobs:
           python-version: '${{ matrix.python-version }}'
       - name: 'Run Checks'
         run: 'just ci'
+        env:
+          UV_PYTHON_VERSION: '${{ matrix.python-version }}'
+  docs:
+    name: 'Build (${{ matrix.python-version }})'
+    runs-on: 'ubuntu-latest'
+    strategy:
+      matrix:
+        python-version:
+          - '3.12'
+    steps:
+      - name: 'Install just'
+        run: 'sudo apt install just'
+      - name: 'Checkout repository'
+        # v5.0.0
+        uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8'
+        with:
+          persist-credentials: false
+      - name: 'Setup uv'
+        # v6.8.0
+        uses: 'astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e'
+        with:
+          enable-cache: true
+          cache-dependency-glob: 'pyproject.toml'
+          python-version: '${{ matrix.python-version }}'
+      - name: 'Build Documentation'
+        run: 'just docs'
         env:
           UV_PYTHON_VERSION: '${{ matrix.python-version }}'

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,27 @@
+"""Pytest test configuration."""
+
+from os import chdir
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Any
+
+from sybil import Sybil
+from sybil.parsers.markdown import PythonCodeBlockParser, SkipParser
+
+
+def documentation_setup(documentation_setup: dict[str, Any]) -> None:  # noqa: ARG001
+    """Create and chnange to a temporary directory for documentation tests."""
+    directory = Path(TemporaryDirectory().name)
+    directory.mkdir(parents=True, exist_ok=True)
+    chdir(directory)
+
+
+pytest_collect_file = Sybil(
+    parsers=[
+        PythonCodeBlockParser(),
+        SkipParser(),
+    ],
+    path=str(Path(__file__).parent / "docs"),
+    pattern="**/*.md",
+    setup=documentation_setup,
+).pytest()

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -1,0 +1,15 @@
+# Getting Started
+
+A brief tutorial on how to get started with `flepimop2`.
+
+```python
+import math
+foo = 2 * math.pi
+```
+
+And then
+
+```python
+>>> foo
+6.283185307179586
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,3 @@
+# Welcome to `flepimop2`
+
+The next generation of the flexible epidemic modeling pipeline.

--- a/justfile
+++ b/justfile
@@ -29,3 +29,11 @@ clean:
     rm -f uv.lock
     rm -rf .*_cache
     rm -rf .venv
+
+# Build the documentation using `mkdocs`
+docs:
+    uv run mkdocs build --verbose --strict
+
+# Serve the documentation locally using `mkdocs`
+serve:
+    uv run mkdocs serve

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,6 @@
+---
+site_name: "flepimop2 Documentation"
+nav:
+  - Home: "index.md"
+  - Guides:
+      - Getting Started: "guides/getting-started.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,15 +24,18 @@ build-backend = "hatchling.build"
 
 [dependency-groups]
 dev = [
+    "mkdocs>=1.6.1",
     "mypy>=1.18.2",
     "pytest>=8.4.2",
     "ruff>=0.13.3",
+    "sybil[pytest]>=9.2.0",
     "types-pyyaml>=6.0.12.20250915",
     "typing-extensions>=4.15.0",
 ]
 
 [tool.pytest.ini_options]
 testpaths = [
+    "docs/",
     "src/flepimop2/",
     "tests/",
 ]


### PR DESCRIPTION
Setup draft documentation with `mkdocs`. Mostly just scaffolding for the moment. However some notable elements to the structure are:

* Integration with `sybil` for running code blocks in documentation as one continuous script.
* Add a `docs` job to the CI GitHub action workflow to check that the documentation builds okay.