### PR TITLE
Fix `gh-pages.yaml`

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -74,7 +74,6 @@ jobs:
           uv run mike deploy \
             --push --update-aliases \
             ${VERSION} ${ALIAS}
-          git push origin gh-pages
         env:
           EVENT_NAME: "${{ github.event_name }}"
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Follow up to 1e115e2 to fix the `gh-pages.yaml` workflow. It was difficult to debug this workflow without first merging into main because GitHub won't parse the workflow, now that it has been merge it can be run on this branch and the test works.

Failed: https://github.com/ACCIDDA/flepimop2/actions/runs/18979649495
Success: https://github.com/ACCIDDA/flepimop2/actions/runs/18980459881

Closes #18.