### PR TITLE
Build hooks for dynamic system/engine construction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a new `flepimop2 skeleton` CLI command for scaffolding a project repository. See [#84](https://github.com/ACCIDDA/flepimop2/issues/84).
 - Added `flepimop.testing` with functionality for integration testing, both for `flepimop2` itself and for external provider packages. See [#107](https://github.com/ACCIDDA/flepimop2/issues/107).
 - Added a parent class, `ModuleABC`, for all customizable modules that sets a required `module` attribute and provides infrastructure for non-standardized properties information. Also extended said infrastructure to allow for standardized property information for `SystemABC`. See [#113](https://github.com/ACCIDDA/flepimop2/issues/113), [#126](https://github.com/ACCIDDA/flepimop2/issues/126), [#129](https://github.com/ACCIDDA/flepimop2/discussions/129).
+- Added a build hook to the `EngineABC` and `SystemABC` classes to allow for engines/systems to easily construct their runner/stepper functions. See [#130](https://github.com/ACCIDDA/flepimop2/issues/130).
 
 ### Changed
 

--- a/docs/development/implementing-custom-engines-and-systems.md
+++ b/docs/development/implementing-custom-engines-and-systems.md
@@ -2,6 +2,8 @@
 
 This guide shows how to implement `EngineABC` and `SystemABC` so they can be loaded by `flepimop2` and used in simulations. It mirrors the style of the external provider guide, but focuses only on the engine/system interfaces.
 
+For full API signatures and attributes, see the [`SystemABC` API reference](./../reference/api/system.md#flepimop2.system.abc.SystemABC) and the [`EngineABC` API reference](./../reference/api/engine.md#flepimop2.engine.abc.EngineABC).
+
 Below is a minimal example creating new `EulerEngine` and `SirSystem`. You can copy these into your own module(s) under the `flepimop2.engine` and `flepimop2.system` namespaces.
 
 ## What are systems and engines?
@@ -50,9 +52,14 @@ class SirSystem(SystemABC):
     module = "flepimop2.system.sir"
     state_change = StateChangeEnum.FLOW
 
-    def __init__(self) -> None:
-        """Initialize the SIR system with the SIR stepper."""
-        self._stepper = stepper
+    def build_stepper(self):
+        """
+        Build the system stepper.
+
+        Returns:
+            The stepper function for this system.
+        """
+        return stepper
 
 
 def build(config: dict[str, Any] | ModuleModel) -> SirSystem:  # noqa: ARG001
@@ -67,9 +74,18 @@ def build(config: dict[str, Any] | ModuleModel) -> SirSystem:  # noqa: ARG001
 
 Key elements in the system implementation:
 
-- `stepper` defines the model dynamics which the engine will call it repeatedly.
-- `SirSystem` inherits `SystemABC` and assigns `_stepper` in `__init__` as well as has the required attributes `module` and `state_change`.
+- `stepper` defines the model dynamics which the engine will call repeatedly.
+- `SirSystem` inherits `SystemABC`, defines the required attributes `module` and `state_change`, and overrides `build_stepper` to provide the stepper.
 - `build(...)` provides a standard entry point so `flepimop2` can construct the system from configuration data. For more details on this you can read the [Creating An External Provider Package](./creating-an-external-provider-package.md) development guide.
+
+For very simple systems, you can define a class-level `_stepper` instead of overriding `build_stepper`:
+
+```python
+class SirSystem(SystemABC):
+    module = "flepimop2.system.sir"
+    state_change = StateChangeEnum.FLOW
+    _stepper = staticmethod(stepper)
+```
 
 ## Engine Implementation (`EulerEngine`)
 
@@ -84,7 +100,7 @@ from flepimop2.configuration import IdentifierString, ModuleModel
 from flepimop2.engine.abc import EngineABC
 from flepimop2.exceptions import ValidationIssue
 from flepimop2.system.abc import SystemABC, SystemProtocol
-from flepimop2.typing import Float64NDArray
+from flepimop2.typing import Float64NDArray, StateChangeEnum
 
 
 def runner(
@@ -116,10 +132,15 @@ class EulerEngine(EngineABC):
 
     module = "flepimop2.engine.euler"
 
-    def __init__(self) -> None:
-        """Initialize the SIR runner with the SIR runner function."""
-        self._runner = runner
-    
+    def build_runner(self):
+        """
+        Build the engine runner.
+
+        Returns:
+            The runner function for this engine.
+        """
+        return runner
+
     def validate_system(self, system: SystemABC) -> list[ValidationIssue] | None:
         """
         Validation hook for system properties.
@@ -157,14 +178,22 @@ def build(config: dict[str, Any] | ModuleModel) -> EulerEngine:  # noqa: ARG001
 Key elements in the engine implementation:
 
 - `runner` drives the simulation by applying the stepper across time points.
-- `EulerEngine` inherits `EngineABC` and assigns `_runner` in `__init__` as well as has a `module` attribute that gives it an importable name.
+- `EulerEngine` inherits `EngineABC`, defines `module`, and overrides `build_runner` to provide the runner.
 - `EulerEngine` implements the optional `validate_system` hook to ensure that the system is compatible.
 - `build(...)` lets `flepimop2` construct the engine from configuration data.
+
+For very simple engines, you can define a class-level `_runner` instead of overriding `build_runner`:
+
+```python
+class EulerEngine(EngineABC):
+    module = "flepimop2.engine.euler"
+    _runner = staticmethod(runner)
+```
 
 ## Summary
 
 Custom engines and systems are simple to implement once you know the required hooks. Keep the interfaces small and explicit, and let `flepimop2` handle construction and validation.
 
-- Systems must supply a stepper function as well as required attributes `module` and `state_change`.
-- Engines must supply a runner function compatible with `SystemProtocol` as well as required attributes `module` and optional system validation hook `validate_system`.
+- Systems must supply a stepper function compatible with `SystemProtocol` as well as required attributes `module` and `state_change`.
+- Engines must supply a runner function compatible with `EngineProtocol` as well as required attribute `module` and optional validation hook `validate_system`.
 - `build(...)` provides the standard entry point for configuration-driven construction.

--- a/src/flepimop2/engine/abc/__init__.py
+++ b/src/flepimop2/engine/abc/__init__.py
@@ -2,7 +2,7 @@
 
 __all__ = ["EngineABC", "EngineProtocol", "build"]
 
-from typing import Any, Protocol, runtime_checkable
+from typing import Any, Protocol, Self, runtime_checkable
 
 from flepimop2._utils._module import _build
 from flepimop2.configuration import IdentifierString, ModuleModel
@@ -57,6 +57,51 @@ class EngineABC(ModuleABC):
         """
         self._runner = _no_run_func
 
+    def build_runner(self) -> EngineProtocol:  # noqa: PLR6301
+        """
+        Build the runner function for this engine.
+
+        Concrete implementations can override this hook to dynamically construct
+        runner functions from instance state.
+
+        Returns:
+            The runner function for this engine.
+        """
+        return _no_run_func
+
+    def build(self) -> Self:
+        """
+        Build the engine internals required for running systems.
+
+        This method is idempotent and supports three strategies, in order:
+
+        1. Keep an existing instance-level runner if already set.
+        2. Reuse a class-level `_runner` callable if provided.
+        3. Fallback to `build_runner()` for dynamic construction.
+
+        Returns:
+            The built engine instance.
+
+        Raises:
+            TypeError: If `build_runner()` returns a non-callable object.
+        """
+        current_runner = getattr(self, "_runner", _no_run_func)
+        if current_runner is not _no_run_func:
+            return self
+
+        class_runner = type(self).__dict__.get("_runner")
+        if isinstance(class_runner, staticmethod):
+            class_runner = class_runner.__func__
+        if callable(class_runner) and class_runner is not _no_run_func:
+            self._runner = class_runner
+            return self
+
+        self._runner = self.build_runner()
+        if not callable(self._runner):
+            msg = "EngineABC::build_runner must return a callable runner function."
+            raise TypeError(msg)
+        return self
+
     def run(
         self,
         system: SystemABC,
@@ -78,6 +123,8 @@ class EngineABC(ModuleABC):
         Returns:
             The evolved time x state array.
         """
+        self.build()
+        system.build()
         return self._runner(
             system._stepper,  # noqa: SLF001
             eval_times,

--- a/src/flepimop2/engine/wrapper/__init__.py
+++ b/src/flepimop2/engine/wrapper/__init__.py
@@ -3,13 +3,11 @@
 __all__ = ["WrapperEngine"]
 
 from pathlib import Path
-from typing import Literal, Self
-
-from pydantic import model_validator
+from typing import Literal, cast
 
 from flepimop2._utils._module import _load_module, _validate_function
 from flepimop2.configuration import ModuleModel
-from flepimop2.engine.abc import EngineABC
+from flepimop2.engine.abc import EngineABC, EngineProtocol
 from flepimop2.exceptions import ValidationIssue
 from flepimop2.system.abc import SystemABC
 from flepimop2.typing import StateChangeEnum
@@ -22,14 +20,21 @@ class WrapperEngine(ModuleModel, EngineABC):
     state_change: StateChangeEnum
     script: Path
 
-    @model_validator(mode="after")
-    def _validate_script(self) -> Self:
+    def build_runner(self) -> EngineProtocol:
+        """
+        Load and validate the wrapped script runner function.
+
+        Returns:
+            The validated runner function from the wrapped script.
+
+        Raises:
+            AttributeError: If the module does not have a valid 'runner' function.
+        """
         mod = _load_module(self.script, "flepimop2.engine.wrapped")
         if not _validate_function(mod, "runner"):
             msg = f"Module at {self.script} does not have a valid 'runner' function."
             raise AttributeError(msg)
-        self._runner = mod.runner
-        return self
+        return cast("EngineProtocol", mod.runner)
 
     def validate_system(self, system: SystemABC) -> list[ValidationIssue] | None:
         """

--- a/src/flepimop2/system/abc/__init__.py
+++ b/src/flepimop2/system/abc/__init__.py
@@ -3,7 +3,7 @@
 __all__ = ["SystemABC", "SystemProtocol", "build"]
 
 import inspect
-from typing import Any, Protocol, runtime_checkable
+from typing import Any, Protocol, Self, runtime_checkable
 
 import numpy as np
 
@@ -87,6 +87,46 @@ class SystemABC(ModuleABC):
         """
         self._stepper = _no_step_function
 
+    def build_stepper(self) -> SystemProtocol:  # noqa: PLR6301
+        """
+        Build the stepper function for this system.
+
+        Concrete implementations can override this hook to dynamically construct
+        stepper functions from instance state.
+
+        Returns:
+            The stepper function for this system.
+        """
+        return _no_step_function
+
+    def build(self) -> Self:
+        """
+        Build the system internals required for stepping.
+
+        This method is idempotent and supports three strategies, in order:
+
+        1. Keep an existing instance-level stepper if already set.
+        2. Reuse a class-level `_stepper` callable if provided.
+        3. Fallback to `build_stepper()` for dynamic construction.
+
+        Returns:
+            The built system instance.
+
+        """
+        current_stepper = getattr(self, "_stepper", _no_step_function)
+        if current_stepper is not _no_step_function:
+            return self
+
+        class_stepper = type(self).__dict__.get("_stepper")
+        if isinstance(class_stepper, staticmethod):
+            class_stepper = class_stepper.__func__
+        if callable(class_stepper) and class_stepper is not _no_step_function:
+            self._stepper = class_stepper
+            return self
+
+        self._stepper = self.build_stepper()
+        return self
+
     def step(
         self, time: np.float64, state: Float64NDArray, **params: Any
     ) -> Float64NDArray:
@@ -101,6 +141,7 @@ class SystemABC(ModuleABC):
         Returns:
             The next state array after one step.
         """
+        self.build()
         return self._stepper(time, state, **params)
 
 
@@ -115,9 +156,4 @@ def build(config: dict[str, Any] | ModuleModel) -> SystemABC:
         The constructed system instance.
 
     """
-    return _build(
-        config,
-        "system",
-        "flepimop2.system.wrapper",
-        SystemABC,
-    )
+    return _build(config, "system", "flepimop2.system.wrapper", SystemABC)

--- a/src/flepimop2/system/wrapper/__init__.py
+++ b/src/flepimop2/system/wrapper/__init__.py
@@ -3,13 +3,11 @@
 __all__ = ["WrapperSystem"]
 
 from pathlib import Path
-from typing import Any, Literal, Self
-
-from pydantic import model_validator
+from typing import Any, Literal, cast
 
 from flepimop2._utils._module import _load_module, _validate_function
 from flepimop2.configuration import ModuleModel
-from flepimop2.system.abc import SystemABC
+from flepimop2.system.abc import SystemABC, SystemProtocol
 from flepimop2.typing import StateChangeEnum
 
 
@@ -21,13 +19,12 @@ class WrapperSystem(ModuleModel, SystemABC):
     script: Path
     options: dict[str, Any] | None = None
 
-    @model_validator(mode="after")
-    def _validate_stepper(self) -> Self:
+    def build_stepper(self) -> SystemProtocol:
         """
-        Validator to load and validate the stepper function from the script file.
+        Load and validate the wrapped script stepper function.
 
         Returns:
-            The validated `WrapperSystem` instance.
+            The validated stepper function from the wrapped script.
 
         Raises:
             AttributeError: If the module does not have a valid 'stepper' function.
@@ -36,5 +33,4 @@ class WrapperSystem(ModuleModel, SystemABC):
         if not _validate_function(mod, "stepper"):
             msg = f"Module at {self.script} does not have a valid 'stepper' function."
             raise AttributeError(msg)
-        self._stepper = mod.stepper
-        return self
+        return cast("SystemProtocol", mod.stepper)

--- a/tests/engine/test_engine_abc.py
+++ b/tests/engine/test_engine_abc.py
@@ -5,8 +5,9 @@ from typing import Any, cast
 import numpy as np
 import pytest
 
-from flepimop2.engine.abc import EngineABC
-from flepimop2.system.abc import SystemABC
+from flepimop2.configuration import IdentifierString
+from flepimop2.engine.abc import EngineABC, EngineProtocol
+from flepimop2.system.abc import SystemABC, SystemProtocol
 from flepimop2.typing import Float64NDArray, StateChangeEnum
 
 
@@ -21,6 +22,88 @@ class DummyEngine(EngineABC):
     """A dummy engine for testing purposes."""
 
     module = "dummy"
+
+
+def _class_runner(
+    stepper: SystemProtocol,
+    times: Float64NDArray,
+    state: Float64NDArray,
+    params: dict[IdentifierString, Any],
+    **kwargs: Any,
+) -> Float64NDArray:
+    _ = kwargs
+    return stepper(np.float64(times[0]), state, **params)
+
+
+def _instance_runner(
+    stepper: SystemProtocol,
+    times: Float64NDArray,
+    state: Float64NDArray,
+    params: dict[IdentifierString, Any],
+    **kwargs: Any,
+) -> Float64NDArray:
+    _ = kwargs
+    return stepper(np.float64(times[0]), state, **params) + 1.0
+
+
+def _built_runner(
+    stepper: SystemProtocol,
+    times: Float64NDArray,
+    state: Float64NDArray,
+    params: dict[IdentifierString, Any],
+    **kwargs: Any,
+) -> Float64NDArray:
+    _ = kwargs
+    return stepper(np.float64(times[0]), state, **params) + 2.0
+
+
+class ClassRunnerEngine(EngineABC):
+    """A simple engine with a class-level runner."""
+
+    module = "class-runner"
+    _runner = staticmethod(_class_runner)
+
+
+class DynamicBuilderEngine(EngineABC):
+    """An engine that dynamically constructs the runner via `build_runner`."""
+
+    module = "dynamic-builder"
+
+    def __init__(self) -> None:
+        """Initialize call tracking for the dynamic build hook."""
+        super().__init__()
+        self.build_runner_calls = 0
+
+    def build_runner(self) -> EngineProtocol:
+        """
+        Build and return a runner while counting hook invocations.
+
+        Returns:
+            The dynamically built runner function.
+        """
+        self.build_runner_calls += 1
+        return _built_runner
+
+
+class PresetInstanceRunnerEngine(EngineABC):
+    """An engine that pre-sets `_runner` and should skip `build_runner`."""
+
+    module = "preset-instance-runner"
+
+    def __init__(self) -> None:
+        """Initialize the engine with a pre-configured instance runner."""
+        super().__init__()
+        self._runner = _instance_runner
+
+    def build_runner(self) -> EngineProtocol:
+        """
+        Fail if called; this class should use the preset instance runner.
+
+        Raises:
+            AssertionError: Always, because this hook should not be invoked.
+        """
+        msg = "build_runner should not be called when `_runner` is already set."
+        raise AssertionError(msg)
 
 
 def sample_step(
@@ -52,3 +135,59 @@ def test_abstraction_error(engine: EngineABC) -> None:
             np.array([1.0, 2.0, 3.0], dtype=np.float64),
             {},
         )
+
+
+def test_class_level_runner_is_used() -> None:
+    """Test class-level `_runner` is used when no dynamic builder is defined."""
+    engine = ClassRunnerEngine()
+    system = DummySystem()
+    system._stepper = sample_step
+    result = engine.run(
+        system,
+        np.array([2.0], dtype=np.float64),
+        np.array([1.0, 2.0, 3.0], dtype=np.float64),
+        {"offset": 1.0},
+    )
+    expected = np.array([4.0, 6.0, 8.0], dtype=np.float64)
+    np.testing.assert_array_equal(result, expected)
+
+
+def test_build_runner_hook_constructs_runner_once() -> None:
+    """Test `build_runner` is called once and cached for subsequent runs."""
+    engine = DynamicBuilderEngine()
+    system = DummySystem()
+    system._stepper = sample_step
+
+    result_1 = engine.run(
+        system,
+        np.array([2.0], dtype=np.float64),
+        np.array([1.0, 2.0, 3.0], dtype=np.float64),
+        {"offset": 1.0},
+    )
+    result_2 = engine.run(
+        system,
+        np.array([1.0], dtype=np.float64),
+        np.array([1.0, 2.0, 3.0], dtype=np.float64),
+        {"offset": 2.0},
+    )
+
+    np.testing.assert_array_equal(
+        result_1, np.array([6.0, 8.0, 10.0], dtype=np.float64)
+    )
+    np.testing.assert_array_equal(result_2, np.array([5.0, 6.0, 7.0], dtype=np.float64))
+    assert engine.build_runner_calls == 1
+
+
+def test_build_preserves_existing_instance_runner() -> None:
+    """Test pre-set instance `_runner` takes precedence over `build_runner`."""
+    engine = PresetInstanceRunnerEngine().build()
+    system = DummySystem()
+    system._stepper = sample_step
+    result = engine.run(
+        system,
+        np.array([2.0], dtype=np.float64),
+        np.array([1.0, 2.0, 3.0], dtype=np.float64),
+        {"offset": 1.0},
+    )
+    expected = np.array([5.0, 7.0, 9.0], dtype=np.float64)
+    np.testing.assert_array_equal(result, expected)

--- a/tests/engine/test_engine_wrapper.py
+++ b/tests/engine/test_engine_wrapper.py
@@ -19,13 +19,17 @@ TEST_SYSTEM_SCRIPT: Final = (
 ).absolute()
 
 
-@pytest.mark.parametrize("config", [{"script": TEST_ENGINE_SCRIPT}])
+@pytest.mark.parametrize(
+    "config",
+    [{"script": TEST_ENGINE_SCRIPT, "state_change": StateChangeEnum.FLOW}],
+)
 @pytest.mark.parametrize(
     "system",
     [
         system_build({
             "module": "flepimop2.system.wrapper",
             "script": TEST_SYSTEM_SCRIPT,
+            "state_change": StateChangeEnum.FLOW,
         })
     ],
 )
@@ -49,7 +53,10 @@ def test_wrapper_system(
     np.testing.assert_array_equal(result, expected)
 
 
-@pytest.mark.parametrize("config", [{"script": TEST_ENGINE_SCRIPT}])
+@pytest.mark.parametrize(
+    "config",
+    [{"script": TEST_ENGINE_SCRIPT, "state_change": StateChangeEnum.FLOW}],
+)
 def test_wrapper_engine_validate_system_properties(config: dict) -> None:
     """Test `WrapperEngine` validates system properties compatibility."""
     engine = engine_build(config)

--- a/tests/system/test_system_abc.py
+++ b/tests/system/test_system_abc.py
@@ -1,10 +1,12 @@
 """Tests for `SystemABC` and default `WrapperSystem`."""
 
+from typing import Any
+
 import numpy as np
 import pytest
 
-from flepimop2.system.abc import SystemABC
-from flepimop2.typing import StateChangeEnum
+from flepimop2.system.abc import SystemABC, SystemProtocol
+from flepimop2.typing import Float64NDArray, StateChangeEnum
 
 
 class DummySystem(SystemABC):
@@ -14,8 +16,114 @@ class DummySystem(SystemABC):
     state_change = StateChangeEnum.FLOW
 
 
+def _class_stepper(
+    time: np.float64, state: Float64NDArray, **kwargs: Any
+) -> Float64NDArray:
+    offset = float(kwargs.get("offset", 0.0))
+    return (state + offset) * time
+
+
+def _instance_stepper(
+    time: np.float64, state: Float64NDArray, **kwargs: Any
+) -> Float64NDArray:
+    _ = kwargs
+    return state + time
+
+
+def _built_stepper(
+    time: np.float64, state: Float64NDArray, **kwargs: Any
+) -> Float64NDArray:
+    scale = float(kwargs.get("scale", 1.0))
+    return state + (time * scale)
+
+
+class ClassStepperSystem(SystemABC):
+    """A simple system with a class-level stepper."""
+
+    module = "class-stepper"
+    state_change = StateChangeEnum.FLOW
+    _stepper = staticmethod(_class_stepper)
+
+
+class DynamicBuilderSystem(SystemABC):
+    """A system that dynamically constructs the stepper via `build_stepper`."""
+
+    module = "dynamic-builder"
+    state_change = StateChangeEnum.FLOW
+
+    def __init__(self) -> None:
+        """Initialize call tracking for the dynamic build hook."""
+        super().__init__()
+        self.build_stepper_calls = 0
+
+    def build_stepper(self) -> SystemProtocol:
+        """
+        Build and return a stepper while counting hook invocations.
+
+        Returns:
+            The dynamically built stepper function.
+        """
+        self.build_stepper_calls += 1
+        return _built_stepper
+
+
+class PresetInstanceStepperSystem(SystemABC):
+    """A system that pre-sets `_stepper` and should skip `build_stepper`."""
+
+    module = "preset-instance-stepper"
+    state_change = StateChangeEnum.FLOW
+
+    def __init__(self) -> None:
+        """Initialize the system with a pre-configured instance stepper."""
+        super().__init__()
+        self._stepper = _instance_stepper
+
+    def build_stepper(self) -> SystemProtocol:
+        """
+        Fail if called; this class should use the preset instance stepper.
+
+        Raises:
+            AssertionError: Always, because this hook should not be invoked.
+        """
+        msg = "build_stepper should not be called when `_stepper` is already set."
+        raise AssertionError(msg)
+
+
 @pytest.mark.parametrize("system", [DummySystem()])
 def test_abstraction_error(system: SystemABC) -> None:
     """Test default stepper raises `NotImplementedError` when not overridden."""
     with pytest.raises(NotImplementedError):
         system.step(np.float64(0.0), np.array([1.0, 2.0, 3.0], dtype=np.float64))
+
+
+def test_class_level_stepper_is_used() -> None:
+    """Test class-level `_stepper` is used when no dynamic builder is defined."""
+    system = ClassStepperSystem()
+    result = system.step(
+        np.float64(2.0), np.array([1.0, 2.0, 3.0], dtype=np.float64), offset=1.0
+    )
+    expected = np.array([4.0, 6.0, 8.0], dtype=np.float64)
+    np.testing.assert_array_equal(result, expected)
+
+
+def test_build_stepper_hook_constructs_stepper_once() -> None:
+    """Test `build_stepper` is called once and cached for subsequent steps."""
+    system = DynamicBuilderSystem()
+    result_1 = system.step(
+        np.float64(2.0), np.array([1.0, 2.0, 3.0], dtype=np.float64), scale=3.0
+    )
+    result_2 = system.step(
+        np.float64(1.0), np.array([1.0, 2.0, 3.0], dtype=np.float64), scale=2.0
+    )
+
+    np.testing.assert_array_equal(result_1, np.array([7.0, 8.0, 9.0], dtype=np.float64))
+    np.testing.assert_array_equal(result_2, np.array([3.0, 4.0, 5.0], dtype=np.float64))
+    assert system.build_stepper_calls == 1
+
+
+def test_build_preserves_existing_instance_stepper() -> None:
+    """Test pre-set instance `_stepper` takes precedence over `build_stepper`."""
+    system = PresetInstanceStepperSystem().build()
+    result = system.step(np.float64(2.0), np.array([1.0, 2.0, 3.0], dtype=np.float64))
+    expected = np.array([3.0, 4.0, 5.0], dtype=np.float64)
+    np.testing.assert_array_equal(result, expected)

--- a/tests/system/test_system_wrapper.py
+++ b/tests/system/test_system_wrapper.py
@@ -7,11 +7,15 @@ import numpy as np
 import pytest
 
 from flepimop2.system.abc import build
+from flepimop2.typing import StateChangeEnum
 
 TEST_SCRIPT = Path(__file__).with_suffix("") / "dummy_system.py"
 
 
-@pytest.mark.parametrize("config", [{"script": TEST_SCRIPT}])
+@pytest.mark.parametrize(
+    "config",
+    [{"script": TEST_SCRIPT, "state_change": StateChangeEnum.FLOW}],
+)
 def test_wrapper_system(config: dict[str, Any]) -> None:
     """Test `WrapperSystem` loads a script and uses its `stepper` function."""
     system = build(config)


### PR DESCRIPTION
This change introduces explicit build-time hooks for `SystemABC` and `EngineABC` so non-trivial implementations can dynamically construct steppers/runners without relying on validator side effects.

- Add `SystemABC.build_stepper()` and `SystemABC.build()` with fallback support for pre-set instance/class `_stepper`, and ensure `step()` triggers build.
- Refactor `WrapperSystem` to override `build_stepper()` and return a validated script stepper callable.
- Add `EngineABC.build_runner()` and `EngineABC.build()` with fallback support for pre-set instance/class `_runner`, and ensure `run()` triggers both engine/system build.
- Refactor `WrapperEngine` to override `build_runner()` and return a validated script runner callable.
- Refresh "Implementing Custom Engines and Systems" development guide.

Closes #130.