### PR TITLE
Integration test with external provider

### DIFF
--- a/src/flepimop2/_testing.py
+++ b/src/flepimop2/_testing.py
@@ -1,0 +1,136 @@
+"""Private testing utilities for `flepimop2`."""
+
+import subprocess  # noqa: S404
+from pathlib import Path
+from shutil import which
+
+import pytest
+
+
+def which_uv() -> str:
+    """
+    Find the 'uv' executable in the system PATH.
+
+    This function checks for the presence of the 'uv' executable, which is required
+    for setting up the external provider project for testing. If 'uv' is not found,
+    the test is skipped. The return type is a string instead of a Path object to make
+    it easier to use in subprocess calls.
+
+    Returns:
+        The absolute path to the 'uv' executable as a string.
+    """
+    result = which("uv")
+    if result is None:
+        pytest.skip("uv executable not found in PATH")
+    return str(Path(result).absolute())
+
+
+def external_provider_project(
+    tmp_path: Path, uv: str | None = None, src_dest_map: dict[Path, Path] | None = None
+) -> None:
+    """
+    Set up the external provider project for testing.
+
+    Args:
+        tmp_path: Temporary directory provided by pytest.
+        uv: Path to the `uv` executable.
+        src_dest_map: Optional mapping of source files to destination paths within
+            the external provider package.
+
+    Notes:
+        This fixture creates a temporary external provider package called
+        `external_provider` using `uv`, adds the necessary dependencies, and
+        installs it in a virtual environment. The directory structure looks like:
+        ```
+        ./
+        ├── .venv/
+        ├── external_provider/
+        │   ├── .python-version
+        │   ├── .venv/
+        │   ├── pyproject.toml
+        │   ├── README.md
+        │   ├── src/
+        │   │   └── external_provider/
+        │   │       └── __init__.py
+        │   └── uv.lock
+        └── model_output/
+
+        7 directories, 5 files
+        ```
+        You can then add additional source files to the package by providing a
+        mapping of source paths to destination paths via the `src_dest_map`
+        argument. Both `external_provider` and `flepimop2` will be installed in the
+        the top level `.venv` virtual environment, so when running commands using this
+        temporary directory make sure to use this virtual environment's Python
+        interpreter.
+
+    """
+    # Create a temporary external provider package
+    uv = uv or which_uv()
+    external_provider_package = tmp_path / "external_provider"
+    external_provider_package.mkdir(parents=True, exist_ok=True)
+    (tmp_path / "model_output").mkdir(parents=True, exist_ok=True)
+    flepimop = str(Path(__file__).parent.parent.parent)
+    # Initialize the package using 'uv'
+    subprocess.run(  # noqa: S603
+        [uv, "init", "--package", "--vcs", "none"],
+        capture_output=True,
+        text=True,
+        cwd=external_provider_package,
+        check=True,
+    )
+    subprocess.run(  # noqa: S603
+        [uv, "add", "numpy"],
+        capture_output=True,
+        text=True,
+        cwd=external_provider_package,
+        check=True,
+    )
+    subprocess.run(  # noqa: S603
+        [uv, "add", "--editable", flepimop],
+        capture_output=True,
+        text=True,
+        cwd=external_provider_package,
+        check=True,
+    )
+    # Add the stepper & runner modules and configuration file
+    src_dest_map = src_dest_map or {}
+    for src, dest in src_dest_map.items():
+        (tmp_path / dest).parent.mkdir(parents=True, exist_ok=True)
+        (tmp_path / dest).write_text(src.read_text())
+    # Install the package
+    subprocess.run(  # noqa: S603
+        [uv, "venv"],
+        capture_output=True,
+        text=True,
+        cwd=tmp_path,
+        check=True,
+    )
+    subprocess.run(  # noqa: S603
+        [
+            uv,
+            "pip",
+            "install",
+            "--python",
+            str(tmp_path / ".venv" / "bin" / "python"),
+            flepimop,
+        ],
+        capture_output=True,
+        text=True,
+        cwd=tmp_path,
+        check=True,
+    )
+    subprocess.run(  # noqa: S603
+        [
+            uv,
+            "pip",
+            "install",
+            "--python",
+            str(tmp_path / ".venv" / "bin" / "python"),
+            str(external_provider_package),
+        ],
+        capture_output=True,
+        text=True,
+        cwd=tmp_path,
+        check=True,
+    )

--- a/src/flepimop2/backend/abc.py
+++ b/src/flepimop2/backend/abc.py
@@ -61,8 +61,10 @@ def build(config: dict[str, Any] | ModuleModel) -> BackendABC:
     Raises:
         TypeError: If the built backend is not an instance of BackendABC.
     """
-    config = config.model_dump() if isinstance(config, ModuleModel) else config
-    builder = _load_builder(f"flepimop2.backend.{config.get('module', 'csv')}")
+    config = {"module": "flepimop2.backend.csv"} | (
+        config.model_dump() if isinstance(config, ModuleModel) else config
+    )
+    builder = _load_builder(config["module"])
     backend = builder.build(config)
     if not isinstance(backend, BackendABC):
         msg = "The built backend is not an instance of BackendABC."

--- a/src/flepimop2/backend/csv.py
+++ b/src/flepimop2/backend/csv.py
@@ -16,7 +16,7 @@ from flepimop2.meta import RunMeta
 class CsvBackend(ModuleModel, BackendABC):
     """CSV backend for saving numpy arrays to CSV files."""
 
-    module: Literal["csv"] = "csv"
+    module: Literal["flepimop2.backend.csv"] = "flepimop2.backend.csv"
     root: Path = Field(default_factory=lambda: Path.cwd() / "model_output")
 
     @field_validator("root", mode="after")

--- a/src/flepimop2/engine/abc.py
+++ b/src/flepimop2/engine/abc.py
@@ -83,10 +83,10 @@ def build(config: dict[str, Any] | ModuleModel) -> EngineABC:
     Raises:
         TypeError: If the built engine is not an instance of EngineABC.
     """
-    config = {"module": "wrapper"} | (
+    config = {"module": "flepimop2.engine.wrapper"} | (
         config.model_dump() if isinstance(config, ModuleModel) else config
     )
-    builder = _load_builder(f"flepimop2.engine.{config['module']}")
+    builder = _load_builder(config["module"])
     engine = builder.build(config)
     if not isinstance(engine, EngineABC):
         msg = "The built engine is not an instance of EngineABC."

--- a/src/flepimop2/process/abc.py
+++ b/src/flepimop2/process/abc.py
@@ -40,10 +40,10 @@ def build(config: dict[str, Any] | ModuleModel) -> ProcessABC:
     Raises:
         TypeError: If the built process is not an instance of ProcessABC.
     """
-    config = {"module": "shell"} | (
+    config = {"module": "flepimop2.process.shell"} | (
         config.model_dump() if isinstance(config, ModuleModel) else config
     )
-    builder = _load_builder(f"flepimop2.process.{config['module']}")
+    builder = _load_builder(config["module"])
     process = builder.build(config)
     if not isinstance(process, ProcessABC):
         msg = "The built process is not an instance of ProcessABC."

--- a/src/flepimop2/process/shell.py
+++ b/src/flepimop2/process/shell.py
@@ -19,7 +19,7 @@ class ShellProcess(ModuleModel, ProcessABC):
         args: Arguments to pass to the shell command.
     """
 
-    module: Literal["shell"] = "shell"
+    module: Literal["flepimop2.process.shell"] = "flepimop2.process.shell"
     command: str = Field(min_length=1)
     args: list[str] = Field(default_factory=list)
 

--- a/src/flepimop2/system/abc.py
+++ b/src/flepimop2/system/abc.py
@@ -67,10 +67,10 @@ def build(config: dict[str, Any] | ModuleModel) -> SystemABC:
     Raises:
         TypeError: If the built system is not an instance of SystemABC.
     """
-    config = {"module": "wrapper"} | (
+    config = {"module": "flepimop2.system.wrapper"} | (
         config.model_dump() if isinstance(config, ModuleModel) else config
     )
-    builder = _load_builder(f"flepimop2.system.{config['module']}")
+    builder = _load_builder(config["module"])
     system = builder.build(config)
     if not isinstance(system, SystemABC):
         msg = "The built system is not an instance of SystemABC."

--- a/src/flepimop2/system/wrapper.py
+++ b/src/flepimop2/system/wrapper.py
@@ -13,7 +13,7 @@ from flepimop2.system import SystemABC
 class WrapperSystem(ModuleModel, SystemABC):
     """A `SystemABC` which wraps a user-defined script file."""
 
-    module: Literal["wrapper"] = "wrapper"
+    module: Literal["flepimop2.system.wrapper"] = "flepimop2.system.wrapper"
     script: Path
 
     @model_validator(mode="after")

--- a/tests/backend/test_csv_backend_class.py
+++ b/tests/backend/test_csv_backend_class.py
@@ -39,7 +39,7 @@ def test_csv_backend_save_and_read_round_trip(
     run_meta: RunMeta,
 ) -> None:
     """Test that saving and reading an array returns the same data."""
-    backend = build({"module": "csv", "root": str(tmp_path)})
+    backend = build({"module": "flepimop2.backend.csv", "root": str(tmp_path)})
 
     backend.save(sample_array, run_meta)
     loaded_array = backend.read(run_meta)

--- a/tests/engine/test_engine_wrapper.py
+++ b/tests/engine/test_engine_wrapper.py
@@ -18,7 +18,13 @@ TEST_SYSTEM_SCRIPT: Final = (
 
 @pytest.mark.parametrize("config", [{"script": TEST_ENGINE_SCRIPT}])
 @pytest.mark.parametrize(
-    "system", [system_build({"module": "wrapper", "script": TEST_SYSTEM_SCRIPT})]
+    "system",
+    [
+        system_build({
+            "module": "flepimop2.system.wrapper",
+            "script": TEST_SYSTEM_SCRIPT,
+        })
+    ],
 )
 @pytest.mark.parametrize("params", [{"offset": 1.0}])
 def test_wrapper_system(

--- a/tests/integration/external_provider/config.yaml
+++ b/tests/integration/external_provider/config.yaml
@@ -1,0 +1,15 @@
+---
+name: 'example-provider'
+system:
+  - module: 'external_provider.stepper'
+engine:
+  - module: 'external_provider.runner'
+backend:
+  - module: 'flepimop2.backend.csv'
+simulate:
+  demo:
+    times: '0.0:0.1:10'
+parameters:
+  S0: 999
+  I0: 1
+  R0: 0

--- a/tests/integration/external_provider/runner.py
+++ b/tests/integration/external_provider/runner.py
@@ -1,0 +1,59 @@
+"""Runner function for SIR model integration tests."""
+
+from typing import Any
+
+import numpy as np
+from numpy.typing import NDArray
+
+from flepimop2.configuration import ModuleModel
+from flepimop2.engine import EngineABC
+from flepimop2.system import SystemProtocol
+
+
+def runner(
+    stepper: SystemProtocol,
+    times: NDArray[np.float64],
+    state: NDArray[np.float64],
+    params: dict[str, Any],
+    **kwargs: Any,  # noqa: ARG001
+) -> NDArray[np.float64]:
+    """
+    Simple Euler runner for the SIR model.
+
+    Args:
+        stepper: The system stepper function.
+        times: Array of time points.
+        state: The current state array.
+        params: Additional parameters for the stepper.
+        **kwargs: Additional keyword arguments for the engine. Unused by this runner.
+
+    Returns:
+        The evolved time x state array.
+    """
+    output = np.zeros((len(times), len(state)), dtype=float)
+    output[0] = state
+    for i, t in enumerate(times[1:]):
+        if i == 0:
+            continue
+        dt = t - times[i - 1]
+        dydt = stepper(times[i - 1], output[i - 1], **params)
+        output[i] = output[i - 1] + (dydt * dt)
+    return np.hstack((times.reshape(-1, 1), output))
+
+
+class EulerEngine(EngineABC):
+    """SIR model runner."""
+
+    def __init__(self) -> None:
+        """Initialize the SIR runner with the SIR runner function."""
+        self._runner = runner
+
+
+def build(config: dict[str, Any] | ModuleModel) -> EulerEngine:  # noqa: ARG001
+    """
+    Build an SIR engine.
+
+    Returns:
+        An instance of the SIR engine.
+    """
+    return EulerEngine()

--- a/tests/integration/external_provider/stepper.py
+++ b/tests/integration/external_provider/stepper.py
@@ -1,0 +1,54 @@
+"""Stepper function for SIR model integration tests."""
+
+from typing import Any
+
+import numpy as np
+from numpy.typing import NDArray
+
+from flepimop2.configuration import ModuleModel
+from flepimop2.system import SystemABC
+
+
+def stepper(
+    time: np.float64,  # noqa: ARG001
+    state: NDArray[np.float64],
+    *,
+    beta: float = 0.3,
+    gamma: float = 0.1,
+    **kwargs: Any,  # noqa: ARG001
+) -> NDArray[np.float64]:
+    """
+    ODE for an SIR model.
+
+    Args:
+        time: Current time (not used in this model).
+        state: Current state array [S, I, R].
+        beta: The infection rate.
+        gamma: The recovery rate.
+        **kwargs: Additional parameters (beta, gamma).
+
+    Returns:
+        Next state array after one step.
+    """
+    y_s, y_i, _ = np.asarray(state, dtype=float)
+    infection = beta * y_s * y_i / np.sum(state)
+    recovery = gamma * y_i
+    return np.array([-infection, infection - recovery, recovery], dtype=float)
+
+
+class SirSystem(SystemABC):
+    """SIR model system."""
+
+    def __init__(self) -> None:
+        """Initialize the SIR system with the SIR stepper."""
+        self._stepper = stepper
+
+
+def build(config: dict[str, Any] | ModuleModel) -> SirSystem:  # noqa: ARG001
+    """
+    Build an SIR system.
+
+    Returns:
+        An instance of the SIR system.
+    """
+    return SirSystem()

--- a/tests/integration/external_provider/test_external_provider.py
+++ b/tests/integration/external_provider/test_external_provider.py
@@ -1,0 +1,65 @@
+"""Integration test for external provider functionality."""
+
+import re
+import subprocess  # noqa: S404
+from pathlib import Path
+
+import pytest
+
+from flepimop2._testing import external_provider_project, which_uv
+
+
+def test_external_provider(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """
+    Test external provider functionality.
+
+    Args:
+        monkeypatch: Pytest monkeypatch fixture.
+        tmp_path: Temporary directory provided by pytest.
+
+    Notes:
+        This test runs the simulation using the external provider package and checks
+        that the output file is created as expected. It verifies that before running
+        the simulation, there are no output files, and after running, exactly one
+        output file is created with the expected naming pattern.
+    """
+    # Setup
+    uv = which_uv()
+    cwd = Path(__file__).parent.resolve()
+    external_provider_project(
+        tmp_path,
+        uv=uv,
+        src_dest_map={
+            cwd / "config.yaml": Path("config.yaml"),
+            cwd / "runner.py": Path("external_provider")
+            / "src"
+            / "external_provider"
+            / "runner.py",
+            cwd / "stepper.py": Path("external_provider")
+            / "src"
+            / "external_provider"
+            / "stepper.py",
+        },
+    )
+    monkeypatch.chdir(tmp_path)
+    # Pre-test
+    assert len(list((tmp_path / "model_output").iterdir())) == 0
+    # Run the simulation using the external provider package
+    result = subprocess.run(  # noqa: S603
+        [
+            str(tmp_path / ".venv" / "bin" / "flepimop2"),
+            "simulate",
+            "config.yaml",
+        ],
+        capture_output=True,
+        text=True,
+        cwd=tmp_path,
+        check=True,
+    )
+    # Post-test
+    assert result.returncode == 0
+    model_output = list((tmp_path / "model_output").iterdir())
+    assert len(model_output) == 1
+    csv = model_output[0]
+    assert re.match(r"^simulate_\d{8}_\d{6}\.csv$", csv.name)
+    assert csv.stat().st_size > 0


### PR DESCRIPTION
Added an integration test to check that using `flepimop2` with an external provider package works as expected. The external provider in this case is a hard coded SIR model for the system and Euler's method for the engine.

- Added `tests/integration/` directory to contain integration tests starting with the `tests/integration/external_provider`.
- Added `flepimop2._testing` to contain private testing utilities that can be reused through tests, primarily integration tests given their additional setup complexity.
- Added the `test_external_provider` test that adds the custom system/engine to the 'external_provider' package and runs it using `flepimop2 simulate` and checks that a valid CSV file is produced.
- Adjusted the engine and system default `build` functions to load modules by full path, so rather than doing `module: 'wrapper'` it is now `module: 'flepimop2.engine.wrapper'` to simplify the ability to load external provider `build` functions.