### PR TITLE
Add authors/maintainer info to documentation site

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,3 +1,4 @@
+authors.md
+changelog.md
 development/contributing.md
 reference/api/*.md
-changelog.md

--- a/justfile
+++ b/justfile
@@ -66,6 +66,7 @@ quality: ci-ruff mypy
 # Generate API reference documentation
 [group('docs')]
 reference:
+    uv run scripts/authors.py
     uv run scripts/api-reference.py
     cp CHANGELOG.md docs/changelog.md
     cp CONTRIBUTING.md docs/development/contributing.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -41,6 +41,9 @@ markdown_extensions:
       permalink: true
       toc_depth: 4
   - attr_list
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
   - mkdocs-click
   - admonition
   - pymdownx.details
@@ -88,3 +91,4 @@ nav:
           - Typing: reference/api/typing.md
       - CLI: reference/cli.md
   - Changelog: changelog.md
+  - Authors: authors.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 authors = [
     { name = "Carl Pearson", email = "cap1024@unc.edu" },
     { name = "Joshua Macdonald", email = "jmacdo16@jh.edu" },
-    { name = "Timothy Willard", email = "twillard@unc.edu" }
+    { name = "Timothy Willard", email = "twillard@unc.edu" },
 ]
 requires-python = ">=3.11,<3.15"
 dependencies = [
@@ -57,6 +57,20 @@ dev = [
     "types-pyyaml>=6.0.12.20250915",
     "yamllint>=1.37.1",
 ]
+
+[[tool.flepimop2.people]]
+email = "cap1024@unc.edu"
+github = "pearsonca"
+orcid = "0000-0003-0701-7860"
+
+[[tool.flepimop2.people]]
+email = "jmacdo16@jh.edu"
+github = "MacdonaldJoshuaCaleb"
+orcid = "0000-0002-3643-6266"
+
+[[tool.flepimop2.people]]
+email = "twillard@unc.edu"
+github = "TimothyWillard"
 
 [tool.pytest.ini_options]
 testpaths = [

--- a/scripts/api-reference.py
+++ b/scripts/api-reference.py
@@ -1,5 +1,5 @@
 # /// script
-# requires-python = ">=3.12"
+# requires-python = ">=3.11,<3.15"
 # dependencies = ["ruamel.yaml"]
 # ///
 """Generate API reference documentation for flepimop2."""

--- a/scripts/authors.py
+++ b/scripts/authors.py
@@ -1,0 +1,65 @@
+# /// script
+# requires-python = ">=3.11,<3.15"
+# ///
+"""Generate authors and maintainers documentation page for flepimop2."""
+
+import tomllib
+from pathlib import Path
+
+
+def format_person(person: dict[str, str]) -> str | None:
+    """
+    Format a person dictionary into a string.
+
+    Args:
+        person: A dictionary containing the person's information.
+
+    Returns:
+        A formatted string with the person's name and optional contact information, or
+        `None` if the name is missing.
+
+    """
+    if (entry := person.get("name")) is None:
+        return None
+    if email := person.get("email"):
+        entry += f" [:material-email:](mailto:{email})"
+    if github := person.get("github"):
+        entry += f" [:simple-github:](https://github.com/{github})"
+    if orcid := person.get("orcid"):
+        entry += f" [:simple-orcid:](https://orcid.org/{orcid})"
+    return f"- {entry}"
+
+
+def main() -> None:
+    """Generate `authors.md` from `pyproject.toml` data."""
+    root = Path(__file__).parent.parent
+
+    pyproject = tomllib.loads((root / "pyproject.toml").read_text())
+
+    authors = pyproject.get("project", {}).get("authors", [])
+    maintainers = pyproject.get("project", {}).get("maintainers", [])
+    people = pyproject.get("tool", {}).get("flepimop2", {}).get("people", [])
+
+    people_by_email = {
+        person["email"]: person for person in people if "email" in person
+    }
+
+    authors = [a | people_by_email.get(a.get("email"), {}) for a in authors]
+    maintainers = [m | people_by_email.get(m.get("email"), {}) for m in maintainers]
+
+    content = ["---", "hide:", "  - 'toc'", "---", "", "# Authors and Maintainers", ""]
+    if formatted_authors := [p for a in authors if (p := format_person(a)) is not None]:
+        content.extend(["## Authors", "", *formatted_authors, ""])
+    if formatted_maintainers := [
+        p for m in maintainers if (p := format_person(m)) is not None
+    ]:
+        content.extend(["## Maintainers", "", *formatted_maintainers, ""])
+
+    authors_md = root / "docs" / "authors.md"
+    if authors_md.exists():
+        authors_md.unlink()
+    authors_md.write_text("\n".join(content))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Added `scripts/authors.py` which will extract author/maintainer information from the `pyproject.toml` file and produce a `docs/authors.md` file. In particular it pulls the role information from `project.authors`/`project.maintainers` and supplemental info (GitHub & ORCID) from `tools.flepimop2.people`.

Closes #116.