### PR TITLE
Add parameter groups configuration

### DIFF
--- a/src/flepimop2/_cli/_options.py
+++ b/src/flepimop2/_cli/_options.py
@@ -26,6 +26,15 @@ COMMON_OPTIONS: Final = {
         default=False,
         help="Should this command be run using dry run?",
     ),
+    "groups": click.option(
+        "-g",
+        "--group",
+        "groups",
+        default=None,
+        type=str,
+        multiple=True,
+        help="The parameter group(s) to use for this command.",
+    ),
     "path": click.argument(
         "path",
         type=click.Path(

--- a/src/flepimop2/_cli/_simulate_command.py
+++ b/src/flepimop2/_cli/_simulate_command.py
@@ -2,17 +2,18 @@
 
 __all__ = []
 
+from collections.abc import Iterable
 from pathlib import Path
 
 import numpy as np
 
 from flepimop2._cli._cli_command import CliCommand
+from flepimop2._parameters import ParameterCollection
 from flepimop2._utils._click import _get_config_target
 from flepimop2.backend.abc import build as build_backend
 from flepimop2.configuration import ConfigurationModel
 from flepimop2.engine.abc import build as build_engine
 from flepimop2.meta import RunMeta
-from flepimop2.parameter.abc import build as build_parameter
 from flepimop2.system.abc import build as build_system
 
 
@@ -22,12 +23,14 @@ class SimulateCommand(CliCommand):
 
     This command runs epidemic simulations specified from a provided configuration file.
     The `CONFIG` argument should point to a valid configuration file.
+
     """
 
     def run(  # type: ignore[override]
         self,
         *,
         config: Path,
+        groups: Iterable[str] | None,
         dry_run: bool,
         target: str | None = None,
     ) -> None:
@@ -36,8 +39,10 @@ class SimulateCommand(CliCommand):
 
         Args:
             config: Path to the configuration file.
+            groups: An iterable of parameter groups to apply.
             dry_run: Whether dry run mode is enabled.
             target: Optional target simulate config to use.
+
         """
         config_model = ConfigurationModel.from_yaml(config)
         simulate_config = _get_config_target(config_model.simulate, target, "simulate")
@@ -46,22 +51,16 @@ class SimulateCommand(CliCommand):
         engine_config = config_model.engines[simulate_config.engine].model_dump()
         backend_config = config_model.backends[simulate_config.backend].model_dump()
 
-        s0 = build_parameter(config_model.parameters["s0"])
-        i0 = build_parameter(config_model.parameters["i0"])
-        r0 = build_parameter(config_model.parameters["r0"])
+        parameter_collection = ParameterCollection(
+            config_model.parameters,
+            config_model.groups,
+            groups,
+        )
+        params = parameter_collection.realize()
         initial_state = np.array(
-            [
-                s0.sample().item(),
-                i0.sample().item(),
-                r0.sample().item(),
-            ],
+            [params.pop("s0").item(), params.pop("i0").item(), params.pop("r0").item()],
             dtype=np.float64,
         )
-        params = {
-            k: build_parameter(v).sample().item()
-            for k, v in config_model.parameters.items()
-            if k not in {"s0", "i0", "r0"}
-        }
 
         self.info(f"  System: {simulate_config.system} => {system_config}")
         self.info(f"  Engine: {simulate_config.engine} => {engine_config}")

--- a/src/flepimop2/_parameters.py
+++ b/src/flepimop2/_parameters.py
@@ -1,0 +1,260 @@
+"""Private module for working with parameters and parameter groups."""
+
+__all__ = ["ParameterCollection"]
+
+
+from collections.abc import Iterable
+
+import numpy as np
+from numpy.typing import NDArray
+
+from flepimop2.configuration._module import ModuleGroupModel
+from flepimop2.configuration._types import IdentifierString
+from flepimop2.parameter.abc import ParameterABC
+from flepimop2.parameter.abc import build as build_parameter
+
+
+def _param_maps_to_alias(
+    param_name: IdentifierString,
+    aliases: set[IdentifierString],
+    groups: dict[IdentifierString, dict[IdentifierString, IdentifierString]],
+    group_names: Iterable[IdentifierString],
+) -> bool:
+    """
+    Check if param maps to an alias in non-selected groups.
+
+    Args:
+        param_name: The original parameter name to check.
+        aliases: Set of aliases created by selected groups.
+        groups: Dictionary mapping group names to parameter rename mappings.
+        group_names: List of group names that are selected.
+
+    Returns:
+        True if the parameter maps to an alias, False otherwise.
+
+    """
+    for group_name, group_mapping in groups.items():
+        if group_name in group_names:
+            continue
+        for alias, source in group_mapping.items():
+            if source == param_name and alias in aliases:
+                return True
+    return False
+
+
+def _resolve_final_parameter_name_mapping(
+    groups: dict[IdentifierString, dict[IdentifierString, IdentifierString]],
+    parameters: ModuleGroupModel,
+    group_names: Iterable[IdentifierString],
+) -> dict[IdentifierString, IdentifierString]:
+    """
+    Resolve the final parameter name mapping based on selected groups.
+
+    This function builds the final parameter name mapping by:
+
+    1. Applying renaming from selected groups
+    2. Adding identity mappings for parameters not excluded by group selection
+
+    Parameters are excluded from identity mapping if they would map to an alias
+    that was created by a selected group in a non-selected group.
+
+    Args:
+        groups: Dictionary mapping group names to parameter rename mappings.
+        parameters: Dictionary of parameter configurations.
+        group_names: List of group names to apply for parameter renaming.
+
+    Returns:
+        The final parameter name mapping.
+
+    """
+    final_mapping: dict[IdentifierString, IdentifierString] = {}
+    for group_name in group_names:
+        final_mapping.update(groups[group_name])
+    aliases_created = set(final_mapping.keys())
+    parameters_used = set(final_mapping.values())
+    final_mapping.update({
+        p: p
+        for p in parameters
+        if p not in parameters_used
+        and not _param_maps_to_alias(p, aliases_created, groups, group_names)
+    })
+    return final_mapping
+
+
+class ParameterCollection:
+    """
+    Parameter collection with support for groups.
+
+    This class takes parameter configurations, group mappings, and a list of
+    group names to apply. It validates the configuration, pre-builds only the
+    needed parameters, and efficiently samples them with group-based renaming.
+
+    Validations:
+        - All group names in `group_names` must exist in `groups`.
+        - No two groups can rename different parameters to the same target name.
+        - All conflicts are reported before raising an error.
+
+    Optimizations:
+        - Parameters are pre-built during initialization.
+        - Only parameters actually used by the selected groups are built.
+        - The final renaming mapping is pre-computed.
+
+    Examples:
+        >>> from flepimop2._parameters import ParameterCollection
+        >>> from flepimop2.configuration import ModuleModel
+        >>> parameters = {
+        ...     "beta_high": ModuleModel(module="fixed", value=0.8),
+        ...     "beta_low": ModuleModel(module="fixed", value=0.2),
+        ...     "gamma": ModuleModel(module="fixed", value=0.1),
+        ... }
+        >>> groups = {
+        ...     "high_transmission": {"beta": "beta_high"},
+        ...     "low_transmission": {"beta": "beta_low"},
+        ... }
+        >>> collection_high = ParameterCollection(
+        ...     parameters=parameters,
+        ...     groups=groups,
+        ...     group_names=["high_transmission"],
+        ... )
+        >>> sorted(collection_high.parameter_names)
+        ['beta', 'gamma']
+        >>> realization = collection_high.realize()
+        >>> {k: realization[k] for k in sorted(realization.keys())}
+        {'beta': array([0.8]), 'gamma': array([0.1])}
+        >>> collection_low = ParameterCollection(
+        ...     parameters=parameters,
+        ...     groups=groups,
+        ...     group_names=["low_transmission"],
+        ... )
+        >>> sorted(collection_low.parameter_names)
+        ['beta', 'gamma']
+        >>> realization = collection_low.realize()
+        >>> {k: realization[k] for k in sorted(realization.keys())}
+        {'beta': array([0.2]), 'gamma': array([0.1])}
+        >>> collection = ParameterCollection(
+        ...     parameters=parameters,
+        ...     groups=groups,
+        ... )
+        >>> sorted(collection.parameter_names)
+        ['beta_high', 'beta_low', 'gamma']
+        >>> realization = collection.realize()
+        >>> {k: realization[k] for k in sorted(realization.keys())}
+        {'beta_high': array([0.8]), 'beta_low': array([0.2]), 'gamma': array([0.1])}
+
+    """
+
+    def __init__(
+        self,
+        parameters: ModuleGroupModel,
+        groups: dict[IdentifierString, dict[IdentifierString, IdentifierString]],
+        group_names: Iterable[IdentifierString] | None = None,
+    ) -> None:
+        """
+        Initialize the ParameterCollection.
+
+        Args:
+            parameters: Dictionary of parameter configurations from ConfigurationModel.
+            groups: Dictionary mapping group names to parameter rename mappings.
+                Each group maps new parameter names to their original names.
+            group_names: An iterable of group names to apply for parameter renaming.
+
+        """
+        self._parameters = parameters
+        self._groups = groups
+        self._group_names = group_names or []
+        self._validate_group_names()
+        self._validate_no_conflicts()
+        self._final_mapping = _resolve_final_parameter_name_mapping(
+            self._groups, self._parameters, self._group_names
+        )
+        self._built_parameters: dict[IdentifierString, ParameterABC] = {
+            target: build_parameter(self._parameters[source])
+            for target, source in self._final_mapping.items()
+        }
+
+    def _validate_group_names(self) -> None:
+        """
+        Validate that all group names exist in groups.
+
+        Raises:
+            ValueError: If any group names are not found in groups.
+
+        """
+        missing_groups = set(self._group_names) - set(self._groups.keys())
+        if missing_groups:
+            msg = (
+                f"Group names not found in groups: {sorted(missing_groups)}. "
+                f"Available groups: {sorted(self._groups.keys())}."
+            )
+            raise ValueError(msg)
+
+    def _validate_no_conflicts(self) -> None:
+        """
+        Validate that there are no parameter renaming conflicts.
+
+        Raises:
+            ValueError: If there are parameter renaming conflicts.
+
+        """
+        target_to_sources: dict[
+            IdentifierString, list[tuple[IdentifierString, IdentifierString]]
+        ] = {}
+        for group_name in self._group_names:
+            group_mapping = self._groups[group_name]
+            for target, source in group_mapping.items():
+                if target not in target_to_sources:
+                    target_to_sources[target] = []
+                target_to_sources[target].append((source, group_name))
+
+        conflicts: dict[
+            IdentifierString, list[tuple[IdentifierString, IdentifierString]]
+        ] = {}
+        for target, sources_list in target_to_sources.items():
+            unique_sources = {source for source, _ in sources_list}
+            if len(unique_sources) > 1:
+                conflicts[target] = sources_list
+
+        if conflicts:
+            conflict_details = []
+            for target in sorted(conflicts.keys()):
+                sources_list = conflicts[target]
+                details = ", ".join(
+                    f"'{source}' from group '{group}'" for source, group in sources_list
+                )
+                conflict_details.append(f"  '{target}' is mapped from: {details}")
+            msg = "Parameter renaming conflicts detected:\n" + "\n".join(
+                conflict_details
+            )
+            raise ValueError(msg)
+
+    @property
+    def parameter_names(self) -> set[IdentifierString]:
+        """
+        Get the set of final parameter names after applying groups.
+
+        Returns:
+            Set of final parameter names.
+
+        """
+        return set(self._final_mapping.keys())
+
+    def realize(
+        self, subset: set[IdentifierString] | None = None
+    ) -> dict[IdentifierString, NDArray[np.float64]]:
+        """
+        Realize parameters by sampling pre-built parameters and applying renaming.
+
+        This method samples from the pre-built parameters (constructed during
+        initialization) and applies the pre-computed group-based renaming.
+
+        Args:
+            subset: Optional set of parameter names to include in the output.
+                If provided, only these parameters will be included.
+
+        Returns:
+            A dictionary mapping parameter names (after renaming) to their
+            sampled values as float64 NumPy arrays.
+
+        """
+        subset = subset or self.parameter_names
+        return {target: self._built_parameters[target].sample() for target in subset}

--- a/tests/_parameters/test_parameter_collection_class.py
+++ b/tests/_parameters/test_parameter_collection_class.py
@@ -1,0 +1,355 @@
+"""Unit tests for the `ParameterCollection` class."""
+
+import re
+from typing import Any
+
+import pytest
+
+from flepimop2._parameters import ParameterCollection
+from flepimop2.configuration import IdentifierString, ModuleGroupModel
+
+
+@pytest.fixture
+def basic_parameters() -> dict[str, Any]:
+    """Basic parameter configurations for testing.
+
+    Returns:
+        A dictionary of parameter configurations with fixed values.
+    """
+    return {
+        "param1": {"module": "flepimop2.parameter.fixed", "value": 1.0},
+        "param2": {"module": "flepimop2.parameter.fixed", "value": 2.0},
+        "param3": {"module": "flepimop2.parameter.fixed", "value": 3.0},
+        "param4": {"module": "flepimop2.parameter.fixed", "value": 4.0},
+    }
+
+
+@pytest.fixture
+def basic_groups() -> dict[str, Any]:
+    """Basic group configurations for testing.
+
+    Returns:
+        A dictionary mapping group names to parameter rename mappings.
+    """
+    return {
+        "group1": {
+            "renamed_a": "param1",
+            "renamed_b": "param2",
+        },
+        "group2": {
+            "renamed_c": "param3",
+            "renamed_d": "param4",
+        },
+    }
+
+
+@pytest.mark.parametrize(
+    ("groups", "parameters", "group_names", "missing_group_names"),
+    [
+        (
+            {"group1": {"reparam1": "param1"}},
+            {"param1": {"module": "fixed", "value": 1.0}},
+            ["nonexistent_group"],
+            ["nonexistent_group"],
+        ),
+        (
+            {"group1": {"reparam1": "param1"}},
+            {"param1": {"module": "fixed", "value": 1.0}},
+            ["group1", "missing_group"],
+            ["missing_group"],
+        ),
+        (
+            {"group1": {"reparam1": "param1"}, "group2": {"reparam2": "param1"}},
+            {"param1": {"module": "fixed", "value": 1.0}},
+            ["missing_group", "group2"],
+            ["missing_group"],
+        ),
+        (
+            {"group1": {"reparam1": "param1"}, "group2": {"reparam2": "param2"}},
+            {
+                "param1": {"module": "fixed", "value": 1.0},
+                "param2": {"module": "fixed", "value": 2.0},
+            },
+            ["group1", "missing_group", "group2", "another_missing_group"],
+            ["missing_group", "another_missing_group"],
+        ),
+        (
+            {},
+            {"param1": {"module": "fixed", "value": 1.0}},
+            ["missing_group"],
+            ["missing_group"],
+        ),
+    ],
+)
+def test_group_names_not_found_in_groups_value_error(
+    groups: dict[IdentifierString, dict[IdentifierString, IdentifierString]],
+    parameters: ModuleGroupModel,
+    group_names: list[IdentifierString],
+    missing_group_names: list[IdentifierString],
+) -> None:
+    """Test that ValueError is raised when group names are not found in groups."""
+    with pytest.raises(
+        ValueError,
+        match=re.escape(
+            "Group names not found in groups: "
+            f"{sorted(missing_group_names)}. "
+            "Available groups:"
+        ),
+    ):
+        ParameterCollection(parameters, groups, group_names)
+
+
+@pytest.mark.parametrize(
+    ("groups", "parameters", "group_names", "conflicting_renames"),
+    [
+        (
+            {"group_a": {"paramX": "param1"}, "group_b": {"paramX": "param2"}},
+            {
+                "param1": {"module": "fixed", "value": 1.0},
+                "param2": {"module": "fixed", "value": 2.0},
+            },
+            ["group_a", "group_b"],
+            {"paramX": [("param1", "group_a"), ("param2", "group_b")]},
+        ),
+        (
+            {
+                "group1": {"p": "param1"},
+                "group2": {"p": "param2"},
+                "group3": {"p": "param3"},
+            },
+            {
+                "param1": {"module": "fixed", "value": 1.0},
+                "param2": {"module": "fixed", "value": 2.0},
+                "param3": {"module": "fixed", "value": 3.0},
+            },
+            ["group1", "group2", "group3"],
+            {"p": [("param1", "group1"), ("param2", "group2"), ("param3", "group3")]},
+        ),
+        (
+            {
+                "group1": {"p": "param1"},
+                "group2": {"p": "param2"},
+                "group3": {"p": "param3"},
+            },
+            {
+                "param1": {"module": "fixed", "value": 1.0},
+                "param2": {"module": "fixed", "value": 2.0},
+                "param3": {"module": "fixed", "value": 3.0},
+            },
+            ["group2", "group3"],
+            {"p": [("param2", "group2"), ("param3", "group3")]},
+        ),
+        (
+            {
+                "groupA": {"x": "param1", "y": "param2"},
+                "groupB": {"y": "param3", "z": "param4"},
+            },
+            {
+                "x": {"module": "fixed", "value": 1.0},
+                "y": {"module": "fixed", "value": 2.0},
+                "z": {"module": "fixed", "value": 3.0},
+            },
+            ["groupA", "groupB"],
+            {"y": [("param2", "groupA"), ("param3", "groupB")]},
+        ),
+        (
+            {
+                "group_1": {"a": "param1", "b": "param2"},
+                "group_2": {"a": "param3", "b": "param4"},
+                "group_a": {"b": "param5"},
+            },
+            {
+                "param1": {"module": "fixed", "value": 1.0},
+                "param2": {"module": "fixed", "value": 2.0},
+                "param3": {"module": "fixed", "value": 3.0},
+                "param4": {"module": "fixed", "value": 4.0},
+                "param5": {"module": "fixed", "value": 5.0},
+            },
+            ["group_1", "group_2", "group_a"],
+            {
+                "a": [("param1", "group_1"), ("param3", "group_2")],
+                "b": [
+                    ("param2", "group_1"),
+                    ("param4", "group_2"),
+                    ("param5", "group_a"),
+                ],
+            },
+        ),
+        (
+            {
+                "group_a": {"a": "param1"},
+                "group_b": {"a": "param2"},
+                "group_c": {"b": "param3"},
+                "group_d": {"b": "param4"},
+            },
+            {
+                "param1": {"module": "fixed", "value": 1.0},
+                "param2": {"module": "fixed", "value": 2.0},
+                "param3": {"module": "fixed", "value": 3.0},
+                "param4": {"module": "fixed", "value": 4.0},
+            },
+            ["group_a", "group_b", "group_c", "group_d"],
+            {
+                "a": [("param1", "group_a"), ("param2", "group_b")],
+                "b": [("param3", "group_c"), ("param4", "group_d")],
+            },
+        ),
+        (
+            {
+                "group_a": {"a": "param1"},
+                "group_b": {"a": "param2"},
+                "group_c": {"b": "param3"},
+                "group_d": {"b": "param4"},
+            },
+            {
+                "param1": {"module": "fixed", "value": 1.0},
+                "param2": {"module": "fixed", "value": 2.0},
+                "param3": {"module": "fixed", "value": 3.0},
+                "param4": {"module": "fixed", "value": 4.0},
+            },
+            ["group_a", "group_b", "group_c"],
+            {"a": [("param1", "group_a"), ("param2", "group_b")]},
+        ),
+    ],
+)
+def test_conflicting_parameter_renaming_value_error(
+    groups: dict[IdentifierString, dict[IdentifierString, IdentifierString]],
+    parameters: ModuleGroupModel,
+    group_names: list[IdentifierString],
+    conflicting_renames: dict[
+        IdentifierString, list[tuple[IdentifierString, IdentifierString]]
+    ],
+) -> None:
+    """Test that ValueError is raised for conflicting parameter renaming."""
+    with pytest.raises(
+        ValueError, match=r"^Parameter renaming conflicts detected:.*"
+    ) as exc_info:
+        ParameterCollection(parameters, groups, group_names)
+    error_message = str(exc_info.value).splitlines()
+    assert len(error_message) == len(conflicting_renames) + 1
+    for rename_conflict, details in conflicting_renames.items():
+        msg = f"  '{rename_conflict}' is mapped from: " + ", ".join([
+            f"'{param}' from group '{source}'" for param, source in details
+        ])
+        assert msg in error_message
+
+
+@pytest.mark.parametrize(
+    ("groups", "parameters", "group_names", "final_mapping"),
+    [
+        (
+            {},
+            {"param1": {"module": "fixed", "value": 1.0}},
+            [],
+            {"param1": "param1"},
+        ),
+        (
+            {"group1": {"renamed1": "param1"}},
+            {"param1": {"module": "fixed", "value": 1.0}},
+            ["group1"],
+            {"renamed1": "param1"},
+        ),
+        (
+            {"group1": {"renamed1": "param1"}},
+            {"param1": {"module": "fixed", "value": 1.0}},
+            [],
+            {"param1": "param1"},
+        ),
+        (
+            {"group1": {"renamed": "param1"}, "group2": {"renamed": "param2"}},
+            {
+                "param1": {"module": "fixed", "value": 1.0},
+                "param2": {"module": "fixed", "value": 2.0},
+            },
+            ["group1"],
+            {"renamed": "param1"},
+        ),
+        (
+            {"group1": {"renamed": "param1"}, "group2": {"renamed": "param2"}},
+            {
+                "param1": {"module": "fixed", "value": 1.0},
+                "param2": {"module": "fixed", "value": 2.0},
+            },
+            ["group2"],
+            {"renamed": "param2"},
+        ),
+        (
+            {"group1": {"renamed": "param1"}, "group2": {"renamed": "param2"}},
+            {
+                "param1": {"module": "fixed", "value": 1.0},
+                "param2": {"module": "fixed", "value": 2.0},
+            },
+            [],
+            {"param1": "param1", "param2": "param2"},
+        ),
+        (
+            {
+                "group_a": {"a": "param1"},
+                "group_b": {"a": "param2"},
+                "group_y": {"b": "param3"},
+                "group_z": {"b": "param4"},
+            },
+            {
+                "param1": {"module": "fixed", "value": 1.0},
+                "param2": {"module": "fixed", "value": 2.0},
+                "param3": {"module": "fixed", "value": 3.0},
+                "param4": {"module": "fixed", "value": 4.0},
+            },
+            [],
+            {
+                "param1": "param1",
+                "param2": "param2",
+                "param3": "param3",
+                "param4": "param4",
+            },
+        ),
+        (
+            {
+                "group_a": {"a": "param1"},
+                "group_b": {"a": "param2"},
+                "group_y": {"b": "param3"},
+                "group_z": {"b": "param4"},
+            },
+            {
+                "param1": {"module": "fixed", "value": 1.0},
+                "param2": {"module": "fixed", "value": 2.0},
+                "param3": {"module": "fixed", "value": 3.0},
+                "param4": {"module": "fixed", "value": 4.0},
+            },
+            ["group_a", "group_y"],
+            {
+                "a": "param1",
+                "b": "param3",
+            },
+        ),
+        (
+            {
+                "group_a": {"a": "param1"},
+                "group_b": {"a": "param2"},
+                "group_y": {"b": "param3"},
+                "group_z": {"b": "param4"},
+            },
+            {
+                "param1": {"module": "fixed", "value": 1.0},
+                "param2": {"module": "fixed", "value": 2.0},
+                "param3": {"module": "fixed", "value": 3.0},
+                "param4": {"module": "fixed", "value": 4.0},
+            },
+            ["group_b"],
+            {
+                "a": "param2",
+                "param3": "param3",
+                "param4": "param4",
+            },
+        ),
+    ],
+)
+def test_final_mapping_attribute(
+    groups: dict[IdentifierString, dict[IdentifierString, IdentifierString]],
+    parameters: ModuleGroupModel,
+    group_names: list[IdentifierString],
+    final_mapping: dict[IdentifierString, IdentifierString],
+) -> None:
+    """Test that the final mapping attribute is correctly computed."""
+    collection = ParameterCollection(parameters, groups, group_names)
+    assert collection._final_mapping == final_mapping


### PR DESCRIPTION
Added parameter groups to configuration as well as a new class,
`ParameterCollection`, to manage parameters/groups and their
realization. Changes included:

- Added `groups` attribute to the `ConfigurationModel` class along with
  validation to check the referenced parameters are defined in the
  `parameters` attribute.
- Added the `ParameterCollection` class which takes parameter/group
  configuration and group names and manages the collection of required
  parameters including providing a `realize` method for sampling all at
  once.
- Added the `--group` option to `flepimop2 simulate` and made use of the
  `ParameterCollection` class in the `SimulateCommand` to make groups
  available for simulating.

Closes #47.