### PR TITLE
Remove `zizmor` linting

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,10 +7,6 @@ name: 'CI'
       - 'main'
   workflow_dispatch:
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 permissions:
   contents: 'read'
 
@@ -29,13 +25,11 @@ jobs:
       - name: 'Install just'
         run: 'sudo apt install just'
       - name: 'Checkout repository'
-        # v5.0.0
-        uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8'
+        uses: 'actions/checkout@v6'
         with:
           persist-credentials: false
       - name: 'Setup uv with python ${{ matrix.python-version }}'
-        # v7.1.2
-        uses: 'astral-sh/setup-uv@85856786d1ce8acfbcc2f13a5f3fbd6b938f9f41'
+        uses: 'astral-sh/setup-uv@v7'
         with:
           enable-cache: true
           cache-dependency-glob: 'pyproject.toml'
@@ -55,13 +49,11 @@ jobs:
       - name: 'Install just'
         run: 'sudo apt install just'
       - name: 'Checkout repository'
-        # v5.0.0
-        uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8'
+        uses: 'actions/checkout@v6'
         with:
           persist-credentials: false
       - name: 'Setup uv'
-        # v7.1.2
-        uses: 'astral-sh/setup-uv@85856786d1ce8acfbcc2f13a5f3fbd6b938f9f41'
+        uses: 'astral-sh/setup-uv@v7'
         with:
           enable-cache: true
           cache-dependency-glob: 'pyproject.toml'

--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -10,10 +10,6 @@ name: 'GitHub Pages Documentation'
       - 'published'
   workflow_dispatch:
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 permissions:
   contents: 'read'
 
@@ -31,8 +27,7 @@ jobs:
       - name: 'Install just'
         run: 'sudo apt install just'
       - name: 'Checkout repository'
-        # v5.0.0
-        uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8'
+        uses: 'actions/checkout@v6'
         with:
           ref: 'main'
           persist-credentials: true
@@ -44,8 +39,7 @@ jobs:
         env:
           ACTOR: "${{ github.actor }}"
       - name: 'Setup uv with python ${{ matrix.python-version }}'
-        # v7.1.2
-        uses: 'astral-sh/setup-uv@85856786d1ce8acfbcc2f13a5f3fbd6b938f9f41'
+        uses: 'astral-sh/setup-uv@v7'
         with:
           enable-cache: true
           cache-dependency-glob: 'pyproject.toml'

--- a/.github/workflows/yaml.yaml
+++ b/.github/workflows/yaml.yaml
@@ -10,10 +10,6 @@ name: 'YAML'
       - '**.yml'
   workflow_dispatch:
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 permissions:
   contents: 'read'
 
@@ -29,31 +25,14 @@ jobs:
       - name: 'Install just'
         run: 'sudo apt install just'
       - name: 'Checkout repository'
-        # v5.0.0
-        uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8'
+        uses: 'actions/checkout@v6'
         with:
           persist-credentials: false
       - name: 'Setup uv'
-        # v7.1.2
-        uses: 'astral-sh/setup-uv@85856786d1ce8acfbcc2f13a5f3fbd6b938f9f41'
+        uses: 'astral-sh/setup-uv@v7'
         with:
           enable-cache: true
           cache-dependency-glob: 'pyproject.toml'
           python-version: '${{ matrix.python-version }}'
       - name: 'Run yamllint'
         run: 'just yamllint'
-  zizmor:
-    name: 'zizmor lint'
-    runs-on: 'ubuntu-latest'
-    steps:
-      - name: 'Checkout repository'
-        # v5.0.0
-        uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8'
-        with:
-          persist-credentials: false
-      - name: 'Run zizmor'
-        # v0.2.0
-        uses: 'zizmorcore/zizmor-action@e673c3917a1aef3c65c972347ed84ccd013ecda4'
-        with:
-          persona: 'pedantic'
-          advanced-security: false


### PR DESCRIPTION
`zizmor` is a bit heavy since the GitHub action workflows in this repository only rely on two external actions, one of which is managed by GitHub.