### PR TITLE
Various minor local dev/ci improvements

### DIFF
--- a/.github/actions/setup-just-and-uv/action.yaml
+++ b/.github/actions/setup-just-and-uv/action.yaml
@@ -1,0 +1,27 @@
+---
+name: 'setup-just-and-uv'
+description: 'Setup just and uv for use in CI workflows'
+inputs:
+  python-version:
+    description: 'Python version to install/configure via uv'
+    required: false
+    default: '3.12'
+  enable-cache:
+    description: 'Whether to enable uv caching'
+    required: false
+    default: 'true'
+  cache-dependency-glob:
+    description: 'Dependency files used for uv cache keying'
+    required: false
+    default: 'pyproject.toml'
+runs:
+  using: 'composite'
+  steps:
+    - name: 'install just'
+      uses: 'extractions/setup-just@v3'
+    - name: 'setup uv'
+      uses: 'astral-sh/setup-uv@v7'
+      with:
+        enable-cache: '${{ inputs.enable-cache }}'
+        cache-dependency-glob: '${{ inputs.cache-dependency-glob }}'
+        python-version: '${{ inputs.python-version }}'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,5 @@
 ---
-name: 'CI'
+name: 'ci'
 
 'on':
   pull_request:
@@ -11,54 +11,62 @@ permissions:
   contents: 'read'
 
 jobs:
-  ci:
-    name: 'CI (${{ matrix.python-version }})'
-    runs-on: 'ubuntu-latest'
-    strategy:
-      matrix:
-        python-version:
-          - '3.11'
-          - '3.12'
-          - '3.13'
-          - '3.14'
-    steps:
-      - name: 'Install just'
-        run: 'sudo apt install just'
-      - name: 'Checkout repository'
-        uses: 'actions/checkout@v6'
-        with:
-          persist-credentials: false
-      - name: 'Setup uv with python ${{ matrix.python-version }}'
-        uses: 'astral-sh/setup-uv@v7'
-        with:
-          enable-cache: true
-          cache-dependency-glob: 'pyproject.toml'
-          python-version: '${{ matrix.python-version }}'
-      - name: 'Run Checks'
-        run: 'just ci'
-        env:
-          UV_PYTHON_VERSION: '${{ matrix.python-version }}'
   docs:
-    name: 'Docs (${{ matrix.python-version }})'
+    name: 'docs'
     runs-on: 'ubuntu-latest'
-    strategy:
-      matrix:
-        python-version:
-          - '3.12'
     steps:
-      - name: 'Install just'
-        run: 'sudo apt install just'
-      - name: 'Checkout repository'
+      - name: 'checkout repository'
         uses: 'actions/checkout@v6'
         with:
           persist-credentials: false
-      - name: 'Setup uv'
-        uses: 'astral-sh/setup-uv@v7'
-        with:
-          enable-cache: true
-          cache-dependency-glob: 'pyproject.toml'
-          python-version: '${{ matrix.python-version }}'
-      - name: 'Build Documentation'
+      - name: 'setup just and uv'
+        uses: './.github/actions/setup-just-and-uv'
+      - name: 'build documentation'
         run: 'just docs'
-        env:
-          UV_PYTHON_VERSION: '${{ matrix.python-version }}'
+  quality:
+    name: 'quality'
+    runs-on: 'ubuntu-latest'
+    steps:
+      - name: 'checkout repository'
+        uses: 'actions/checkout@v6'
+        with:
+          persist-credentials: false
+      - name: 'setup just and uv'
+        uses: './.github/actions/setup-just-and-uv'
+      - name: 'run quality checks'
+        run: 'just quality'
+  tests:
+    name: 'tests (${{ matrix.python-version }}-${{ matrix.coverage }})'
+    needs:
+      - 'docs'
+      - 'quality'
+    runs-on: 'ubuntu-latest'
+    strategy:
+      matrix:
+        include:
+          - python-version: '3.11'
+            coverage: false
+          - python-version: '3.12'
+            coverage: true
+          - python-version: '3.13'
+            coverage: false
+          - python-version: '3.14'
+            coverage: false
+    steps:
+      - name: 'checkout repository'
+        uses: 'actions/checkout@v6'
+        with:
+          persist-credentials: false
+      - name: 'setup just and uv with python ${{ matrix.python-version }}'
+        uses: './.github/actions/setup-just-and-uv'
+        with:
+          python-version: '${{ matrix.python-version }}'
+      - name: 'run coverage tests'
+        if: '${{ matrix.coverage }}'
+        run: 'just cov'
+      - name: 'run integration tests'
+        if: '${{ matrix.coverage }}'
+        run: 'just integration'
+      - name: 'run full pytest suite'
+        if: '${{ !matrix.coverage }}'
+        run: 'just pytest'

--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -1,5 +1,5 @@
 ---
-name: 'GitHub Pages Documentation'
+name: 'github pages'
 
 'on':
   push:
@@ -15,36 +15,26 @@ permissions:
 
 jobs:
   deploy:
-    name: 'Deploy Documentation to GitHub Pages'
+    name: 'deploy documentation to github pages'
     runs-on: 'ubuntu-latest'
-    strategy:
-      matrix:
-        python-version:
-          - '3.12'
     permissions:
       contents: 'write'  # Needed to push to gh-pages
     steps:
-      - name: 'Install just'
-        run: 'sudo apt install just'
-      - name: 'Checkout repository'
+      - name: 'checkout repository'
         uses: 'actions/checkout@v6'
         with:
           ref: 'main'
           persist-credentials: true
-      - name: 'Fetch gh-pages branch'
+      - name: 'setup just and uv'
+        uses: './.github/actions/setup-just-and-uv'
+      - name: 'fetch gh-pages branch'
         run: |
           git fetch origin gh-pages:gh-pages --depth=1
           git config --global user.name "${ACTOR}"
           git config --global user.email "${ACTOR}@users.noreply.github.com"
         env:
           ACTOR: "${{ github.actor }}"
-      - name: 'Setup uv with python ${{ matrix.python-version }}'
-        uses: 'astral-sh/setup-uv@v7'
-        with:
-          enable-cache: true
-          cache-dependency-glob: 'pyproject.toml'
-          python-version: '${{ matrix.python-version }}'
-      - name: 'Extract flepimop2 version'
+      - name: 'extract flepimop2 version'
         id: extract-version
         run: |
           cat > version.py << EOF
@@ -57,9 +47,9 @@ jobs:
           EOF
           uv run -qq python version.py >> $GITHUB_OUTPUT
           rm version.py
-      - name: 'Build API Reference'
+      - name: 'build reference'
         run: 'just reference'
-      - name: 'Deploy to GitHub Pages'
+      - name: 'deploy to github pages'
         run: |
           uv run mike set-default latest
           if [ "${EVENT_NAME}" == "release" ] || [[ $VERSION == 0* ]]; then

--- a/.github/workflows/yaml.yaml
+++ b/.github/workflows/yaml.yaml
@@ -1,5 +1,5 @@
 ---
-name: 'YAML'
+name: 'yaml'
 
 'on':
   pull_request:
@@ -14,25 +14,15 @@ permissions:
   contents: 'read'
 
 jobs:
-  yaml:
-    name: 'YAML Lint'
+  yamllint:
+    name: 'yaml lint'
     runs-on: 'ubuntu-latest'
-    strategy:
-      matrix:
-        python-version:
-          - '3.12'
     steps:
-      - name: 'Install just'
-        run: 'sudo apt install just'
-      - name: 'Checkout repository'
+      - name: 'checkout repository'
         uses: 'actions/checkout@v6'
         with:
           persist-credentials: false
-      - name: 'Setup uv'
-        uses: 'astral-sh/setup-uv@v7'
-        with:
-          enable-cache: true
-          cache-dependency-glob: 'pyproject.toml'
-          python-version: '${{ matrix.python-version }}'
-      - name: 'Run yamllint'
+      - name: 'setup just and uv'
+        uses: './.github/actions/setup-just-and-uv'
+      - name: 'run yamllint'
         run: 'just yamllint'

--- a/conftest.py
+++ b/conftest.py
@@ -3,12 +3,43 @@
 from collections.abc import Generator
 from os import chdir
 from pathlib import Path
-from tempfile import TemporaryDirectory
-from typing import Any
 
 import pytest
 from sybil import Sybil
 from sybil.parsers.markdown import PythonCodeBlockParser, SkipParser
+
+
+def _find_repo_root(start: Path) -> Path:
+    """
+    Find the repository root by searching for a parent with `pyproject.toml`.
+
+    Args:
+        start: The starting directory to search from.
+
+    Returns:
+        The path to the repository root directory.
+
+    Raises:
+        FileNotFoundError: If no repository root is found.
+
+    """
+    for candidate in (start, *start.parents):
+        if (candidate / "pyproject.toml").is_file():
+            return candidate
+    msg = f"Could not find repository root from {start} (missing `pyproject.toml`)."
+    raise FileNotFoundError(msg)
+
+
+@pytest.fixture(scope="session")
+def repo_root() -> Path:
+    """
+    Get the repository root directory containing `pyproject.toml`.
+
+    Returns:
+        The path to the repository root directory.
+
+    """
+    return _find_repo_root(Path(__file__).resolve())
 
 
 @pytest.fixture(autouse=True)
@@ -21,6 +52,7 @@ def doctest_tmpdir(request: pytest.FixtureRequest) -> Generator[None]:
 
     Notes:
         [See this StackOverflow answer for details.](https://stackoverflow.com/q/46962007)
+
     """
     doctest_plugin = request.config.pluginmanager.getplugin("doctest")
     if isinstance(
@@ -34,11 +66,27 @@ def doctest_tmpdir(request: pytest.FixtureRequest) -> Generator[None]:
         yield
 
 
-def documentation_setup(documentation_setup: dict[str, Any]) -> None:  # noqa: ARG001
-    """Create and change to a temporary directory for documentation tests."""
-    directory = Path(TemporaryDirectory().name)
-    directory.mkdir(parents=True, exist_ok=True)
-    chdir(directory)
+@pytest.fixture(autouse=True)
+def docs_tmpdir(request: pytest.FixtureRequest, tmp_path: Path) -> Generator[None]:
+    """
+    Run docs tests from a temp working directory and restore cwd afterwards.
+
+    Args:
+        request: The pytest fixture request object.
+        tmp_path: The temporary working directory.
+
+    Yields:
+        `None`, but ensures the current working directory is changed to `tmp_path`
+    """
+    if request.node.nodeid.startswith("docs/"):
+        old_cwd = Path.cwd()
+        chdir(tmp_path)
+        try:
+            yield
+        finally:
+            chdir(old_cwd)
+    else:
+        yield
 
 
 pytest_collect_file = Sybil(
@@ -48,5 +96,19 @@ pytest_collect_file = Sybil(
     ],
     path=str(Path(__file__).parent / "docs"),
     pattern="**/*.md",
-    setup=documentation_setup,
 ).pytest()
+
+
+def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
+    """
+    Automatically mark tests in tests/integration as integration tests.
+
+    Args:
+        items: The list of collected pytest items to modify.
+
+    """
+    integration_prefix = "tests/integration/"
+    marker = pytest.mark.integration
+    for item in items:
+        if item.nodeid.startswith(integration_prefix):
+            item.add_marker(marker)

--- a/docs/assets/SIR.py
+++ b/docs/assets/SIR.py
@@ -11,7 +11,19 @@ def stepper(
     beta: float,
     gamma: float,
 ) -> Float64NDArray:
-    """dY/dt for the SIR model."""
+    """
+    Compute dY/dt for the SIR model.
+
+    Args:
+        t: The current time (not used in this model, but included for compatibility).
+        y: A numpy array containing the current values [S, I, R].
+        beta: The infection rate.
+        gamma: The recovery rate.
+
+    Returns:
+        A numpy array containing the derivatives [dS/dt, dI/dt, dR/dt].
+
+    """
     y_s, y_i, _ = np.asarray(y, dtype=float)
     infection = (beta * y_s * y_i) / np.sum(y)
     recovery = gamma * y_i

--- a/docs/assets/solve_ivp.py
+++ b/docs/assets/solve_ivp.py
@@ -31,6 +31,10 @@ def runner(
         FloatArray: Array with time and state values evaluated at `times`.
         Each row is [t, y...].
 
+    Raises:
+        ValueError: If `times` is not a 1D sequence of time points with length >= 1, or
+            if the first time point is negative.
+
     """
     if not (times.ndim == 1 and times.size >= 1):
         msg = "times must be a 1D sequence of time points"
@@ -44,5 +48,12 @@ def runner(
         raise ValueError(msg)
 
     args = tuple(val for val in params.values()) if params is not None else None
-    result = solve_ivp(fun, (t0, tf), y0, t_eval=times, args=args, **solver_options)
+    result = solve_ivp(
+        fun,
+        (t0, tf),
+        y0,
+        t_eval=times,
+        args=args,  # type: ignore[arg-type]
+        **solver_options,
+    )
     return np.transpose(np.vstack((result.t, result.y)))

--- a/docs/development/implementing-custom-engines-and-systems.md
+++ b/docs/development/implementing-custom-engines-and-systems.md
@@ -27,7 +27,6 @@ from flepimop2.typing import Float64NDArray, StateChangeEnum
 def stepper(
     time: np.float64,  # noqa: ARG001
     state: Float64NDArray,
-    *,
     **kwargs: Any,  # noqa: ARG001
 ) -> Float64NDArray:
     """
@@ -83,7 +82,8 @@ import numpy as np
 
 from flepimop2.configuration import IdentifierString, ModuleModel
 from flepimop2.engine.abc import EngineABC
-from flepimop2.system.abc import SystemProtocol
+from flepimop2.exceptions import ValidationIssue
+from flepimop2.system.abc import SystemABC, SystemProtocol
 from flepimop2.typing import Float64NDArray
 
 

--- a/justfile
+++ b/justfile
@@ -1,50 +1,81 @@
 # Run all default tasks for local development
-default: format check pytest mypy yamllint
+default: dev lint
+
+# Run all default dev tasks
+dev: ruff mypy test
+
+# Run all default lint tasks
+lint: yamllint
+
+# Run all default CI tasks
+ci: quality test docs
 
 # Format code using `ruff`
-format:
-    uv run ruff format --preview
+[group('dev')]
+ruff:
+    uv run ruff format
+    uv run ruff check --fix
 
-# Check code using `ruff`
-check:
-    uv run ruff check --preview --fix
+# Run coverage tests
+[group('dev')]
+cov:
+    uv run pytest -m "not integration" --cov=src/flepimop2 --cov-report=term-missing
 
-# Run tests using `pytest`
+# Run integration tests
+[group('dev')]
+integration:
+    uv run pytest -m "integration"
+
+# Run full pytest suite, including integration tests, without coverage report
+[group('ci')]
 pytest:
     uv run pytest
 
+# Run coverage and integration tests
+[group('dev')]
+test: cov integration
+
 # Type check using `mypy`
+[group('dev')]
 mypy:
-    uv run mypy .
-
-# Lint YAML files using `yamllint`
-yamllint:
-    uv run yamllint --strict --config-file .yamllint.yaml .
-
-# Run all CI checks
-ci:
-    uv run ruff format --preview --check
-    uv run ruff check --preview --no-fix
-    uv run pytest --doctest-modules --ignore=src/flepimop2/typing
-    uv run mypy --strict .
+    uv run mypy
 
 # Clean up generated lock files, venvs, and caches
+[group('dev')]
 clean:
     rm -f uv.lock
     rm -rf .*_cache
     rm -rf .venv
     rm -rf site
 
+# Lint YAML files using `yamllint`
+[group('lint')]
+yamllint:
+    uv run yamllint --strict --config-file .yamllint.yaml .
+
+# Run CI `ruff` formatting/linting checks
+[group('ci')]
+ci-ruff:
+    uv run ruff format --check
+    uv run ruff check --no-fix
+
+# Run CI quality checks (format/lint/type check)
+[group('ci')]
+quality: ci-ruff mypy
+
 # Generate API reference documentation
+[group('docs')]
 reference:
     uv run scripts/api-reference.py
     cp CHANGELOG.md docs/changelog.md
     cp CONTRIBUTING.md docs/development/contributing.md
 
 # Build the documentation using `mkdocs`
+[group('docs')]
 docs: reference
     uv run mkdocs build --verbose --strict
 
 # Serve the documentation locally using `mkdocs`
+[group('docs')]
 serve: reference
     uv run mkdocs serve --livereload

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,10 @@ dev = [
     "mkdocstrings[python]>=0.30.1",
     "mypy>=1.18.2",
     "pytest>=8.4.2",
+    "pytest-cov>=7.0.0",
     "ruff>=0.13.3",
+    "scipy>=1.17.0",
+    "scipy-stubs>=1.17.0.2",
     "sybil[pytest]>=9.2.0",
     "types-pyyaml>=6.0.12.20250915",
     "yamllint>=1.37.1",
@@ -57,20 +60,22 @@ dev = [
 
 [tool.pytest.ini_options]
 testpaths = [
+    "docs/",
     "src",
     "tests/",
 ]
 addopts = ["--import-mode=importlib", "--doctest-modules"]
-
-
-[tool.ruff]
-exclude = ["docs/assets/*.py"]
+markers = [
+    "integration: marks integration tests in tests/integration/",
+]
 
 [tool.ruff.format]
+preview = true
 docstring-code-format = true
 docstring-code-line-length = 72
 
 [tool.ruff.lint]
+preview = true
 select = [
     "ALL",
 ]
@@ -102,12 +107,17 @@ allow-star-arg-any = true
 convention = "google"
 
 [tool.mypy]
-strict = true
-exclude = ["^build/", "^docs/"]
-namespace_packages = true
 mypy_path = ["src"]
+files = "."
+exclude = ["^build/", "^site/"]
+namespace_packages = true
 explicit_package_bases = true
+strict = true
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/flepimop2"]
 include = ["src/flepimop2/templates"]
+
+[tool.coverage.report]
+fail_under = 75
+precision = 1

--- a/src/flepimop2/exceptions/_flepimop2_error.py
+++ b/src/flepimop2/exceptions/_flepimop2_error.py
@@ -1,15 +1,6 @@
-from typing import Any
-
-
 class Flepimop2Error(Exception):
     """
     Base class for exceptions provided by `flepimop2`.
 
     This class serves as the root for all custom exceptions in the `flepimop2` library.
     """
-
-    __module__ = "flepimop2.exceptions"
-
-    def __init_subclass__(cls, **kwargs: Any) -> None:
-        super().__init_subclass__(**kwargs)
-        cls.__module__ = "flepimop2.exceptions"

--- a/src/flepimop2/exceptions/_flepimop2_validation_error.py
+++ b/src/flepimop2/exceptions/_flepimop2_validation_error.py
@@ -83,7 +83,7 @@ class Flepimop2ValidationError(Flepimop2Error):
         >>> raise Flepimop2ValidationError(issues)
         Traceback (most recent call last):
             ...
-        flepimop2.exceptions.Flepimop2ValidationError: 2 validation issues encountered:
+        flepimop2.exceptions._flepimop2_validation_error.Flepimop2ValidationError: 2 validation issues encountered:
         - [missing_parameter] Model requires undefined parameter 'gamma'. (parameter=gamma, transition=gamma * (S / N))
         - [unreachable_compartment] Compartment 'E' is unreachable. (compartment=E)
 

--- a/tests/integration/documentation_quick_start/test_quick_start.py
+++ b/tests/integration/documentation_quick_start/test_quick_start.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from flepimop2.testing import flepimop2_run, project_skeleton
 
 
-def test_quick_start_simulate(tmp_path: Path) -> None:
+def test_quick_start_simulate(repo_root: Path, tmp_path: Path) -> None:
     """
     Create a skeleton project, add plugins + config from docs, then simulate.
 
@@ -14,11 +14,13 @@ def test_quick_start_simulate(tmp_path: Path) -> None:
     project_skeleton(
         tmp_path,
         copy_files={
-            Path("tests/integration/documentation_quick_start/config.yaml"): Path(
+            repo_root / "tests/integration/documentation_quick_start/config.yaml": Path(
                 "configs/config.yaml"
             ),
-            Path("docs/assets/SIR.py"): Path("model_input/plugins/SIR.py"),
-            Path("docs/assets/solve_ivp.py"): Path("model_input/plugins/solve_ivp.py"),
+            repo_root / "docs/assets/SIR.py": Path("model_input/plugins/SIR.py"),
+            repo_root / "docs/assets/solve_ivp.py": Path(
+                "model_input/plugins/solve_ivp.py"
+            ),
         },
         dependencies=["scipy"],
     )

--- a/tests/integration/external_provider/test_external_provider.py
+++ b/tests/integration/external_provider/test_external_provider.py
@@ -8,12 +8,15 @@ import pytest
 from flepimop2.testing import external_provider_package, flepimop2_run
 
 
-def test_external_provider(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+def test_external_provider(
+    monkeypatch: pytest.MonkeyPatch, repo_root: Path, tmp_path: Path
+) -> None:
     """
     Test external provider functionality.
 
     Args:
         monkeypatch: Pytest monkeypatch fixture.
+        repo_root: Path to the repository root.
         tmp_path: Temporary directory provided by pytest.
 
     Notes:
@@ -24,21 +27,18 @@ def test_external_provider(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> N
 
     """
     # Setup
-    cwd = Path(__file__).parent.resolve()
     external_provider_package(
         tmp_path,
         copy_files={
-            cwd / "config.yaml": Path("config.yaml"),
-            cwd / "euler.py": Path("external_provider")
-            / "src"
-            / "flepimop2"
-            / "engine"
-            / "euler.py",
-            cwd / "sir.py": Path("external_provider")
-            / "src"
-            / "flepimop2"
-            / "system"
-            / "sir.py",
+            repo_root / "tests/integration/external_provider/config.yaml": Path(
+                "config.yaml"
+            ),
+            repo_root / "tests/integration/external_provider/euler.py": Path(
+                "external_provider/src/flepimop2/engine/euler.py"
+            ),
+            repo_root / "tests/integration/external_provider/sir.py": Path(
+                "external_provider/src/flepimop2/system/sir.py"
+            ),
         },
     )
     monkeypatch.chdir(tmp_path)


### PR DESCRIPTION
- Added code coverage check to local development via `just cov` as well
  as incorporating into CI by running them for python version 3.12 and
  then opting to just run the unit tests as is for other versions.
- Automatically mark tests in the `tests/integration/` directory with an
  "integration" pytest marker to differentiate them and make them easier
  to run separately.
- Consolidated settings from `justfile` into `pyproject.toml` for `ruff`
  and `mypy`.
- Refactored `justfile` for local development UX and updated CI checks
  to do the same as local checks when possible.
- Refactored `ci.yaml` workflow to split code quality checks from tests.
- Updated `CONTRIBUTING.md` to reflect the changes made above.
- Reenabled linting/formatting/type checking/testing of code within the
  `docs/` directory, which identified an issue with both the getting
  started example and the implementing a custom engine example.
  Closes #152.
- Added `repo_root` fixture to `conftest.py` for internal testing
  purposes, simplifies integration tests.
- Consolidated the steps to setup uv and just into a custom composite
  action named 'setup-just-and-uv' to DRY across the custom workflows.
  Also switched from installing `just` manually to using
  'extractions/setup-just@v3' to obtain a more recent version of `just`.