### PR TITLE
Re-export ABC definitions via `flepimop2.abcs`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,3 +14,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Added core simulation infrastructure including engines (machinery to evolve a model) and systems (descriptions of model changes). These are contained in the `flepimop2.engine/system/backend` modules.
 - Added the ability to execute auxiliary commands in the context of `flepimop2` with the `flepimop2 process` CLI backed by the `flepimop.process` module.
 - Converted `flepimop2` to a PEP420 implicit namespace package so external providers can inject themselves into the `flepimop2` namespace. This allows users to reference modules by name only and then `flepimop2` will resolve the kind of module based on its location in a configuration file. See [#45](https://github.com/ACCIDDA/flepimop2/issues/45).
+- Added `flepimop2.abcs` as a convenient re-export of ABCs/protocols for developer use. See [#85](https://github.com/ACCIDDA/flepimop2/issues/85).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -51,6 +51,7 @@ nav:
       - Adding A New CLI Command: development/adding-a-new-cli-command.md
   - Reference:
       - API:
+          - Abcs: reference/api/abcs.md
           - Backend: reference/api/backend.md
           - Configuration: reference/api/configuration.md
           - Engine: reference/api/engine.md

--- a/src/flepimop2/abcs/__init__.py
+++ b/src/flepimop2/abcs/__init__.py
@@ -1,0 +1,22 @@
+"""
+Abstract base classes for flepimop2 modules.
+
+This module provides abstract base classes (ABCs) for key modules of the flepimop2
+pipeline. The ABCs defined here can also be found in their respective submodules, but
+are re-exported here for developer convenience.
+
+"""
+
+__all__ = [
+    "BackendABC",
+    "EngineABC",
+    "EngineProtocol",
+    "ProcessABC",
+    "SystemABC",
+    "SystemProtocol",
+]
+
+from flepimop2.backend.abc import BackendABC
+from flepimop2.engine.abc import EngineABC, EngineProtocol
+from flepimop2.process.abc import ProcessABC
+from flepimop2.system.abc import SystemABC, SystemProtocol


### PR DESCRIPTION
Re-exported `BackendABC`, `EngineABC`, `EngineProtocol`, `ProcessABC`,
`SystemABC`, and `SystemProtocol` from their respective subpackages via
`flepimop2.abcs` for convenience. So instead of:

```python
from flepimop2.backend.abc import BackendABC

class MyCustomBackend(BackendABC):
  ...
```

Developers can now reference `flepimop2.abcs`:

```python
from flepimop2.abcs import BackendABC

class MyCustomBackend(BackendABC):
  ...
```

And ditto for the other ABCs/interfaces. Closes #85.