### PR TITLE
Add `flepimop2.typing` module for custom types

### DIFF
--- a/docs/assets/SIR.py
+++ b/docs/assets/SIR.py
@@ -1,15 +1,16 @@
 """SIR model plugin for flepimop2 demo."""
 
 import numpy as np
-from numpy.typing import NDArray
+
+from flepimop2.typing import Float64NDArray
 
 
 def stepper(
     t: float,  # noqa: ARG001
-    y: NDArray[np.float64],
+    y: Float64NDArray,
     beta: float,
     gamma: float,
-) -> NDArray[np.float64]:
+) -> Float64NDArray:
     """dY/dt for the SIR model."""
     y_s, y_i, _ = np.asarray(y, dtype=float)
     infection = (beta * y_s * y_i) / np.sum(y)

--- a/docs/assets/solve_ivp.py
+++ b/docs/assets/solve_ivp.py
@@ -3,26 +3,26 @@
 from typing import Any
 
 import numpy as np
-from numpy.typing import NDArray
 from scipy.integrate import solve_ivp
 
 from flepimop2.system.abc import SystemProtocol
+from flepimop2.typing import Float64NDArray
 
 
 def runner(
     fun: SystemProtocol,
-    times: NDArray[np.float64],
-    y0: NDArray[np.float64],
+    times: Float64NDArray,
+    y0: Float64NDArray,
     params: dict[str, Any] | None = None,
     **solver_options: Any,
-) -> NDArray[np.float64]:
+) -> Float64NDArray:
     """Solve an initial value problem using scipy.solve_ivp.
 
     Args:
         fun (SystemProtocol): A function that computes derivatives.
-        times (NDArray[np.float64]): sequence of time points where we evaluate the
+        times (Float64NDArray): sequence of time points where we evaluate the
           solution. Must have length >= 1.
-        y0 (NDArray[np.float64]): Initial condition.
+        y0 (Float64NDArray): Initial condition.
         params: Optional dict of keyword parameters forwarded to fun.
         **solver_options: Additional keyword options forwarded to
           scipy.integrate.solve_ivp.

--- a/docs/development/creating-an-external-provider-package.md
+++ b/docs/development/creating-an-external-provider-package.md
@@ -129,7 +129,7 @@ from pathlib import Path
 from typing import Literal
 
 import numpy as np
-from numpy.typing import NDArray
+from flepimop2.typing import Float64NDArray
 from pydantic import Field, field_validator
 
 from flepimop2.abcs import BackendABC
@@ -179,7 +179,7 @@ class NpzBackend(ModuleModel, BackendABC):
         filename = f"{name_part}{run_meta.action}_{timestamp_str}.npz"
         return self.root / filename
 
-    def _save(self, data: NDArray[np.float64], run_meta: RunMeta) -> None:
+    def _save(self, data: Float64NDArray, run_meta: RunMeta) -> None:
         """
         Save a numpy array to an NPZ file.
 
@@ -195,7 +195,7 @@ class NpzBackend(ModuleModel, BackendABC):
         else:
             np.savez(file_path, data=data)
 
-    def _read(self, run_meta: RunMeta) -> NDArray[np.float64]:
+    def _read(self, run_meta: RunMeta) -> Float64NDArray:
         """
         Read a numpy array from an NPZ file.
 
@@ -232,7 +232,7 @@ from pathlib import Path
 from typing import Any
 
 import numpy as np
-from numpy.typing import NDArray
+from flepimop2.typing import Float64NDArray
 
 from flepimop2.abcs import BackendABC
 from flepimop2.configuration import ModuleModel
@@ -275,7 +275,7 @@ class NpzBackend(BackendABC):
         filename = f"{name_part}{run_meta.action}_{timestamp_str}.npz"
         return self.root / filename
 
-    def _save(self, data: NDArray[np.float64], run_meta: RunMeta) -> None:
+    def _save(self, data: Float64NDArray, run_meta: RunMeta) -> None:
         """
         Save a numpy array to an NPZ file.
 
@@ -291,7 +291,7 @@ class NpzBackend(BackendABC):
         else:
             np.savez(file_path, data=data)
 
-    def _read(self, run_meta: RunMeta) -> NDArray[np.float64]:
+    def _read(self, run_meta: RunMeta) -> Float64NDArray:
         """
         Read a numpy array from an NPZ file.
 

--- a/justfile
+++ b/justfile
@@ -11,11 +11,11 @@ check:
 
 # Run tests using `pytest`
 pytest:
-    uv run pytest --doctest-modules
+    uv run pytest
 
 # Type check using `mypy`
 mypy:
-    uv run mypy --strict .
+    uv run mypy .
 
 # Lint YAML files using `yamllint`
 yamllint:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ testpaths = [
     "src/flepimop2/",
     "tests/",
 ]
+addopts = ["--import-mode=importlib", "--doctest-modules"]
 
 [tool.ruff]
 exclude = ["docs/assets/*.py"]
@@ -84,6 +85,7 @@ allow-star-arg-any = true
 convention = "google"
 
 [tool.mypy]
+strict = true
 exclude = ["^build/", "^docs/"]
 namespace_packages = true
 mypy_path = ["src"]

--- a/src/flepimop2/_utils/_pydantic.py
+++ b/src/flepimop2/_utils/_pydantic.py
@@ -12,8 +12,9 @@ from keyword import iskeyword
 from typing import Annotated, TypeVar
 
 import numpy as np
-from numpy.typing import NDArray
 from pydantic import Field, StringConstraints
+
+from flepimop2.typing import Float64NDArray
 
 T = TypeVar("T")
 
@@ -68,7 +69,7 @@ def _to_default_dict(value: dict[str, T] | list[T]) -> dict[str, T]:
     return value
 
 
-def _to_np_array(value: RangeSpec) -> NDArray[np.float64]:
+def _to_np_array(value: RangeSpec) -> Float64NDArray:
     """
     Convert a list of floats or a range specification string to a NumPy array.
 

--- a/src/flepimop2/backend/abc/__init__.py
+++ b/src/flepimop2/backend/abc/__init__.py
@@ -3,18 +3,16 @@
 from abc import ABC, abstractmethod
 from typing import Any
 
-import numpy as np
-from numpy.typing import NDArray
-
 from flepimop2._utils._module import _build
 from flepimop2.configuration import ModuleModel
 from flepimop2.meta import RunMeta
+from flepimop2.typing import Float64NDArray
 
 
 class BackendABC(ABC):
     """Abstract base class for flepimop2 file IO backends."""
 
-    def save(self, data: NDArray[np.float64], run_meta: RunMeta) -> None:
+    def save(self, data: Float64NDArray, run_meta: RunMeta) -> None:
         """
         Save a numpy array to storage.
 
@@ -24,7 +22,7 @@ class BackendABC(ABC):
         """
         return self._save(data, run_meta)
 
-    def read(self, run_meta: RunMeta) -> NDArray[np.float64]:
+    def read(self, run_meta: RunMeta) -> Float64NDArray:
         """
         Read a numpy array from storage.
 
@@ -37,12 +35,12 @@ class BackendABC(ABC):
         return self._read(run_meta)
 
     @abstractmethod
-    def _save(self, data: NDArray[np.float64], run_meta: RunMeta) -> None:
+    def _save(self, data: Float64NDArray, run_meta: RunMeta) -> None:
         """Backend-specific implementation for saving data."""
         ...
 
     @abstractmethod
-    def _read(self, run_meta: RunMeta) -> NDArray[np.float64]:
+    def _read(self, run_meta: RunMeta) -> Float64NDArray:
         """Backend-specific implementation for reading data."""
         ...
 

--- a/src/flepimop2/backend/csv/__init__.py
+++ b/src/flepimop2/backend/csv/__init__.py
@@ -5,12 +5,12 @@ from pathlib import Path
 from typing import Literal
 
 import numpy as np
-from numpy.typing import NDArray
 from pydantic import Field, field_validator
 
 from flepimop2.backend.abc import BackendABC
 from flepimop2.configuration import ModuleModel
 from flepimop2.meta import RunMeta
+from flepimop2.typing import Float64NDArray
 
 
 class CsvBackend(ModuleModel, BackendABC):
@@ -54,7 +54,7 @@ class CsvBackend(ModuleModel, BackendABC):
         filename = f"{name_part}{run_meta.action}_{timestamp_str}.csv"
         return self.root / filename
 
-    def _save(self, data: NDArray[np.float64], run_meta: RunMeta) -> None:
+    def _save(self, data: Float64NDArray, run_meta: RunMeta) -> None:
         """
         Save a numpy array to a CSV file.
 
@@ -66,7 +66,7 @@ class CsvBackend(ModuleModel, BackendABC):
         file_path.parent.mkdir(parents=True, exist_ok=True)
         np.savetxt(file_path, data, delimiter=",")
 
-    def _read(self, run_meta: RunMeta) -> NDArray[np.float64]:
+    def _read(self, run_meta: RunMeta) -> Float64NDArray:
         """
         Read a numpy array from a CSV file.
 

--- a/src/flepimop2/configuration/_simulate.py
+++ b/src/flepimop2/configuration/_simulate.py
@@ -1,9 +1,8 @@
-import numpy as np
-from numpy.typing import NDArray
 from pydantic import BaseModel, ConfigDict, Field
 
 from flepimop2._utils._pydantic import RangeSpec, _to_np_array
 from flepimop2.configuration._types import IdentifierString
+from flepimop2.typing import Float64NDArray
 
 
 class SimulateSpecificationModel(BaseModel):
@@ -27,7 +26,7 @@ class SimulateSpecificationModel(BaseModel):
     params: dict[str, float] | None = Field(default_factory=dict)
 
     @property
-    def t_eval(self) -> NDArray[np.float64]:
+    def t_eval(self) -> Float64NDArray:
         """
         Get the evaluation times as a NumPy array.
 

--- a/src/flepimop2/engine/abc/__init__.py
+++ b/src/flepimop2/engine/abc/__init__.py
@@ -2,21 +2,19 @@
 
 from typing import Any, Protocol, runtime_checkable
 
-import numpy as np
-from numpy.typing import NDArray
-
 from flepimop2._utils._module import _build
 from flepimop2.configuration import IdentifierString, ModuleModel
 from flepimop2.system.abc import SystemABC, SystemProtocol
+from flepimop2.typing import Float64NDArray
 
 
 def _no_run_func(
     stepper: SystemProtocol,
-    times: NDArray[np.float64],
-    state: NDArray[np.float64],
+    times: Float64NDArray,
+    state: Float64NDArray,
     params: dict[IdentifierString, Any],
     **kwargs: Any,
-) -> NDArray[np.float64]:
+) -> Float64NDArray:
     msg = "EngineABC::_runner must be provided by a concrete implementation."
     raise NotImplementedError(msg)
 
@@ -28,11 +26,11 @@ class EngineProtocol(Protocol):
     def __call__(
         self,
         stepper: SystemProtocol,
-        times: NDArray[np.float64],
-        state: NDArray[np.float64],
+        times: Float64NDArray,
+        state: Float64NDArray,
         params: dict[IdentifierString, Any],
         **kwargs: Any,
-    ) -> NDArray[np.float64]:
+    ) -> Float64NDArray:
         """Protocol for engine runner functions."""
         ...
 
@@ -58,11 +56,11 @@ class EngineABC:
     def run(
         self,
         system: SystemABC,
-        eval_times: NDArray[np.float64],
-        initial_state: NDArray[np.float64],
+        eval_times: Float64NDArray,
+        initial_state: Float64NDArray,
         params: dict[IdentifierString, Any],
         **kwargs: Any,
-    ) -> NDArray[np.float64]:
+    ) -> Float64NDArray:
         """
         Run the engine with the provided system and parameters.
 

--- a/src/flepimop2/parameter/abc/__init__.py
+++ b/src/flepimop2/parameter/abc/__init__.py
@@ -5,18 +5,16 @@ __all__ = ["ParameterABC", "build"]
 from abc import ABC, abstractmethod
 from typing import Any
 
-import numpy as np
-from numpy.typing import NDArray
-
 from flepimop2._utils._module import _build
 from flepimop2.configuration import ModuleModel
+from flepimop2.typing import Float64NDArray
 
 
 class ParameterABC(ABC):
     """Abstract base class for parameters."""
 
     @abstractmethod
-    def sample(self) -> NDArray[np.float64]:
+    def sample(self) -> Float64NDArray:
         """Sample a value from the parameter.
 
         Returns:

--- a/src/flepimop2/parameter/fixed/__init__.py
+++ b/src/flepimop2/parameter/fixed/__init__.py
@@ -5,10 +5,10 @@ __all__ = ["FixedParameter"]
 from typing import Literal
 
 import numpy as np
-from numpy.typing import NDArray
 
 from flepimop2.configuration import ModuleModel
 from flepimop2.parameter.abc import ParameterABC
+from flepimop2.typing import Float64NDArray
 
 
 class FixedParameter(ModuleModel, ParameterABC):
@@ -26,7 +26,7 @@ class FixedParameter(ModuleModel, ParameterABC):
     module: Literal["flepimop2.parameter.fixed"] = "flepimop2.parameter.fixed"
     value: float
 
-    def sample(self) -> NDArray[np.float64]:
+    def sample(self) -> Float64NDArray:
         """
         Return the fixed value of the parameter.
 

--- a/src/flepimop2/system/abc/__init__.py
+++ b/src/flepimop2/system/abc/__init__.py
@@ -3,10 +3,10 @@
 from typing import Any, Protocol, runtime_checkable
 
 import numpy as np
-from numpy.typing import NDArray
 
 from flepimop2._utils._module import _build
 from flepimop2.configuration import ModuleModel
+from flepimop2.typing import Float64NDArray
 
 
 @runtime_checkable
@@ -14,17 +14,17 @@ class SystemProtocol(Protocol):
     """Type-definition (Protocol) for system stepper functions."""
 
     def __call__(
-        self, time: np.float64, state: NDArray[np.float64], **kwargs: Any
-    ) -> NDArray[np.float64]:
+        self, time: np.float64, state: Float64NDArray, **kwargs: Any
+    ) -> Float64NDArray:
         """Protocol for system stepper functions."""
         ...
 
 
 def _no_step_function(
     time: np.float64,
-    state: NDArray[np.float64],
+    state: Float64NDArray,
     **kwargs: Any,
-) -> NDArray[np.float64]:
+) -> Float64NDArray:
     msg = "SystemABC::stepper must be provided by a concrete implementation."
     raise NotImplementedError(msg)
 
@@ -48,8 +48,8 @@ class SystemABC:
         self._stepper = _no_step_function
 
     def step(
-        self, time: np.float64, state: NDArray[np.float64], **params: Any
-    ) -> NDArray[np.float64]:
+        self, time: np.float64, state: Float64NDArray, **params: Any
+    ) -> Float64NDArray:
         """
         Perform a single step of the system's dynamics.
 

--- a/src/flepimop2/typing.py
+++ b/src/flepimop2/typing.py
@@ -1,0 +1,22 @@
+"""
+Custom Typing Helpers.
+
+This module centralizes type aliases used throughout the project and makes
+it easy to keep runtime imports lightweight while still providing precise
+type information. The goal is to express common shapes and dtypes once,
+so internal modules can share consistent, readable annotations without
+repeating NumPy typing boilerplate.
+
+Examples:
+    >>> from flepimop2.typing import Float64NDArray
+    >>> Float64NDArray
+    numpy.ndarray[tuple[typing.Any, ...], numpy.dtype[numpy.float64]]
+"""
+
+__all__ = ["Float64NDArray"]
+
+import numpy as np
+import numpy.typing as npt
+
+Float64NDArray = npt.NDArray[np.float64]
+"""Alias for a NumPy ndarray with float64 data type."""

--- a/tests/backend/test_csv_backend_class.py
+++ b/tests/backend/test_csv_backend_class.py
@@ -6,10 +6,10 @@ from pathlib import Path
 import numpy as np
 import pytest
 from numpy.testing import assert_array_equal
-from numpy.typing import NDArray
 
 from flepimop2.backend.abc import build
 from flepimop2.meta import RunMeta
+from flepimop2.typing import Float64NDArray
 
 
 @pytest.mark.parametrize(
@@ -35,7 +35,7 @@ from flepimop2.meta import RunMeta
 )
 def test_csv_backend_save_and_read_round_trip(
     tmp_path: Path,
-    sample_array: NDArray[np.float64],
+    sample_array: Float64NDArray,
     run_meta: RunMeta,
 ) -> None:
     """Test that saving and reading an array returns the same data."""

--- a/tests/engine/test_engine_abc.py
+++ b/tests/engine/test_engine_abc.py
@@ -4,10 +4,10 @@ from typing import Any, Literal, cast
 
 import numpy as np
 import pytest
-from numpy.typing import NDArray
 
 from flepimop2.engine.abc import EngineABC
 from flepimop2.system.abc import SystemABC
+from flepimop2.typing import Float64NDArray
 
 
 class DummySystem(SystemABC):
@@ -17,8 +17,8 @@ class DummySystem(SystemABC):
 
 
 def sample_step(
-    time: np.float64, state: NDArray[np.float64], **kwargs: Any
-) -> NDArray[np.float64]:
+    time: np.float64, state: Float64NDArray, **kwargs: Any
+) -> Float64NDArray:
     """
     A simple stepper function for testing purposes.
 

--- a/tests/engine/test_engine_wrapper/dummy_engine.py
+++ b/tests/engine/test_engine_wrapper/dummy_engine.py
@@ -3,20 +3,20 @@
 from typing import Any
 
 import numpy as np
-from numpy.typing import NDArray
 
 from flepimop2.configuration import IdentifierString
 from flepimop2.system.abc import SystemProtocol
+from flepimop2.typing import Float64NDArray
 
 
 def runner(
     f: SystemProtocol,
-    times: NDArray[np.float64],
-    state: NDArray[np.float64],
+    times: Float64NDArray,
+    state: Float64NDArray,
     params: dict[IdentifierString, Any],
     *,
     accumulate: bool,
-) -> NDArray[np.float64]:
+) -> Float64NDArray:
     """
     A dummy runner function for testing purposes: only evaluates stepper at times.
 

--- a/tests/integration/external_provider/euler.py
+++ b/tests/integration/external_provider/euler.py
@@ -3,20 +3,20 @@
 from typing import Any
 
 import numpy as np
-from numpy.typing import NDArray
 
 from flepimop2.configuration import IdentifierString, ModuleModel
 from flepimop2.engine.abc import EngineABC
 from flepimop2.system.abc import SystemProtocol
+from flepimop2.typing import Float64NDArray
 
 
 def runner(
     stepper: SystemProtocol,
-    times: NDArray[np.float64],
-    state: NDArray[np.float64],
+    times: Float64NDArray,
+    state: Float64NDArray,
     params: dict[IdentifierString, Any],
     **kwargs: Any,  # noqa: ARG001
-) -> NDArray[np.float64]:
+) -> Float64NDArray:
     """
     Simple Euler runner for the SIR model.
 

--- a/tests/integration/external_provider/sir.py
+++ b/tests/integration/external_provider/sir.py
@@ -3,20 +3,20 @@
 from typing import Any
 
 import numpy as np
-from numpy.typing import NDArray
 
 from flepimop2.configuration import ModuleModel
 from flepimop2.system.abc import SystemABC
+from flepimop2.typing import Float64NDArray
 
 
 def stepper(
     time: np.float64,  # noqa: ARG001
-    state: NDArray[np.float64],
+    state: Float64NDArray,
     *,
     beta: float = 0.3,
     gamma: float = 0.1,
     **kwargs: Any,  # noqa: ARG001
-) -> NDArray[np.float64]:
+) -> Float64NDArray:
     """
     ODE for an SIR model.
 

--- a/tests/system/test_system_wrapper/dummy_system.py
+++ b/tests/system/test_system_wrapper/dummy_system.py
@@ -1,12 +1,11 @@
 """A dummy stepper function for testing `WrapperSystem`."""
 
 import numpy as np
-from numpy.typing import NDArray
+
+from flepimop2.typing import Float64NDArray
 
 
-def stepper(
-    time: float, state: NDArray[np.float64], offset: np.float64
-) -> NDArray[np.float64]:
+def stepper(time: float, state: Float64NDArray, offset: np.float64) -> Float64NDArray:
     """
     A dummy stepper function for testing purposes: (state + offset) * time.
 


### PR DESCRIPTION
Added `flepimop2.typing` for custom types starting with `Float64NDArray` alias. Also fixed an issue with pytest's doctest runner where it would confuse `flepimop2` module names with stdlib modules where names conflicted (e.g. `flepimop2.typing` and `typing`) via the `--import-mode=importlib` option.