### PR TITLE
Add `doctest_tmpdir` fixture for doctests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,12 +1,37 @@
 """Pytest test configuration."""
 
+from collections.abc import Generator
 from os import chdir
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Any
 
+import pytest
 from sybil import Sybil
 from sybil.parsers.markdown import PythonCodeBlockParser, SkipParser
+
+
+@pytest.fixture(autouse=True)
+def doctest_tmpdir(request: pytest.FixtureRequest) -> Generator[None]:
+    """
+    Create and change to a temporary directory for doctests.
+
+    Args:
+        request: The pytest fixture request object.
+
+    Notes:
+        [See this StackOverflow answer for details.](https://stackoverflow.com/q/46962007)
+    """
+    doctest_plugin = request.config.pluginmanager.getplugin("doctest")
+    if isinstance(
+        request.node,
+        doctest_plugin.DoctestItem,
+    ):
+        tmpdir = request.getfixturevalue("tmpdir")
+        with tmpdir.as_cwd():
+            yield
+    else:
+        yield
 
 
 def documentation_setup(documentation_setup: dict[str, Any]) -> None:  # noqa: ARG001


### PR DESCRIPTION
Added `doctest_tmpdir` pytest fixture to `conftest.py` for creating a temporary directory and changing to it for doctests only. This allows all doctests to safely run in a temporary directory and not have to add said setup for the test in the examples section of the docstring which will potentially be displayed in the documentation. The doctests in `src/flepimop2/_cli/_skeleton_command.py` highlighted this as an issue.