### PR TITLE
Deploy to GitHub pages

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -1,0 +1,81 @@
+---
+name: 'GitHub Pages Documentation'
+
+'on':
+  push:
+    branches:
+      - 'main'
+  release:
+    types:
+      - 'published'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: 'read'
+
+jobs:
+  deploy:
+    name: 'Deploy Documentation to GitHub Pages'
+    runs-on: 'ubuntu-latest'
+    strategy:
+      matrix:
+        python-version:
+          - '3.12'
+    permissions:
+      contents: 'write'  # Needed to push to gh-pages
+    steps:
+      - name: 'Install just'
+        run: 'sudo apt install just'
+      - name: 'Checkout repository'
+        # v5.0.0
+        uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8'
+        with:
+          ref: 'main'
+          persist-credentials: false
+      - name: 'Fetch gh-pages branch'
+        run: |
+          git fetch origin gh-pages:gh-pages --depth=1
+          git config --global user.name "${ACTOR}"
+          git config --global user.email "${ACTOR}@users.noreply.github.com"
+        env:
+          ACTOR: "${{ github.actor }}"
+      - name: 'Setup uv with python ${{ matrix.python-version }}'
+        # v7.1.2
+        uses: 'astral-sh/setup-uv@85856786d1ce8acfbcc2f13a5f3fbd6b938f9f41'
+        with:
+          enable-cache: true
+          cache-dependency-glob: 'pyproject.toml'
+          python-version: '${{ matrix.python-version }}'
+      - name: 'Extract flepimop2 version'
+        id: extract-version
+        run: |
+          cat > version.py << EOF
+          import tomllib
+          with open('pyproject.toml', 'rb') as f:
+              data = tomllib.load(f)
+          version = data['project']['version']
+          version = '.'.join(version.split('.')[:2])
+          print(f"version={version}")
+          EOF
+          uv run -qq python version.py >> $GITHUB_OUTPUT
+          rm version.py
+      - name: 'Deploy to GitHub Pages'
+        run: |
+          uv run mike set-default latest
+          if [ "${EVENT_NAME}" == "release" ] || [[ $VERSION == 0* ]]; then
+            ALIAS=latest
+          else
+            ALIAS=dev
+          fi
+          uv run mike deploy \
+            --push --update-aliases \
+            ${VERSION} ${ALIAS}
+          git push origin gh-pages
+        env:
+          EVENT_NAME: "${{ github.event_name }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          VERSION: "${{ steps.extract-version.outputs.version }}"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,24 @@
 ---
+# Site information
 site_name: "flepimop2 Documentation"
+site_url: "https://accidda.github.io/flepimop2/"
+
+# Repository information
+repo_name: "ACCIDDA/flepimop2"
+repo_url: "https://github.com/ACCIDDA/flepimop2"
+edit_uri: ""
+
+# Theme information
+theme:
+  name: "material"
+  custom_dir: "overrides"
+
+# Plugins
+extra:
+  version:
+    provider: "mike"
+
+# Navigation structure
 nav:
   - Home: "index.md"
   - Guides:

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -1,0 +1,8 @@
+{% extends "base.html" %}
+
+{% block outdated %}
+  You're not viewing the latest version.
+  <a href="{{ '../' ~ base_url }}">
+    <strong>Click here to go to latest.</strong>
+  </a>
+{% endblock %}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,9 @@ build-backend = "hatchling.build"
 
 [dependency-groups]
 dev = [
+    "mike>=2.1.3",
     "mkdocs>=1.6.1",
+    "mkdocs-material>=9.6.22",
     "mypy>=1.18.2",
     "pytest>=8.4.2",
     "ruff>=0.13.3",


### PR DESCRIPTION
* Added `mike` and `mkdocs-material` as dev deps.
* Updated configuration to support github pages deployment, namely adding support for multiple versions of the documentation.
* Added `gh-pages.yaml` workflow for automatically building and pushing documentation.