### PR TITLE
Mock engine

### DIFF
--- a/src/flepimop2/__init__.py
+++ b/src/flepimop2/__init__.py
@@ -1,7 +1,7 @@
 """flepimop2 modeling pipeline package."""
 
-__all__ = ["__version__", "backends", "configuration", "logging"]
+__all__ = ["__version__", "backend", "configuration", "logging"]
 
 __version__ = "0.1.0"
 
-from flepimop2 import backends, configuration, logging
+from flepimop2 import backend, configuration, logging

--- a/src/flepimop2/_cli/_options.py
+++ b/src/flepimop2/_cli/_options.py
@@ -2,6 +2,7 @@
 
 __all__ = []
 
+import pathlib
 from collections.abc import Callable
 from typing import Any, Final, TypeVar
 
@@ -15,7 +16,9 @@ FC = TypeVar("FC", bound="AnyCallable | click.Command")
 COMMON_OPTIONS: Final = {
     "config": click.argument(
         "config",
-        type=click.Path(exists=True, dir_okay=False, readable=True),
+        type=click.Path(
+            exists=True, dir_okay=False, readable=True, path_type=pathlib.Path
+        ),
     ),
     "dry_run": click.option(
         "--dry-run",

--- a/src/flepimop2/_cli/_simulate_command.py
+++ b/src/flepimop2/_cli/_simulate_command.py
@@ -2,8 +2,16 @@
 
 __all__ = []
 
+from pathlib import Path
 
+import numpy as np
+
+import flepimop2.backend as backend_module
+import flepimop2.engine as engine_module
+import flepimop2.system as system_module
 from flepimop2._cli._cli_command import CliCommand
+from flepimop2.configuration import ConfigurationModel
+from flepimop2.meta import RunMeta
 
 
 class SimulateCommand(CliCommand):
@@ -16,7 +24,7 @@ class SimulateCommand(CliCommand):
 
     options = ("config", "verbosity", "dry_run")
 
-    def run(self, *, config: str, verbosity: int, dry_run: bool) -> None:  # type: ignore[override]
+    def run(self, *, config: Path, verbosity: int, dry_run: bool) -> None:  # type: ignore[override]
         """
         Execute the simulation.
 
@@ -25,5 +33,40 @@ class SimulateCommand(CliCommand):
             verbosity: Verbosity level (0-3).
             dry_run: Whether dry run mode is enabled.
         """
-        msg = "`SimulateCommand.run` is not yet implemented."
-        raise NotImplementedError(msg)
+        configmodel = ConfigurationModel.from_yaml(config)
+        simconfig = next(iter(configmodel.simulate.values()))
+
+        backend = configmodel.backends[simconfig.backend].model_dump()
+        stepper = configmodel.systems[simconfig.system].model_dump()
+        engine = configmodel.engines[simconfig.engine].model_dump()
+        params = configmodel.parameters
+
+        times = np.asarray(simconfig.times, dtype=np.float64)
+        initial_state = np.array(
+            [
+                params.pop("S0").value,
+                params.pop("I0").value,
+                params.pop("R0").value,
+            ],
+            dtype=np.float64,
+        )
+        pars = {k: v.value for k, v in params.items()}
+
+        if dry_run:
+            self.info(msg=f"Dry run, verbosity {verbosity}")
+            self.info(f"Configuration {config} parsed successfully:")
+            self.info(f"  System: {simconfig.system} => {stepper}")
+            self.info(f"  Engine: {simconfig.engine} => {engine}")
+            self.info(f"  Backend: {simconfig.backend} => {backend}")
+            self.info(f"  Y0: {initial_state} [{type(initial_state)}]")
+            self.info(f"  Params: {pars} [{type(pars)}]")
+            self.info(f"  T: {times} [{type(times)}]")
+            return
+
+        stepobj = system_module.build(stepper)
+        engineobj = engine_module.build(engine)
+        backendobj = backend_module.build(backend)
+
+        res = engineobj.run(stepobj, times, initial_state, pars)
+
+        backendobj.save(res, RunMeta())

--- a/src/flepimop2/_utils/__init__.py
+++ b/src/flepimop2/_utils/__init__.py
@@ -1,0 +1,7 @@
+__all__ = [
+    "_load_builder",
+    "_load_module",
+    "_validate_function",
+]
+
+from flepimop2._utils._module import _load_builder, _load_module, _validate_function

--- a/src/flepimop2/_utils/_module.py
+++ b/src/flepimop2/_utils/_module.py
@@ -1,0 +1,34 @@
+from importlib import import_module
+from importlib.util import module_from_spec, spec_from_file_location
+from os import PathLike
+from pathlib import Path
+from types import ModuleType
+
+
+def _load_module(path: PathLike[str], mod_name: str) -> ModuleType:
+    resolved = Path(path).expanduser().resolve()
+    if not resolved.exists():
+        msg = f"No file found at: {resolved}"
+        raise FileNotFoundError(msg)
+    if resolved.suffix != ".py":
+        msg = f"No valid Python file found at: {resolved}"
+        raise FileNotFoundError(msg)
+    spec = spec_from_file_location(mod_name, str(resolved))
+    if not (spec and spec.loader):
+        msg = f"Could not load module from spec at: {resolved}"
+        raise ImportError(msg)
+    module = module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _validate_function(module: ModuleType, func_name: str) -> bool:
+    return hasattr(module, func_name) and callable(getattr(module, func_name))
+
+
+def _load_builder(mod_name: str) -> ModuleType:
+    mod = import_module(mod_name)
+    if _validate_function(mod, "build"):
+        return mod
+    msg = f"Module '{mod_name}' does not have a valid 'build' function."
+    raise AttributeError(msg)

--- a/src/flepimop2/backend/__init__.py
+++ b/src/flepimop2/backend/__init__.py
@@ -1,0 +1,5 @@
+"""Backend module for handling file IO in flepimop2."""
+
+__all__ = ["BackendABC", "build"]
+
+from flepimop2.backend.abc import BackendABC, build

--- a/src/flepimop2/backends/__init__.py
+++ b/src/flepimop2/backends/__init__.py
@@ -1,6 +1,0 @@
-"""Backend module for handling file IO in flepimop2."""
-
-__all__ = ["BackendABC", "CsvBackend"]
-
-from flepimop2.backends._backend import BackendABC
-from flepimop2.backends._csv import CsvBackend

--- a/src/flepimop2/configuration/_simulate.py
+++ b/src/flepimop2/configuration/_simulate.py
@@ -9,3 +9,5 @@ class SimulateSpecificationModel(BaseModel):
     engine: str = Field(min_length=1)
     system: str = Field(min_length=1)
     backend: str = Field(min_length=1)
+    times: list[float] = Field(min_length=1)
+    params: dict[str, float] | None = Field(default_factory=dict)

--- a/src/flepimop2/engine/__init__.py
+++ b/src/flepimop2/engine/__init__.py
@@ -1,0 +1,6 @@
+"""Abstract class for Engines to evolve Dynamic Systems."""
+
+__all__ = ["EngineABC", "EngineProtocol", "build"]
+
+from flepimop2.engine.abc import EngineABC, build
+from flepimop2.engine.protocol import EngineProtocol

--- a/src/flepimop2/engine/abc.py
+++ b/src/flepimop2/engine/abc.py
@@ -1,0 +1,91 @@
+"""Abstract class for Engines to evolve Dynamic Systems."""
+
+from abc import ABC
+from typing import Any
+
+import numpy as np
+from numpy.typing import NDArray
+
+from flepimop2._utils import _load_builder
+from flepimop2.engine.protocol import EngineProtocol
+from flepimop2.system import SystemABC, SystemProtocol
+
+
+def _no_run_func(
+    stepper: SystemProtocol,
+    times: NDArray[np.float64],
+    state: NDArray[np.float64],
+    params: dict[str, Any],
+    **kwargs: Any,
+) -> NDArray[np.float64]:
+    msg = "EngineABC::_runner must be provided by a concrete implementation."
+    raise NotImplementedError(msg)
+
+
+class EngineABC(ABC):
+    """Abstract class for Engines to evolve Dynamic Systems."""
+
+    def __init__(self, runner: EngineProtocol = _no_run_func) -> None:
+        """
+        Initialize an `EngineABC` from a runner function.
+
+        Args:
+            runner: The runner function for the engine. Defaults to a function that
+                raises `NotImplementedError`.
+        """
+        self._runner = runner
+
+    _runner: EngineProtocol
+
+    def run(
+        self,
+        system: SystemABC,
+        eval_times: NDArray[np.float64],
+        initial_state: NDArray[np.float64],
+        params: dict[str, Any],
+        **kwargs: Any,
+    ) -> NDArray[np.float64]:
+        """
+        Run the engine with the provided system and parameters.
+
+        Args:
+            system: The dynamic system to be evolved.
+            eval_times: Array of time points for evaluation.
+            initial_state: The initial state array.
+            params: Additional parameters for the stepper.
+            **kwargs: Additional keyword arguments for the engine.
+
+        Returns:
+            The evolved time x state array.
+        """
+        return self._runner(
+            system.stepper,
+            eval_times,
+            initial_state,
+            params,
+            **kwargs,
+        )
+
+
+def build(config: dict[str, Any] | EngineProtocol) -> EngineABC:
+    """Build a `EngineABC` from a configuration dictionary.
+
+    Args:
+        config: Configuration dictionary or a EngineProtocol. In dict mode, it contains
+            a 'module' key, it will be used to lookup the Engine module path. The module
+            will have "flepimop2.engine." prepended.
+
+    Returns:
+        The constructed engine instance.
+
+    Raises:
+        TypeError: If the built engine is not an instance of EngineABC.
+    """
+    if isinstance(config, EngineProtocol):
+        return EngineABC(config)
+    builder = _load_builder(f"flepimop2.engine.{config.pop('module', 'wrapper')}")
+    engine = builder.build(**config)
+    if not isinstance(engine, EngineABC):
+        msg = "The built engine is not an instance of EngineABC."
+        raise TypeError(msg)
+    return engine

--- a/src/flepimop2/engine/protocol.py
+++ b/src/flepimop2/engine/protocol.py
@@ -1,0 +1,36 @@
+"""Type-definition (Protocol) for engine runner functions."""
+
+from typing import Any, Protocol, runtime_checkable
+
+import numpy as np
+from numpy.typing import NDArray
+
+from flepimop2.system import SystemProtocol
+
+
+@runtime_checkable
+class EngineProtocol(Protocol):
+    """Type-definition (Protocol) for engine runner functions."""
+
+    def __call__(
+        self,
+        stepper: SystemProtocol,
+        times: NDArray[np.float64],
+        state: NDArray[np.float64],
+        params: dict[str, Any],
+        **kwargs: Any,
+    ) -> NDArray[np.float64]:
+        """
+        Protocol for engine runner functions.
+
+        Args:
+            stepper: The system stepper function.
+            times: Array of time points.
+            state: The current state array.
+            params: Additional parameters for the stepper.
+            **kwargs: Additional keyword arguments for the engine.
+
+        Returns:
+            The evolved time x state array.
+        """
+        ...

--- a/src/flepimop2/engine/wrapper.py
+++ b/src/flepimop2/engine/wrapper.py
@@ -1,0 +1,39 @@
+"""A `EngineABC` which wraps a user-defined script file."""
+
+from os import PathLike
+
+from flepimop2._utils._module import _load_module, _validate_function
+from flepimop2.engine.abc import EngineABC
+
+
+class WrapperEngine(EngineABC):
+    """A `EngineABC` which wraps a user-defined script file."""
+
+    def __init__(self, script: PathLike[str]) -> None:
+        """
+        Initialize a `WrapperEngine` from a script file.
+
+        Args:
+            script: Path to a script file which defines a 'runner' function.
+
+        Raises:
+            AttributeError: If the module does not have a valid 'runner' function.
+        """
+        mod = _load_module(script, "flepimop2.engine.wrapped")
+        if not _validate_function(mod, "runner"):
+            msg = f"Module at {script} does not have a valid 'runner' function."
+            raise AttributeError(msg)
+        super().__init__(mod.runner)
+
+
+def build(script: PathLike[str]) -> WrapperEngine:
+    """
+    Build a `WrapperEngine` from a configuration arguments.
+
+    Args:
+        script: Path to a script file which defines a 'runner' function.
+
+    Returns:
+        The constructed wrapper engine instance.
+    """
+    return WrapperEngine(script)

--- a/src/flepimop2/meta.py
+++ b/src/flepimop2/meta.py
@@ -2,7 +2,7 @@
 
 __all__ = ["RunMeta"]
 
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Literal, NamedTuple
 
 
@@ -16,6 +16,6 @@ class RunMeta(NamedTuple):
         name: An optional name for the run, typically pulled from the config.
     """
 
-    action: Literal["simulate"]
-    timestamp: datetime
-    name: str | None
+    action: Literal["simulate"] = "simulate"
+    timestamp: datetime = datetime.now(UTC)
+    name: str | None = None

--- a/src/flepimop2/system/__init__.py
+++ b/src/flepimop2/system/__init__.py
@@ -1,0 +1,6 @@
+"""Abstract class for Dynamic Systems."""
+
+__all__ = ["SystemABC", "SystemProtocol", "build"]
+
+from flepimop2.system.abc import SystemABC, build
+from flepimop2.system.protocol import SystemProtocol

--- a/src/flepimop2/system/abc.py
+++ b/src/flepimop2/system/abc.py
@@ -1,0 +1,77 @@
+"""Abstract class for Dynamic Systems."""
+
+from abc import ABC
+from typing import Any
+
+import numpy as np
+from numpy.typing import NDArray
+
+from flepimop2._utils import _load_builder
+from flepimop2.system.protocol import SystemProtocol
+
+
+def _no_step_function(
+    time: np.float64,
+    state: NDArray[np.float64],
+    **kwargs: Any,
+) -> NDArray[np.float64]:
+    msg = "SystemABC::stepper must be provided by a concrete implementation."
+    raise NotImplementedError(msg)
+
+
+class SystemABC(ABC):
+    """Abstract class for Dynamic Systems."""
+
+    # f(t, Y, params) -> dYdt
+    _stepper: SystemProtocol
+
+    def __init__(self, f: SystemProtocol = _no_step_function) -> None:
+        """
+        Initialize a `SystemABC` from a stepper function.
+
+        Args:
+            f: The stepper function for the system. Defaults to a function that
+                raises `NotImplementedError`.
+        """
+        self.stepper = f
+
+    def step(
+        self, time: np.float64, state: NDArray[np.float64], **params: Any
+    ) -> NDArray[np.float64]:
+        """
+        Perform a single step of the system's dynamics.
+
+        Args:
+            time: The current time.
+            state: The current state array.
+            **params: Additional parameters for the stepper.
+
+        Returns:
+            The next state array after one step.
+        """
+        return self.stepper(time, state, **params)
+
+
+def build(config: dict[str, Any] | SystemProtocol) -> SystemABC:
+    """
+    Build a `SystemABC` from a configuration dictionary.
+
+    Args:
+        config: Configuration dictionary or a SystemProtocol. In dict mode, it contains
+            a 'module' key, it will be used to lookup the System module path. The module
+            will have "flepimop2.system." prepended.
+
+    Returns:
+        The constructed system.
+
+    Raises:
+        TypeError: If the built system is not an instance of SystemABC.
+    """
+    if isinstance(config, SystemProtocol):
+        return SystemABC(config)
+    builder = _load_builder(f"flepimop2.system.{config.pop('module', 'wrapper')}")
+    system = builder.build(**config)
+    if not isinstance(system, SystemABC):
+        msg = "The built system is not an instance of SystemABC."
+        raise TypeError(msg)
+    return system

--- a/src/flepimop2/system/protocol.py
+++ b/src/flepimop2/system/protocol.py
@@ -1,0 +1,28 @@
+"""Type-definition (Protocol) for system stepper functions."""
+
+from typing import Any, Protocol, runtime_checkable
+
+import numpy as np
+from numpy.typing import NDArray
+
+__all__ = ["SystemProtocol"]
+
+
+@runtime_checkable
+class SystemProtocol(Protocol):
+    """Type-definition (Protocol) for system stepper functions."""
+
+    def __call__(
+        self, time: np.float64, state: NDArray[np.float64], **kwargs: Any
+    ) -> NDArray[np.float64]:
+        """Protocol for system stepper functions.
+
+        Args:
+            time: The current time.
+            state: The current state array.
+            **kwargs: Additional keyword arguments for the stepper.
+
+        Returns:
+            The next state array after one step.
+        """
+        ...

--- a/src/flepimop2/system/wrapper.py
+++ b/src/flepimop2/system/wrapper.py
@@ -1,0 +1,39 @@
+"""A `SystemABC` which wraps a user-defined script file."""
+
+from os import PathLike
+
+from flepimop2._utils._module import _load_module, _validate_function
+from flepimop2.system import SystemABC
+
+
+class WrapperSystem(SystemABC):
+    """A `SystemABC` which wraps a user-defined script file."""
+
+    def __init__(self, script: PathLike[str]) -> None:
+        """
+        Initialize a `WrapperSystem` from a script file.
+
+        Args:
+            script: Path to a script file which defines a 'stepper' function.
+
+        Raises:
+            AttributeError: If the module does not have a valid 'stepper' function.
+        """
+        mod = _load_module(script, "flepimop2.system.wrapped")
+        if not _validate_function(mod, "stepper"):
+            msg = f"Module at {script} does not have a valid 'stepper' function."
+            raise AttributeError(msg)
+        super().__init__(mod.stepper)
+
+
+def build(script: PathLike[str]) -> WrapperSystem:
+    """
+    Build a `WrapperSystem` from a configuration arguments.
+
+    Args:
+        script: Path to a script file which defines a 'stepper' function.
+
+    Returns:
+        The constructed wrapper system instance.
+    """
+    return WrapperSystem(script)

--- a/tests/backend/test_csv_backend_class.py
+++ b/tests/backend/test_csv_backend_class.py
@@ -8,7 +8,7 @@ import pytest
 from numpy.testing import assert_array_equal
 from numpy.typing import NDArray
 
-from flepimop2.backends import CsvBackend
+from flepimop2.backend import build
 from flepimop2.meta import RunMeta
 
 
@@ -39,7 +39,7 @@ def test_csv_backend_save_and_read_round_trip(
     run_meta: RunMeta,
 ) -> None:
     """Test that saving and reading an array returns the same data."""
-    backend = CsvBackend({"module": "csv", "path": str(tmp_path)})
+    backend = build({"module": "csv", "root": str(tmp_path)})
 
     backend.save(sample_array, run_meta)
     loaded_array = backend.read(run_meta)

--- a/tests/engine/test_engine_abc.py
+++ b/tests/engine/test_engine_abc.py
@@ -1,0 +1,38 @@
+"""Tests for `EngineABC` and default `WrapperEngine`."""
+
+from typing import Any, cast
+
+import numpy as np
+import pytest
+from numpy.typing import NDArray
+
+from flepimop2.engine import EngineABC
+
+
+def sample_step(
+    time: np.float64, state: NDArray[np.float64], **kwargs: Any
+) -> NDArray[np.float64]:
+    """
+    A simple stepper function for testing purposes.
+
+    Args:
+        time: The current time as a float64.
+        state: The current state as a numpy array.
+        **kwargs: Additional keyword arguments, including 'offset'.
+
+    Returns:
+        The updated state after applying the stepper logic.
+    """
+    return (state + cast("float", kwargs["offset"])) * time
+
+
+@pytest.mark.parametrize("engine", [EngineABC()])
+def test_abstraction_error(engine: EngineABC) -> None:
+    """Test `EngineABC` raises `NotImplementedError` when not overridden."""
+    with pytest.raises(NotImplementedError):
+        engine._runner(
+            sample_step,
+            np.array([0.0], dtype=np.float64),
+            np.array([1.0, 2.0, 3.0], dtype=np.float64),
+            {},
+        )

--- a/tests/engine/test_engine_wrapper.py
+++ b/tests/engine/test_engine_wrapper.py
@@ -1,0 +1,41 @@
+"""Tests for `EngineABC` and default `WrapperEngine`."""
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+from numpy.typing import NDArray
+
+import flepimop2.engine as engine_module
+import flepimop2.system as system_module
+from flepimop2.system import SystemABC
+
+TEST_SCRIPT = Path(__file__).with_suffix("") / "dummy_engine.py"
+
+
+def _test_step(
+    time: np.float64, state: NDArray[np.float64], offset: float
+) -> NDArray[np.float64]:
+    return (state + offset) * time
+
+
+@pytest.mark.parametrize("config", [{"script": TEST_SCRIPT}])
+@pytest.mark.parametrize("system", [system_module.build(_test_step)])
+@pytest.mark.parametrize("params", [{"offset": 1.0}])
+def test_wrapper_system(
+    config: dict, system: SystemABC, params: dict[str, float]
+) -> None:
+    """Test `WrapperEngine` loads a script and uses its `runner` function."""
+    engine = engine_module.build(config)
+    result = engine.run(
+        system,
+        [1.0, 2.0],
+        np.array([1.0, 2.0], dtype=np.float64),
+        params,
+        accumulate=False,
+    )
+    expected = np.zeros((2, 3), dtype=np.float64)
+    expected[:, 0] = [1.0, 2.0]
+    expected[0, 1:] = [1.0, 2.0]
+    expected[1, 1:] = (expected[0, 1:] + params["offset"]) * 2.0
+    np.testing.assert_array_equal(result, expected)

--- a/tests/engine/test_engine_wrapper/dummy_engine.py
+++ b/tests/engine/test_engine_wrapper/dummy_engine.py
@@ -1,0 +1,40 @@
+"""A dummy stepper function for testing `WrapperEngine`."""
+
+from typing import Any
+
+import numpy as np
+from numpy.typing import NDArray
+
+from flepimop2.system import SystemProtocol
+
+
+def runner(
+    f: SystemProtocol,
+    times: NDArray[np.float64],
+    state: NDArray[np.float64],
+    params: dict[str, Any],
+    *,
+    accumulate: bool,
+) -> NDArray[np.float64]:
+    """
+    A dummy runner function for testing purposes: only evaluates stepper at times.
+
+    Args:
+        f: The stepper function.
+        times: Array of time points.
+        state: The current state array.
+        params: Additional parameters for the stepper.
+        accumulate: Whether to accumulate results over time.
+
+    Returns:
+        The state array evaluated at each time point.
+    """
+    # numpy array to hold results - first column time, rest state
+    res = np.zeros((len(times), len(state) + 1), dtype=np.float64)
+    res[:, 0] = times
+    res[0, 1:] = state
+    for i, t in enumerate(times[1:]):
+        if accumulate:
+            res[i + 1, 1:] = res[i, 1:]
+        res[i + 1, 1:] += f(t, res[i, 1:], **params)
+    return res

--- a/tests/system/test_system_abc.py
+++ b/tests/system/test_system_abc.py
@@ -1,0 +1,44 @@
+"""Tests for `SystemABC` and default `WrapperSystem`."""
+
+from typing import Any, cast
+
+import numpy as np
+import pytest
+from numpy.typing import NDArray
+
+import flepimop2.system as system_module
+from flepimop2.system import SystemABC
+
+
+def stepper(
+    time: np.float64, state: NDArray[np.float64], **kwargs: Any
+) -> NDArray[np.float64]:
+    """
+    A simple stepper function for testing purposes.
+
+    Args:
+        time: The current time as a float64.
+        state: The current state as a numpy array.
+        **kwargs: Additional keyword arguments, including 'offset'.
+
+    Returns:
+        The updated state after applying the stepper logic.
+    """
+    return (state + cast("float", kwargs["offset"])) * time
+
+
+@pytest.mark.parametrize("system", [SystemABC()])
+def test_abstraction_error(system: SystemABC) -> None:
+    """Test `SystemABC` raises `NotImplementedError` when not overridden."""
+    with pytest.raises(NotImplementedError):
+        system.step(np.float64(0.0), np.array([1.0, 2.0, 3.0], dtype=np.float64))
+
+
+def test_build_with_protocol() -> None:
+    """Test `build` constructs a `SystemABC` when given a `SystemProtocol`."""
+    system = system_module.build(stepper)
+    result = system.step(
+        np.float64(1.0), np.array([1.0, 2.0, 3.0], dtype=np.float64), offset=1.0
+    )
+    expected = np.array([2.0, 3.0, 4.0], dtype=np.float64)
+    np.testing.assert_array_equal(result, expected)

--- a/tests/system/test_system_wrapper.py
+++ b/tests/system/test_system_wrapper.py
@@ -1,0 +1,30 @@
+"""Tests for `SystemABC` and default `WrapperSystem`."""
+
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+
+import flepimop2.system as system_module
+from flepimop2.system import SystemABC
+
+TEST_SCRIPT = Path(__file__).with_suffix("") / "dummy_system.py"
+
+
+@pytest.mark.parametrize("system", [SystemABC()])
+def test_abstraction_error(system: SystemABC) -> None:
+    """Test `SystemABC` raises `NotImplementedError` when not overridden."""
+    with pytest.raises(NotImplementedError):
+        system.step(0.0, np.array([1.0, 2.0, 3.0], dtype=np.float64))
+
+
+@pytest.mark.parametrize("config", [{"script": TEST_SCRIPT}])
+def test_wrapper_system(config: dict[str, Any]) -> None:
+    """Test `WrapperSystem` loads a script and uses its `stepper` function."""
+    system = system_module.build(config)
+    result = system.stepper(
+        1.0, np.array([1.0, 2.0, 3.0], dtype=np.float64), offset=1.0
+    )
+    expected = np.array([2.0, 3.0, 4.0], dtype=np.float64)
+    np.testing.assert_array_equal(result, expected)

--- a/tests/system/test_system_wrapper/dummy_system.py
+++ b/tests/system/test_system_wrapper/dummy_system.py
@@ -1,0 +1,21 @@
+"""A dummy stepper function for testing `WrapperSystem`."""
+
+import numpy as np
+from numpy.typing import NDArray
+
+
+def stepper(
+    time: float, state: NDArray[np.float64], offset: np.float64
+) -> NDArray[np.float64]:
+    """
+    A dummy stepper function for testing purposes: (state + offset) * time.
+
+    Args:
+        time: The current time.
+        state: The current state array.
+        offset: An offset value to be added to the state.
+
+    Returns:
+        The updated state array after applying the stepper logic.
+    """
+    return (state + offset) * time


### PR DESCRIPTION
Engine/systems initial implementation

Added an initial implementation of engines and systems starting with a
basic wrapper implementation which will load them from a file.

Systems are implementations of state evolvers (going from t to t+1). An
implementation of a system should inherit the `SystemABC` class. The
only currently included implementation is the `WrapperSystem` which will
load a stepper function from a file path.

Engines are implementations of system evolvers (the thing that
successively calls a system). Similar to systems, an engine should
inherit the `EngineABC` and the only currently included implementation
is `WrapperEngine`.

Both systems and engines provide a `build` function at
`flepimop2.{system/engine}.build` that allow for dynamically loading a
module by name which sets a foundation for a generalized plugin system.
Module loading mechanics are internal only at `flepimop2._util._module`.

Also refactored `flepimop2.backends` to `flepimop2.backend` to match the
naming and export conventions of `flepimop2.{system/engine}` to take
advantage of the dynamic module loading infrastructure.