### PR TITLE
Fix `gh-pages.yaml` workflow

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -64,7 +64,7 @@ jobs:
           uv run -qq python version.py >> $GITHUB_OUTPUT
           rm version.py
       - name: 'Build API Reference'
-        run: 'just api-reference'
+        run: 'just reference'
       - name: 'Deploy to GitHub Pages'
         run: |
           uv run mike set-default latest


### PR DESCRIPTION
Replace `just api-reference` with `just reference` because of 9b4bebb401a3954e74f627473170d970550c6c9f.