### PR TITLE
Convert `CliCommand.run` to an instance method

### DIFF
--- a/src/flepimop2/_cli/_build_command.py
+++ b/src/flepimop2/_cli/_build_command.py
@@ -11,10 +11,7 @@ class BuildCommand(CliCommand):
 
     options = ("config", "verbosity", "dry_run")
 
-    @staticmethod
-    def run(  # type: ignore[override]
-        *, config: str, verbosity: int, dry_run: bool
-    ) -> None:
+    def run(self, *, config: str, verbosity: int, dry_run: bool) -> None:  # type: ignore[override]
         """
         Execute the build.
 

--- a/src/flepimop2/_cli/_cli_command.py
+++ b/src/flepimop2/_cli/_cli_command.py
@@ -41,9 +41,8 @@ class CliCommand(ABC):
             self.debug("%s = %s", key.ljust(longest_key, " "), self.format(value))
         self.run(**kwargs)
 
-    @staticmethod
     @abstractmethod
-    def run(**kwargs: Any) -> None:
+    def run(self, **kwargs: Any) -> None:
         """
         Execute the command.
 

--- a/src/flepimop2/_cli/_simulate_command.py
+++ b/src/flepimop2/_cli/_simulate_command.py
@@ -16,10 +16,7 @@ class SimulateCommand(CliCommand):
 
     options = ("config", "verbosity", "dry_run")
 
-    @staticmethod
-    def run(  # type: ignore[override]
-        *, config: str, verbosity: int, dry_run: bool
-    ) -> None:
+    def run(self, *, config: str, verbosity: int, dry_run: bool) -> None:  # type: ignore[override]
         """
         Execute the simulation.
 


### PR DESCRIPTION
Converted `CliCommand.run` from a static method to an instance method and made adjustments to `SimulateCommand` and `BuildCommand` to accommodate. This now allows implementations of `CliCommand` to access logging infrastructure provided by the abstract class. This change probably should have been included with a7bc505.