### PR TITLE
Simplify how `CliCommand`s request opts/args

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,7 @@ allow-star-arg-any = true
 "tests/**/*" = [
     "INP001",   # Implicit namespace package
     "PLC2701",  # Private name import from external module
+    "PLR6301",  # Method could be a function, class method, or static method
     "S101",     # Use of `assert` detected
     "SLF001",   # Private member accessed
 ]

--- a/src/flepimop2/_cli/_build_command.py
+++ b/src/flepimop2/_cli/_build_command.py
@@ -9,15 +9,12 @@ from flepimop2._cli._cli_command import CliCommand
 class BuildCommand(CliCommand):
     """Compile and build a model defined in a configuration file."""
 
-    options = ("config", "verbosity", "dry_run")
-
-    def run(self, *, config: str, verbosity: int, dry_run: bool) -> None:  # type: ignore[override]
+    def run(self, *, config: str, dry_run: bool) -> None:  # type: ignore[override]
         """
         Execute the build.
 
         Args:
             config: Path to the configuration file.
-            verbosity: Verbosity level (0-3).
             dry_run: Whether dry run mode is enabled.
         """
         msg = "`BuildCommand.run` is not yet implemented."

--- a/src/flepimop2/_cli/_cli_command.py
+++ b/src/flepimop2/_cli/_cli_command.py
@@ -2,6 +2,7 @@
 
 __all__ = []
 
+import inspect
 import logging
 import re
 from abc import ABC, abstractmethod
@@ -22,7 +23,8 @@ class CliCommand(ABC):
     for batch operations.
     """
 
-    logger: logging.Logger
+    auto_append_verbosity: bool = True
+    logger: logging.Logger | None = None
 
     def __call__(self, **kwargs: Any) -> None:
         """
@@ -31,14 +33,21 @@ class CliCommand(ABC):
         This method allows instances of `CliCommand` subclasses to be called
         directly, forwarding all keyword arguments to the `run` method.
 
+        The 'verbosity' option is consumed here for logger setup. If 'verbosity'
+        was auto-appended (not in _literal_options), it's removed from kwargs
+        before passing to run().
+
         Args:
             **kwargs: Command-specific arguments passed from Click options/arguments.
         """
-        self.logger = get_script_logger(__name__, kwargs.get("verbosity", 0))
+        verbosity = kwargs.pop("verbosity", 0)
+        self.logger = get_script_logger(__name__, verbosity)
         longest_key = max((len(str(k)) for k in kwargs), default=0)
         self.debug("Given %u options/arguments:", len(kwargs))
         for key, value in kwargs.items():
             self.debug("%s = %s", key.ljust(longest_key, " "), self.format(value))
+        if "verbosity" in self._literal_options():
+            kwargs |= {"verbosity": verbosity}
         self.run(**kwargs)
 
     @abstractmethod
@@ -51,22 +60,61 @@ class CliCommand(ABC):
         """
         raise NotImplementedError
 
-    @property
-    @abstractmethod
-    def options(self) -> tuple[str, ...]:
+    @classmethod
+    def _literal_options(cls) -> list[str]:
+        """
+        Get the literal options from the run method signature.
+
+        This method introspects the keyword-only parameters of the `run` method
+        and returns their names exactly as they appear in the signature, without
+        any automatic additions like verbosity.
+
+        Returns:
+            List of option names from the run method signature.
+        """
+        return [
+            param_name
+            for param_name, param in inspect.signature(cls.run).parameters.items()
+            if param.kind == inspect.Parameter.KEYWORD_ONLY
+        ]
+
+    @classmethod
+    def options(cls) -> list[str]:
         """
         Get the list of common CLI options/arguments this command uses.
 
-        Commands should override this method to specify which common options
-        they want to use from `cli_options.COMMON_OPTIONS`.
+        By default, this method uses _literal_options() to get the keyword-only
+        parameters from the `run` method. If 'verbosity' is not present and
+        `auto_append_verbosity` is True, it will be automatically appended.
+
+        Commands can override this method to specify custom options that differ
+        from the `run` method's parameters, or when more complex logic is needed.
 
         The options will be applied in the order specified, with arguments
         typically appearing before options in the list for proper Click behavior.
 
         Returns:
             List of option names to request from `COMMON_OPTIONS`.
+
+        Examples:
+            >>> class MyCommand(CliCommand):
+            ...     def run(self, *, config: Path, dry_run: bool) -> None:
+            ...         pass
+            >>> MyCommand.options()
+            ['config', 'dry_run', 'verbosity']
+
+            >>> class MyCommandWithVerbosity(CliCommand):
+            ...     def run(
+            ...         self, *, config: Path, verbosity: int, dry_run: bool
+            ...     ) -> None:
+            ...         pass
+            >>> MyCommandWithVerbosity.options()
+            ['config', 'verbosity', 'dry_run']
         """
-        raise NotImplementedError
+        options = cls._literal_options()
+        if cls.auto_append_verbosity and "verbosity" not in options:
+            options.append("verbosity")
+        return options
 
     @classmethod
     def command_name(cls) -> str:
@@ -104,26 +152,38 @@ class CliCommand(ABC):
 
     def log(self, level: int, *args: Any, **kwargs: Any) -> None:
         """Log a message at the specified level."""
+        if self.logger is None:
+            return
         self.logger.log(level, *args, **kwargs)
 
     def debug(self, *args: Any, **kwargs: Any) -> None:
         """Log a debug message."""
+        if self.logger is None:
+            return
         self.logger.debug(*args, **kwargs)
 
     def info(self, *args: Any, **kwargs: Any) -> None:
         """Log a debug message."""
+        if self.logger is None:
+            return
         self.logger.info(*args, **kwargs)
 
     def warning(self, *args: Any, **kwargs: Any) -> None:
         """Log a debug message."""
+        if self.logger is None:
+            return
         self.logger.warning(*args, **kwargs)
 
     def error(self, *args: Any, **kwargs: Any) -> None:
         """Log a debug message."""
+        if self.logger is None:
+            return
         self.logger.error(*args, **kwargs)
 
     def critical(self, *args: Any, **kwargs: Any) -> None:
         """Log a debug message."""
+        if self.logger is None:
+            return
         self.logger.critical(*args, **kwargs)
 
     @staticmethod

--- a/src/flepimop2/_cli/_process_command.py
+++ b/src/flepimop2/_cli/_process_command.py
@@ -16,13 +16,10 @@ class ProcessCommand(CliCommand):
     The `CONFIG` argument should point to a valid configuration file.
     """
 
-    options = ("config", "verbosity", "dry_run")
-
     def run(  # type: ignore[override]
         self,
         *,
         config: Path,
-        verbosity: int,  # noqa: ARG002
         dry_run: bool,
     ) -> None:
         """
@@ -30,7 +27,6 @@ class ProcessCommand(CliCommand):
 
         Args:
             config: Path to the configuration file.
-            verbosity: Verbosity level (0-3).
             dry_run: Whether dry run mode is enabled.
         """
         configmodel = ConfigurationModel.from_yaml(config)

--- a/src/flepimop2/_cli/_register_command.py
+++ b/src/flepimop2/_cli/_register_command.py
@@ -32,7 +32,7 @@ def register_command(command_cls: type[CliCommand], group: Group) -> None:
 
     # Apply the options/arguments in reverse order
     # (Click decorators are applied bottom-up)
-    for option_name in reversed(command_cls.options):  # type: ignore[call-overload]
+    for option_name in reversed(command_cls.options()):
         option_decorator = get_option(option_name)
         command_wrapper = option_decorator(command_wrapper)
 

--- a/src/flepimop2/_cli/_simulate_command.py
+++ b/src/flepimop2/_cli/_simulate_command.py
@@ -22,13 +22,10 @@ class SimulateCommand(CliCommand):
     The `CONFIG` argument should point to a valid configuration file.
     """
 
-    options = ("config", "verbosity", "dry_run")
-
     def run(  # type: ignore[override]
         self,
         *,
         config: Path,
-        verbosity: int,  # noqa: ARG002
         dry_run: bool,
     ) -> None:
         """
@@ -36,7 +33,6 @@ class SimulateCommand(CliCommand):
 
         Args:
             config: Path to the configuration file.
-            verbosity: Verbosity level (0-3).
             dry_run: Whether dry run mode is enabled.
         """
         configmodel = ConfigurationModel.from_yaml(config)

--- a/tests/_cli/_register_command/test_register_command.py
+++ b/tests/_cli/_register_command/test_register_command.py
@@ -1,9 +1,9 @@
 """Tests for the `register_command` function in `flepimop2._cli._cli`."""
 
-from typing import Any
 from unittest.mock import MagicMock
 
 import click
+import pytest
 from click.testing import CliRunner
 
 from flepimop2._cli._cli_command import CliCommand
@@ -13,29 +13,21 @@ from flepimop2._cli._register_command import register_command
 class MockCommand(CliCommand):
     """Mock command for testing."""
 
-    options = ("verbosity", "dry_run")
-
-    @staticmethod
-    def run(**kwargs: Any) -> None:
+    def run(self, *, dry_run: bool) -> None:  # type: ignore[override]
         """Mock run method."""
-        click.echo(f"Mock command ran with: {kwargs}")
+        click.echo(f"Mock command ran with: {{'dry_run': {dry_run}}}")
 
 
 class MockCommandNoOptions(CliCommand):
     """Mock command with no options for testing."""
 
-    options = ()
-
-    @staticmethod
-    def run(**kwargs: Any) -> None:  # noqa: ARG004
+    def run(self) -> None:  # type: ignore[override]
         """Mock run method with no options."""
         click.echo("Mock command with no options ran")
 
 
 class MockCommandCustomName(CliCommand):
     """Mock command with custom name."""
-
-    options = ("verbosity",)
 
     @classmethod
     def command_name(cls) -> str:
@@ -47,16 +39,13 @@ class MockCommandCustomName(CliCommand):
         """
         return "custom-name"
 
-    @staticmethod
-    def run(**kwargs: Any) -> None:  # noqa: ARG004
+    def run(self) -> None:  # type: ignore[override]
         """Mock run method."""
         click.echo("Custom named command ran")
 
 
 class MockCommandCustomHelp(CliCommand):
     """Mock command with custom help text."""
-
-    options = ()
 
     @classmethod
     def help_text(cls) -> str:
@@ -68,10 +57,50 @@ class MockCommandCustomHelp(CliCommand):
         """
         return "Custom help text for this command."
 
-    @staticmethod
-    def run(**kwargs: Any) -> None:  # noqa: ARG004
+    def run(self) -> None:  # type: ignore[override]
         """Mock run method."""
         click.echo("Custom help command ran")
+
+
+class MockCommandWithOverriddenOptions(CliCommand):
+    """Mock command that overrides the options() method."""
+
+    @classmethod
+    def options(cls) -> list[str]:
+        """Override to provide custom options different from run parameters.
+
+        Returns:
+            Tuple of option names to request.
+        """
+        return ["verbosity"]  # Only verbosity, not extra_param
+
+    def run(self, *, verbosity: int, extra_param: str = "default") -> None:  # type: ignore[override]
+        """
+        Mock run method with different parameters.
+
+        Note: extra_param has a default and won't be in options().
+        """
+        click.echo(f"Command ran with verbosity: {verbosity}, extra: {extra_param}")
+
+
+class MockCommandNoAutoVerbosity(CliCommand):
+    """Mock command that disables auto-appending verbosity."""
+
+    auto_append_verbosity = False
+
+    def run(self, *, config: str) -> None:  # type: ignore[override]
+        """Mock run method."""
+        click.echo(f"Command ran with config: {config}")
+
+
+class MockCommandWithNonExistentOption(CliCommand):
+    """Mock command that requests a non-existent option."""
+
+    def run(self, *, non_existent_option: str) -> None:  # type: ignore[override]
+        """Mock run method."""
+        click.echo(
+            f"This should not run due to non-existent option, {non_existent_option}."
+        )
 
 
 def test_register_command_creates_click_command() -> None:
@@ -102,9 +131,9 @@ def test_register_command_applies_options_in_correct_order() -> None:
 
     register_command(MockCommand, test_cli)
 
-    # Options should be applied in order: config (argument), then verbosity
+    # Options should be applied in order: dry_run, then verbosity (auto-appended)
     param_names = [param.name for param in test_cli.commands["mock"].params]
-    assert param_names == list(MockCommand.options)
+    assert param_names == MockCommand.options() == ["dry_run", "verbosity"]
 
 
 def test_register_command_with_no_options() -> None:
@@ -115,8 +144,9 @@ def test_register_command_with_no_options() -> None:
 
     command = test_cli.commands["mock-command-no-options"]
 
-    # Should have no parameters
-    assert len(command.params) == 0
+    # Should only have verbosity parameter (auto-appended)
+    assert len(command.params) == 1
+    assert command.params[0].name == "verbosity"
 
 
 def test_register_command_sets_help_text() -> None:
@@ -151,7 +181,7 @@ def test_register_command_wrapper_instantiates_and_runs() -> None:
     mock_command_cls.return_value = mock_instance
     mock_command_cls.command_name.return_value = "test-cmd"
     mock_command_cls.help_text.return_value = "Test help"
-    mock_command_cls.options = ()
+    mock_command_cls.options.return_value = ()
 
     register_command(mock_command_cls, test_cli)
 
@@ -182,3 +212,46 @@ def test_register_command_passes_kwargs_to_run() -> None:
     # Check that the command ran successfully
     assert result.exit_code == 0
     assert "verbosity" in result.output or "Mock command ran" in result.output
+
+
+def test_register_command_allows_custom_options_override() -> None:
+    """Test that commands can override options() for custom behavior."""
+    test_cli = click.Group()
+
+    register_command(MockCommandWithOverriddenOptions, test_cli)
+
+    command = test_cli.commands["mock-command-with-overridden-options"]
+
+    # Should only have verbosity parameter, not dry_run or extra_param
+    param_names = [param.name for param in command.params]
+    assert param_names == ["verbosity"]
+    assert "dry_run" not in param_names
+    assert "extra_param" not in param_names
+
+
+def test_introspection_gets_keyword_only_params() -> None:
+    """Test that options introspection correctly identifies keyword-only params."""
+    # MockCommand should automatically introspect dry_run and auto-append verbosity
+    options = MockCommand.options()
+    assert options == ["dry_run", "verbosity"]
+
+    # MockCommandNoOptions should only have verbosity (auto-appended)
+    options_no_params = MockCommandNoOptions.options()
+    assert options_no_params == ["verbosity"]
+
+
+def test_auto_append_verbosity_can_be_disabled() -> None:
+    """Test that auto_append_verbosity can be set to False to disable auto-appending."""
+    # Command with auto_append_verbosity = False should not have verbosity
+    options = MockCommandNoAutoVerbosity.options()
+    assert options == ["config"]
+    assert "verbosity" not in options
+
+
+def test_non_existent_option_raises_key_error() -> None:
+    """Test that requesting a non-existent option raises KeyError."""
+    with pytest.raises(
+        KeyError,
+        match=r"Unknown option 'non_existent_option'. Available options: .*",
+    ):
+        register_command(MockCommandWithNonExistentOption, click.Group())


### PR DESCRIPTION
Changed the `CliCommand.options` abstract property to a class method that introspects the `run` method to determine the options/arguments to pull for the CLI command. This works by:

* The private `CliCommand._literal_options` class method which pulls the keyword only arguments from the `run` method.
* The public `CliCommand.options` class method calls `_literal_options` and optionally adds 'verbosity' if `auto_append_verbosity` is `True` and not present in the keyword arguments.
* Finally, after the command is registered and once called the `CliCommand.__call__` dunder wraps `CliCommand.run` and determines if it wants the verbosity option.

This design allows commands to have a consistent verbosity option by default that can be utilized via the `self.log/debug/info/...` methods rather than needing to accept `verbosity` directly. For the few commands that do not need a verbosity option they can set the `auto_append_verbosity` class var to `False`.

Also changed the type of `options` from `tuple[str, ...]` to `list[str]` since it is no longer a class var and it simplifies the internals. This change alleviates 'noqa' comments that were previously required for `CliCommand.run`, partially addressing #27.