### PR TITLE
Add ACCIDDA/Insight Net branding images

### DIFF
--- a/docs/stylesheets/branding.css
+++ b/docs/stylesheets/branding.css
@@ -1,0 +1,31 @@
+.brand-links--footer {
+  display: flex;
+  align-items: center;
+  gap: 1.0rem;
+  margin-left: auto;
+}
+
+.brand-links--footer a {
+  display: inline-flex;
+  align-items: center;
+}
+
+.brand-links--footer img {
+  display: block;
+  width: auto;
+  max-height: 84px;
+  object-fit: contain;
+}
+
+@media screen and (max-width: 44.9375em) {
+  .brand-links--footer {
+    width: 100%;
+    justify-content: center;
+    margin-left: 0;
+    margin-top: 0.5rem;
+  }
+}
+
+.md-footer-meta__inner {
+  padding: 0.6rem !important;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -57,6 +57,7 @@ extra_javascript:
   - https://unpkg.com/katex@0/dist/contrib/auto-render.min.js
 
 extra_css:
+  - stylesheets/branding.css
   - https://unpkg.com/katex@0/dist/katex.min.css
 
 # Navigation structure

--- a/overrides/partials/footer.html
+++ b/overrides/partials/footer.html
@@ -1,0 +1,64 @@
+{#-
+  This file is based on Material's footer partial and includes custom branding links.
+-#}
+<footer class="md-footer">
+  {% if "navigation.footer" in features %}
+    {% if page.previous_page or page.next_page %}
+      {% if page.meta and page.meta.hide %}
+        {% set hidden = "hidden" if "footer" in page.meta.hide %}
+      {% endif %}
+      <nav class="md-footer__inner md-grid" aria-label="{{ lang.t('footer') }}" {{ hidden }}>
+        {% if page.previous_page %}
+          {% set direction = lang.t("footer.previous") %}
+          <a href="{{ page.previous_page.url | url }}" class="md-footer__link md-footer__link--prev" aria-label="{{ direction }}: {{ page.previous_page.title | e }}">
+            <div class="md-footer__button md-icon">
+              {% set icon = config.theme.icon.previous or "material/arrow-left" %}
+              {% include ".icons/" ~ icon ~ ".svg" %}
+            </div>
+            <div class="md-footer__title">
+              <span class="md-footer__direction">
+                {{ direction }}
+              </span>
+              <div class="md-ellipsis">
+                {{ page.previous_page.title }}
+              </div>
+            </div>
+          </a>
+        {% endif %}
+        {% if page.next_page %}
+          {% set direction = lang.t("footer.next") %}
+          <a href="{{ page.next_page.url | url }}" class="md-footer__link md-footer__link--next" aria-label="{{ direction }}: {{ page.next_page.title | e }}">
+            <div class="md-footer__title">
+              <span class="md-footer__direction">
+                {{ direction }}
+              </span>
+              <div class="md-ellipsis">
+                {{ page.next_page.title }}
+              </div>
+            </div>
+            <div class="md-footer__button md-icon">
+              {% set icon = config.theme.icon.next or "material/arrow-right" %}
+              {% include ".icons/" ~ icon ~ ".svg" %}
+            </div>
+          </a>
+        {% endif %}
+      </nav>
+    {% endif %}
+  {% endif %}
+  <div class="md-footer-meta md-typeset">
+    <div class="md-footer-meta__inner md-grid">
+      {% include "partials/copyright.html" %}
+      {% if config.extra.social %}
+        {% include "partials/social.html" %}
+      {% endif %}
+      <div class="brand-links brand-links--footer" aria-label="Organization links">
+        <a href="https://accidda.org/" target="_blank" rel="noopener" aria-label="ACCIDDA">
+          <img src="https://raw.githubusercontent.com/ACCIDDA/ACCIDDA-Images/refs/heads/main/accidda/accidda-white.png" alt="ACCIDDA" loading="lazy" />
+        </a>
+        <a href="https://insightnet.us/" target="_blank" rel="noopener" aria-label="Insight Net">
+          <img src="https://raw.githubusercontent.com/ACCIDDA/ACCIDDA-Images/refs/heads/main/insight-net/in-logo-white-no-words.png" alt="Insight Net" loading="lazy" />
+        </a>
+      </div>
+    </div>
+  </div>
+</footer>


### PR DESCRIPTION
Added ACCIDDA and Insight Net branding images to the footer with links to the respective websites. Also enlarged the footer to make the images more visible.

Closes #112.