### PR TITLE
Normalize `flepimop2` pipeline component APIs

### DIFF
--- a/src/flepimop2/backend/abc.py
+++ b/src/flepimop2/backend/abc.py
@@ -7,19 +7,12 @@ import numpy as np
 from numpy.typing import NDArray
 
 from flepimop2._utils import _load_builder
+from flepimop2.configuration import ModuleModel
 from flepimop2.meta import RunMeta
 
 
 class BackendABC(ABC):
     """Abstract base class for flepimop2 file IO backends."""
-
-    def __init__(self, backend_model: dict[str, Any]) -> None:  # noqa: B027
-        """
-        Initialize the backend with the given configuration.
-
-        Args:
-            backend_model: The configuration dictionary for the backend.
-        """
 
     def save(self, data: NDArray[np.float64], run_meta: RunMeta) -> None:
         """
@@ -54,7 +47,7 @@ class BackendABC(ABC):
         ...
 
 
-def build(config: dict[str, Any]) -> BackendABC:
+def build(config: dict[str, Any] | ModuleModel) -> BackendABC:
     """Build a `BackendABC` from a configuration dictionary.
 
     Args:
@@ -68,8 +61,9 @@ def build(config: dict[str, Any]) -> BackendABC:
     Raises:
         TypeError: If the built backend is not an instance of BackendABC.
     """
-    builder = _load_builder(f"flepimop2.backend.{config.pop('module', 'csv')}")
-    backend = builder.build(**config)
+    config = config.model_dump() if isinstance(config, ModuleModel) else config
+    builder = _load_builder(f"flepimop2.backend.{config.get('module', 'csv')}")
+    backend = builder.build(config)
     if not isinstance(backend, BackendABC):
         msg = "The built backend is not an instance of BackendABC."
         raise TypeError(msg)

--- a/src/flepimop2/process/abc.py
+++ b/src/flepimop2/process/abc.py
@@ -10,9 +10,6 @@ from flepimop2.configuration import ModuleModel
 class ProcessABC(ABC):
     """Abstract base class for flepimop2 processing steps."""
 
-    def __init__(self) -> None:  # noqa: B027
-        """Initialize the process with the given configuration."""
-
     def execute(self, *, dry_run: bool = False) -> None:
         """
         Execute a processing step.
@@ -43,11 +40,10 @@ def build(config: dict[str, Any] | ModuleModel) -> ProcessABC:
     Raises:
         TypeError: If the built process is not an instance of ProcessABC.
     """
-    if isinstance(config, ModuleModel):
-        config = config.model_dump()
-    module = config.pop("module", "shell")
-    module_abs = f"flepimop2.process.{module}"
-    builder = _load_builder(module_abs)
+    config = {"module": "shell"} | (
+        config.model_dump() if isinstance(config, ModuleModel) else config
+    )
+    builder = _load_builder(f"flepimop2.process.{config['module']}")
     process = builder.build(config)
     if not isinstance(process, ProcessABC):
         msg = "The built process is not an instance of ProcessABC."

--- a/src/flepimop2/process/shell.py
+++ b/src/flepimop2/process/shell.py
@@ -40,7 +40,7 @@ class ShellProcess(ModuleModel, ProcessABC):
             raise RuntimeError(msg)
 
 
-def build(config: dict[str, Any]) -> ShellProcess:
+def build(config: dict[str, Any] | ModuleModel) -> ShellProcess:
     """
     Build a [`ShellProcess`][flepimop2.process.shell.ShellProcess] from a configuration.
 
@@ -53,4 +53,6 @@ def build(config: dict[str, Any]) -> ShellProcess:
         The ready-to-use [`ShellProcess`][flepimop2.process.shell.ShellProcess]
             instance.
     """
-    return ShellProcess.model_validate(config)
+    return ShellProcess.model_validate(
+        config.model_dump() if isinstance(config, ModuleModel) else config
+    )

--- a/src/flepimop2/system/abc.py
+++ b/src/flepimop2/system/abc.py
@@ -1,12 +1,12 @@
 """Abstract class for Dynamic Systems."""
 
-from abc import ABC
 from typing import Any
 
 import numpy as np
 from numpy.typing import NDArray
 
 from flepimop2._utils import _load_builder
+from flepimop2.configuration import ModuleModel
 from flepimop2.system.protocol import SystemProtocol
 
 
@@ -19,21 +19,23 @@ def _no_step_function(
     raise NotImplementedError(msg)
 
 
-class SystemABC(ABC):
+class SystemABC:
     """Abstract class for Dynamic Systems."""
 
-    # f(t, Y, params) -> dYdt
     _stepper: SystemProtocol
 
-    def __init__(self, f: SystemProtocol = _no_step_function) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:  # noqa: ARG002
         """
-        Initialize a `SystemABC` from a stepper function.
+        Initialize the SystemABC.
+
+        The default initialization sets the stepper to a no-op function. Concrete
+        implementations should override this with a valid stepper function.
 
         Args:
-            f: The stepper function for the system. Defaults to a function that
-                raises `NotImplementedError`.
+            *args: Positional arguments.
+            **kwargs: Keyword arguments.
         """
-        self.stepper = f
+        self._stepper = _no_step_function
 
     def step(
         self, time: np.float64, state: NDArray[np.float64], **params: Any
@@ -49,28 +51,27 @@ class SystemABC(ABC):
         Returns:
             The next state array after one step.
         """
-        return self.stepper(time, state, **params)
+        return self._stepper(time, state, **params)
 
 
-def build(config: dict[str, Any] | SystemProtocol) -> SystemABC:
+def build(config: dict[str, Any] | ModuleModel) -> SystemABC:
     """
     Build a `SystemABC` from a configuration dictionary.
 
     Args:
-        config: Configuration dictionary or a SystemProtocol. In dict mode, it contains
-            a 'module' key, it will be used to lookup the System module path. The module
-            will have "flepimop2.system." prepended.
+        config: Configuration dictionary or a `ModuleModel` instance.
 
     Returns:
-        The constructed system.
+        The constructed system instance.
 
     Raises:
         TypeError: If the built system is not an instance of SystemABC.
     """
-    if isinstance(config, SystemProtocol):
-        return SystemABC(config)
-    builder = _load_builder(f"flepimop2.system.{config.pop('module', 'wrapper')}")
-    system = builder.build(**config)
+    config = {"module": "wrapper"} | (
+        config.model_dump() if isinstance(config, ModuleModel) else config
+    )
+    builder = _load_builder(f"flepimop2.system.{config['module']}")
+    system = builder.build(config)
     if not isinstance(system, SystemABC):
         msg = "The built system is not an instance of SystemABC."
         raise TypeError(msg)

--- a/src/flepimop2/system/wrapper.py
+++ b/src/flepimop2/system/wrapper.py
@@ -1,39 +1,50 @@
 """A `SystemABC` which wraps a user-defined script file."""
 
-from os import PathLike
+from pathlib import Path
+from typing import Any, Literal, Self
+
+from pydantic import model_validator
 
 from flepimop2._utils._module import _load_module, _validate_function
+from flepimop2.configuration import ModuleModel
 from flepimop2.system import SystemABC
 
 
-class WrapperSystem(SystemABC):
+class WrapperSystem(ModuleModel, SystemABC):
     """A `SystemABC` which wraps a user-defined script file."""
 
-    def __init__(self, script: PathLike[str]) -> None:
-        """
-        Initialize a `WrapperSystem` from a script file.
+    module: Literal["wrapper"] = "wrapper"
+    script: Path
 
-        Args:
-            script: Path to a script file which defines a 'stepper' function.
+    @model_validator(mode="after")
+    def _validate_stepper(self) -> Self:
+        """
+        Validator to load and validate the stepper function from the script file.
+
+        Returns:
+            The validated `WrapperSystem` instance.
 
         Raises:
             AttributeError: If the module does not have a valid 'stepper' function.
         """
-        mod = _load_module(script, "flepimop2.system.wrapped")
+        mod = _load_module(self.script, "flepimop2.system.wrapped")
         if not _validate_function(mod, "stepper"):
-            msg = f"Module at {script} does not have a valid 'stepper' function."
+            msg = f"Module at {self.script} does not have a valid 'stepper' function."
             raise AttributeError(msg)
-        super().__init__(mod.stepper)
+        self._stepper = mod.stepper
+        return self
 
 
-def build(script: PathLike[str]) -> WrapperSystem:
+def build(config: dict[str, Any] | ModuleModel) -> WrapperSystem:
     """
     Build a `WrapperSystem` from a configuration arguments.
 
     Args:
-        script: Path to a script file which defines a 'stepper' function.
+        config: Configuration dictionary or a `ModuleModel` instance.
 
     Returns:
         The constructed wrapper system instance.
     """
-    return WrapperSystem(script)
+    return WrapperSystem.model_validate(
+        config.model_dump() if isinstance(config, ModuleModel) else config
+    )

--- a/tests/engine/test_engine_abc.py
+++ b/tests/engine/test_engine_abc.py
@@ -1,12 +1,19 @@
 """Tests for `EngineABC` and default `WrapperEngine`."""
 
-from typing import Any, cast
+from typing import Any, Literal, cast
 
 import numpy as np
 import pytest
 from numpy.typing import NDArray
 
 from flepimop2.engine import EngineABC
+from flepimop2.system import SystemABC
+
+
+class DummySystem(SystemABC):
+    """A dummy system for testing purposes."""
+
+    module: Literal["dummy"] = "dummy"
 
 
 def sample_step(
@@ -29,9 +36,11 @@ def sample_step(
 @pytest.mark.parametrize("engine", [EngineABC()])
 def test_abstraction_error(engine: EngineABC) -> None:
     """Test `EngineABC` raises `NotImplementedError` when not overridden."""
+    system = DummySystem()
+    system._stepper = sample_step
     with pytest.raises(NotImplementedError):
-        engine._runner(
-            sample_step,
+        engine.run(
+            system,
             np.array([0.0], dtype=np.float64),
             np.array([1.0, 2.0, 3.0], dtype=np.float64),
             {},

--- a/tests/engine/test_engine_wrapper.py
+++ b/tests/engine/test_engine_wrapper.py
@@ -1,32 +1,31 @@
 """Tests for `EngineABC` and default `WrapperEngine`."""
 
 from pathlib import Path
+from typing import Final
 
 import numpy as np
 import pytest
-from numpy.typing import NDArray
 
-import flepimop2.engine as engine_module
-import flepimop2.system as system_module
+from flepimop2.engine import build as engine_build
 from flepimop2.system import SystemABC
+from flepimop2.system import build as system_build
 
-TEST_SCRIPT = Path(__file__).with_suffix("") / "dummy_engine.py"
-
-
-def _test_step(
-    time: np.float64, state: NDArray[np.float64], offset: float
-) -> NDArray[np.float64]:
-    return (state + offset) * time
+TEST_ENGINE_SCRIPT: Final = Path(__file__).with_suffix("") / "dummy_engine.py"
+TEST_SYSTEM_SCRIPT: Final = (
+    Path(__file__).parent.parent / "system" / "test_system_wrapper" / "dummy_system.py"
+).absolute()
 
 
-@pytest.mark.parametrize("config", [{"script": TEST_SCRIPT}])
-@pytest.mark.parametrize("system", [system_module.build(_test_step)])
+@pytest.mark.parametrize("config", [{"script": TEST_ENGINE_SCRIPT}])
+@pytest.mark.parametrize(
+    "system", [system_build({"module": "wrapper", "script": TEST_SYSTEM_SCRIPT})]
+)
 @pytest.mark.parametrize("params", [{"offset": 1.0}])
 def test_wrapper_system(
     config: dict, system: SystemABC, params: dict[str, float]
 ) -> None:
     """Test `WrapperEngine` loads a script and uses its `runner` function."""
-    engine = engine_module.build(config)
+    engine = engine_build(config)
     result = engine.run(
         system,
         [1.0, 2.0],

--- a/tests/system/test_system_abc.py
+++ b/tests/system/test_system_abc.py
@@ -1,44 +1,21 @@
 """Tests for `SystemABC` and default `WrapperSystem`."""
 
-from typing import Any, cast
+from typing import Literal
 
 import numpy as np
 import pytest
-from numpy.typing import NDArray
 
-import flepimop2.system as system_module
 from flepimop2.system import SystemABC
 
 
-def stepper(
-    time: np.float64, state: NDArray[np.float64], **kwargs: Any
-) -> NDArray[np.float64]:
-    """
-    A simple stepper function for testing purposes.
+class DummySystem(SystemABC):
+    """A dummy system for testing purposes."""
 
-    Args:
-        time: The current time as a float64.
-        state: The current state as a numpy array.
-        **kwargs: Additional keyword arguments, including 'offset'.
-
-    Returns:
-        The updated state after applying the stepper logic.
-    """
-    return (state + cast("float", kwargs["offset"])) * time
+    module: Literal["dummy"] = "dummy"
 
 
-@pytest.mark.parametrize("system", [SystemABC()])
+@pytest.mark.parametrize("system", [DummySystem()])
 def test_abstraction_error(system: SystemABC) -> None:
-    """Test `SystemABC` raises `NotImplementedError` when not overridden."""
+    """Test default stepper raises `NotImplementedError` when not overridden."""
     with pytest.raises(NotImplementedError):
         system.step(np.float64(0.0), np.array([1.0, 2.0, 3.0], dtype=np.float64))
-
-
-def test_build_with_protocol() -> None:
-    """Test `build` constructs a `SystemABC` when given a `SystemProtocol`."""
-    system = system_module.build(stepper)
-    result = system.step(
-        np.float64(1.0), np.array([1.0, 2.0, 3.0], dtype=np.float64), offset=1.0
-    )
-    expected = np.array([2.0, 3.0, 4.0], dtype=np.float64)
-    np.testing.assert_array_equal(result, expected)

--- a/tests/system/test_system_wrapper.py
+++ b/tests/system/test_system_wrapper.py
@@ -6,25 +6,15 @@ from typing import Any
 import numpy as np
 import pytest
 
-import flepimop2.system as system_module
-from flepimop2.system import SystemABC
+from flepimop2.system import build
 
 TEST_SCRIPT = Path(__file__).with_suffix("") / "dummy_system.py"
-
-
-@pytest.mark.parametrize("system", [SystemABC()])
-def test_abstraction_error(system: SystemABC) -> None:
-    """Test `SystemABC` raises `NotImplementedError` when not overridden."""
-    with pytest.raises(NotImplementedError):
-        system.step(0.0, np.array([1.0, 2.0, 3.0], dtype=np.float64))
 
 
 @pytest.mark.parametrize("config", [{"script": TEST_SCRIPT}])
 def test_wrapper_system(config: dict[str, Any]) -> None:
     """Test `WrapperSystem` loads a script and uses its `stepper` function."""
-    system = system_module.build(config)
-    result = system.stepper(
-        1.0, np.array([1.0, 2.0, 3.0], dtype=np.float64), offset=1.0
-    )
+    system = build(config)
+    result = system.step(1.0, np.array([1.0, 2.0, 3.0], dtype=np.float64), offset=1.0)
     expected = np.array([2.0, 3.0, 4.0], dtype=np.float64)
     np.testing.assert_array_equal(result, expected)


### PR DESCRIPTION
Refactored `backend`, `system`, `engine`, and `process`  modules so that all of the implementations inherit from `ModuleModel` so the objects are they themselves configuration and changed all `build` methods to accept only `config: dict[str, Any] | ModuleModel`. Light reworking of the test suite was required, but core functionality is still present.

Closes #40, #41.