### PR TITLE
Add validation hook to `ProcessABC`

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -54,6 +54,7 @@ nav:
           - Backend: reference/api/backend.md
           - Configuration: reference/api/configuration.md
           - Engine: reference/api/engine.md
+          - Exceptions: reference/api/exceptions.md
           - Meta: reference/api/meta.md
           - Process: reference/api/process.md
           - System: reference/api/system.md

--- a/src/flepimop2/exceptions/__init__.py
+++ b/src/flepimop2/exceptions/__init__.py
@@ -1,0 +1,9 @@
+"""Custom exceptions provided by the `flepimop2` package."""
+
+__all__ = ["Flepimop2Error", "Flepimop2ValidationError", "ValidationIssue"]
+
+from flepimop2.exceptions._flepimop2_error import Flepimop2Error
+from flepimop2.exceptions._flepimop2_validation_error import (
+    Flepimop2ValidationError,
+    ValidationIssue,
+)

--- a/src/flepimop2/exceptions/_flepimop2_error.py
+++ b/src/flepimop2/exceptions/_flepimop2_error.py
@@ -1,0 +1,15 @@
+from typing import Any
+
+
+class Flepimop2Error(Exception):
+    """
+    Base class for exceptions provided by `flepimop2`.
+
+    This class serves as the root for all custom exceptions in the `flepimop2` library.
+    """
+
+    __module__ = "flepimop2.exceptions"
+
+    def __init_subclass__(cls, **kwargs: Any) -> None:
+        super().__init_subclass__(**kwargs)
+        cls.__module__ = "flepimop2.exceptions"

--- a/src/flepimop2/exceptions/_flepimop2_validation_error.py
+++ b/src/flepimop2/exceptions/_flepimop2_validation_error.py
@@ -1,0 +1,163 @@
+from dataclasses import dataclass
+from typing import Any
+
+from flepimop2.exceptions._flepimop2_error import Flepimop2Error
+
+
+@dataclass
+class ValidationIssue:
+    """
+    Represents a single validation issue encountered during data validation.
+
+    Attributes:
+        msg: A human readable description of the validation issue.
+        kind: The type/category of the validation issue.
+        ctx: Optional context providing additional information about the issue.
+
+    Examples:
+        >>> from pprint import pprint
+        >>> from flepimop2.exceptions import ValidationIssue
+        >>> issue = ValidationIssue(
+        ...     msg="Invalid wrapper data format.",
+        ...     kind="invalid_format",
+        ...     ctx={"expected_format": "JSON", "line": 42},
+        ... )
+        >>> pprint(issue)
+        ValidationIssue(msg='Invalid wrapper data format.',
+                        kind='invalid_format',
+                        ctx={'expected_format': 'JSON', 'line': 42})
+    """
+
+    msg: str
+    kind: str
+    ctx: dict[str, Any] | None = None
+
+
+class Flepimop2ValidationError(Flepimop2Error):
+    """
+    Exception raised for validation errors from `flepimop2`.
+
+    This exception's main purpose is to signal that validation has failed
+    within the `flepimop2` library and provides detailed information about
+    the validation issues encountered, typically provided by an external
+    provider package. The main benefit of this exception is to encapsulate
+    multiple validation issues into a single error object, making it easier
+    to handle and report validation failures as well as providing a consistent
+    interface for validation errors across different parts of the `flepimop2`
+    library.
+
+    Attributes:
+        issues: A list of `ValidationIssue` instances representing the validation
+            errors.
+
+    Examples:
+        >>> from pprint import pprint
+        >>> from flepimop2.exceptions import (
+        ...     Flepimop2ValidationError,
+        ...     ValidationIssue,
+        ... )
+        >>> issues = [
+        ...     ValidationIssue(
+        ...         msg="Model requires undefined parameter 'gamma'.",
+        ...         kind="missing_parameter",
+        ...         ctx={"parameter": "gamma", "transition": "gamma * (S / N)"},
+        ...     ),
+        ...     ValidationIssue(
+        ...         msg="Compartment 'E' is unreachable.",
+        ...         kind="unreachable_compartment",
+        ...         ctx={"compartment": "E"},
+        ...     ),
+        ... ]
+        >>> exception = Flepimop2ValidationError(issues)
+        >>> pprint(exception.issues)
+        [ValidationIssue(msg="Model requires undefined parameter 'gamma'.",
+                         kind='missing_parameter',
+                         ctx={'parameter': 'gamma', 'transition': 'gamma * (S / N)'}),
+         ValidationIssue(msg="Compartment 'E' is unreachable.",
+                         kind='unreachable_compartment',
+                         ctx={'compartment': 'E'})]
+        >>> print(exception)
+        2 validation issues encountered:
+        - [missing_parameter] Model requires undefined parameter 'gamma'. (parameter=gamma, transition=gamma * (S / N))
+        - [unreachable_compartment] Compartment 'E' is unreachable. (compartment=E)
+        >>> raise Flepimop2ValidationError(issues)
+        Traceback (most recent call last):
+            ...
+        flepimop2.exceptions.Flepimop2ValidationError: 2 validation issues encountered:
+        - [missing_parameter] Model requires undefined parameter 'gamma'. (parameter=gamma, transition=gamma * (S / N))
+        - [unreachable_compartment] Compartment 'E' is unreachable. (compartment=E)
+
+
+    """  # noqa: E501
+
+    def __init__(self, issues: list[ValidationIssue]) -> None:
+        """
+        Initialize the Flepimop2ValidationError.
+
+        Args:
+            issues: A list of `ValidationIssue` instances representing the validation
+                errors.
+        """
+        self.issues = issues
+        message = self._format_issues(issues)
+        super().__init__(message)
+
+    @staticmethod
+    def _format_issues(issues: list[ValidationIssue]) -> str:
+        """
+        Format validation issues into a readable error message.
+
+        Args:
+            issues: A list of `ValidationIssue` instances to format.
+
+        Returns:
+            A formatted string representation of all validation issues.
+
+        Examples:
+            >>> from flepimop2.exceptions import (
+            ...     ValidationIssue,
+            ...     Flepimop2ValidationError,
+            ... )
+            >>> issues = [
+            ...     ValidationIssue(
+            ...         msg="Missing required field 'model'.",
+            ...         kind="missing_field",
+            ...         ctx={"field": "model"},
+            ...     ),
+            ...     ValidationIssue(
+            ...         msg="Invalid value for 'dt'.",
+            ...         kind="invalid_value",
+            ...         ctx={"field": "dt", "value": -5},
+            ...     ),
+            ... ]
+            >>> print(Flepimop2ValidationError._format_issues(issues))
+            2 validation issues encountered:
+            - [missing_field] Missing required field 'model'. (field=model)
+            - [invalid_value] Invalid value for 'dt'. (field=dt, value=-5)
+            >>> issues = [
+            ...     ValidationIssue(
+            ...         msg="Model outputs are not guaranteed to be non-negative.",
+            ...         kind="negative_output_warning",
+            ...     ),
+            ... ]
+            >>> print(Flepimop2ValidationError._format_issues(issues))
+            1 validation issue encountered:
+            - [negative_output_warning] Model outputs are not guaranteed to be non-negative.
+
+        """  # noqa: E501
+        count = len(issues)
+        plural = "issue" if count == 1 else "issues"
+        lines = [f"{count} validation {plural} encountered:"]
+
+        for issue in issues:
+            # Start with the kind and message
+            line = f"- [{issue.kind}] {issue.msg}"
+
+            # Add context if present
+            if issue.ctx:
+                ctx_parts = [f"{k}={v}" for k, v in issue.ctx.items()]
+                line += f" ({', '.join(ctx_parts)})"
+
+            lines.append(line)
+
+        return "\n".join(lines)

--- a/src/flepimop2/process/abc/__init__.py
+++ b/src/flepimop2/process/abc/__init__.py
@@ -5,6 +5,7 @@ from typing import Any
 
 from flepimop2._utils._module import _load_builder, _resolve_module_name
 from flepimop2.configuration import ModuleModel
+from flepimop2.exceptions import Flepimop2ValidationError, ValidationIssue
 
 
 class ProcessABC(ABC):
@@ -17,13 +18,30 @@ class ProcessABC(ABC):
         Args:
             dry_run: If True, the process will not actually execute but will simulate
                 execution.
+
+        Raises:
+            Flepimop2ValidationError: If validation fails during a dry run.
         """
+        if dry_run and (result := self._process_validate()) is not None:
+            if result:
+                raise Flepimop2ValidationError(result)
+            return None
         return self._process(dry_run=dry_run)
 
     @abstractmethod
     def _process(self, *, dry_run: bool) -> None:
         """Backend-specific implementation for processing data."""
         ...
+
+    def _process_validate(self) -> list[ValidationIssue] | None:  # noqa: PLR6301
+        """
+        Process validation hook.
+
+        Returns:
+            A boolean indicating if the process is valid, or `None` if not implemented.
+
+        """
+        return None
 
 
 def build(config: dict[str, Any] | ModuleModel) -> ProcessABC:


### PR DESCRIPTION
Added a hook to incorporate validation into a process action. This
validation hook only runs in dry mode and is optional, however if not
provided it is assumed that the user has incorporated dry mode into
their regular execute method themselves.

- Added `flepimop2.exceptions` subpackage with a generic
  `Flepimop2Error` and more specific `Flepimop2ValidationError` which
  takes a list of `ValidationIssues` to produce a pydantic-esque
  exception.
- Added detailed API reference documentation for the
  `flepimop2.exceptions` subpackage.
- Added `ProcessABC._process_validate` hook to provide a way for
  `ProcessABC` subclasses to provide validation without running.

Addresses #25 for `flepimop2.process`.