### PR TITLE
Add changelog check

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,6 +11,19 @@ permissions:
   contents: 'read'
 
 jobs:
+  changelog:
+    name: 'changelog'
+    runs-on: 'ubuntu-latest'
+    steps:
+      - name: 'checkout repository'
+        uses: 'actions/checkout@v6'
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: 'setup just and uv'
+        uses: './.github/actions/setup-just-and-uv'
+      - name: 'Check changelog updated'
+        run: 'just changelog'
   docs:
     name: 'docs'
     runs-on: 'ubuntu-latest'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
@@ -20,3 +21,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Added a new `flepimop2 skeleton` CLI command for scaffolding a project repository. See [#84](https://github.com/ACCIDDA/flepimop2/issues/84).
 - Added `flepimop.testing` with functionality for integration testing, both for `flepimop2` itself and for external provider packages. See [#107](https://github.com/ACCIDDA/flepimop2/issues/107).
 - Added a parent class, `ModuleABC`, for all customizable modules that sets a required `module` attribute and provides infrastructure for non-standardized properties information. Also extended said infrastructure to allow for standardized property information for `SystemABC`. See [#113](https://github.com/ACCIDDA/flepimop2/issues/113), [#126](https://github.com/ACCIDDA/flepimop2/issues/126), [#129](https://github.com/ACCIDDA/flepimop2/discussions/129).
+
+### Changed
+
+- ...
+
+### Deprecated
+
+- ...
+
+### Removed
+
+- ...
+
+### Fixed
+
+- ...
+
+### Security
+
+- ...

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -147,9 +147,9 @@ In GitHub Actions, these correspond to the `quality`, `tests`, and `docs` jobs i
 
 If you edit YAML files, also run `just yamllint`. YAML linting is separate from `just ci`.
 
-2. Update documentation if your changes affect user-facing functionality or add features that require usage guides.
+2. Add tests for new functionality or bug fixes. Particularly for bug fixes, the test should be written before the fix and fail without the fix present.
 
-3. Add tests for new functionality or bug fixes. Particularly for bug fixes, the test should be written before the fix and fail without the fix present.
+3. Update documentation if your changes affect user-facing functionality or add features that require usage guides. This should include adding a note to the `CHANGELOG.md` file if the change is more than a "patch" type change.
 
 ### Submitting a Pull Request
 

--- a/justfile
+++ b/justfile
@@ -5,7 +5,7 @@ default: dev lint
 dev: ruff mypy test
 
 # Run all default lint tasks
-lint: yamllint
+lint: yamllint changelog
 
 # Run all default CI tasks
 ci: quality test docs
@@ -42,16 +42,12 @@ mypy:
 
 # Clean up generated lock files, venvs, and caches
 [group('dev')]
+[unix]
 clean:
-    rm -f uv.lock
-    rm -rf .*_cache
+    rm -rf .*cache
     rm -rf .venv
     rm -rf site
-
-# Lint YAML files using `yamllint`
-[group('lint')]
-yamllint:
-    uv run yamllint --strict --config-file .yamllint.yaml .
+    rm -f uv.lock
 
 # Run CI `ruff` formatting/linting checks
 [group('ci')]
@@ -65,6 +61,7 @@ quality: ci-ruff mypy
 
 # Generate API reference documentation
 [group('docs')]
+[unix]
 reference:
     uv run scripts/authors.py
     uv run scripts/api-reference.py
@@ -80,3 +77,33 @@ docs: reference
 [group('docs')]
 serve: reference
     uv run mkdocs serve --livereload
+
+# Lint YAML files using `yamllint`
+[group('lint')]
+yamllint:
+    uv run yamllint --strict --config-file .yamllint.yaml .
+
+# Check that CHANGELOG.md was updated relative to main
+[group('lint')]
+[unix]
+changelog:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    BASE_REF="main"
+    if ! git show-ref --verify --quiet "refs/heads/${BASE_REF}"; then
+        git fetch origin "${BASE_REF}:${BASE_REF}"
+    fi
+    COMMIT_COUNT=$(git rev-list --count "${BASE_REF}..HEAD")
+    if [[ "${COMMIT_COUNT}" -eq 1 ]]; then
+        COMMIT_MSG=$(git log -1 --pretty=format:"%s %b")
+        SKIP_REGEX='no[[:space:]]+major[[:space:]]+changes'
+        if echo "${COMMIT_MSG}" | tr '\n' ' ' | grep -Eiq "${SKIP_REGEX}"; then
+            echo "Bypassing changelog check: single commit contains 'no major changes'"
+            exit 0
+        fi
+    fi
+    if ! git diff --name-only "${BASE_REF}...HEAD" | grep -q '^CHANGELOG\.md$'; then
+        echo "Error: Please update CHANGELOG.md"
+        exit 1
+    fi
+    echo "CHANGELOG.md check passed"


### PR DESCRIPTION
Added `just changelog` to check that an appropriate update has been made to the `CHANGELOG.md` file in pull requests. Also incorporated this check into the `ci.yaml` workflow. 

Closes #121