### PR TITLE
Add `SystemABC.bind` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a new `flepimop2 skeleton` CLI command for scaffolding a project repository. See [#84](https://github.com/ACCIDDA/flepimop2/issues/84).
 - Added `flepimop.testing` with functionality for integration testing, both for `flepimop2` itself and for external provider packages. See [#107](https://github.com/ACCIDDA/flepimop2/issues/107).
 - Added a parent class, `ModuleABC`, for all customizable modules that sets a required `module` attribute and provides infrastructure for non-standardized properties information. Also extended said infrastructure to allow for standardized property information for `SystemABC`. See [#113](https://github.com/ACCIDDA/flepimop2/issues/113), [#126](https://github.com/ACCIDDA/flepimop2/issues/126), [#129](https://github.com/ACCIDDA/flepimop2/discussions/129).
+- Add "binding" to `SystemABC` objects to convert fully generic signature to a simulation needs-specific signature.
 
 ### Changed
 

--- a/docs/development/implementing-custom-engines-and-systems.md
+++ b/docs/development/implementing-custom-engines-and-systems.md
@@ -1,75 +1,78 @@
 # Implementing Custom Engines and Systems
 
-This guide shows how to implement `EngineABC` and `SystemABC` so they can be loaded by `flepimop2` and used in simulations. It mirrors the style of the external provider guide, but focuses only on the engine/system interfaces.
+This guide shows how to implement `EngineABC` and `SystemABC` modules so they can be used in `flepimop2` for simulation. This guide mirrors the external provider guide, but focuses only on the engine/system interfaces.
 
 Below is a minimal example creating new `EulerEngine` and `SirSystem`. You can copy these into your own module(s) under the `flepimop2.engine` and `flepimop2.system` namespaces.
 
 ## What are systems and engines?
 
-- **System**: implements the model dynamics via a stepper and advertises its properties via the standardized required attributes or non-standardized options.
-- **Engine**: runs a system stepper over time using an `EngineABC` runner.
-- **Compatibility**: engines may validate system properties (e.g., flow vs. delta vs. state semantics) before running.
+To answer this question, let's start from a more general picture of doing modeling. There's are lots elements to that task, but they generally build upon the foundation of "having a model". We think about creating that foundation in three steps: defining __model worlds__, translating those worlds into __model representations__, and using those representations to create __model implementations__.
 
-## System Implementation (`SirSystem`)
+A __model world__ defines the interesting processes and states, and generally what is "in" the model (endogenous dynamics) versus "out" (exogenous effects). For the classic SIR model, the model world is roughly "There are Susceptible, Infectious, and Recovered populations. Those populations interact at a constant rate, and when S and I interact some constant fraction of interactions convert S to I. The I population converts at a constant rate into R population." Note that this world definition only concerns the states (S, I, R) and processes (infection of S into I; recovery of I into R), not any formal mathematics.
+
+A __model representation__ translates the world into a particular mathematical framework. Taking again the classic SIR model, ordinary differential equations for the states would be a representation. As would Gillespie-style stochastic equations, update rules for individuals on a network, and so on.
+
+A __model implementation__ creates a computationally-useful version of those representations.
+
+The `flepimop2` tool captures these three steps using the configuration files, **System**s, and **Engine**s. This enables users to focus as much as possible in the __model world__ step, while developers automate as much as possible with modules for the other steps. Put another way: people should think of what they write in `flepimop2` configuration files as expressing their __model worlds__. Then, a **System** module translates that expression into __model representations__. Finally, an **Engine** module converts **System**s into fully-usable calculators. With reliable calculators in hand, researchers can then rapidly conduct their scientific or public health analyses.
+
+To make all that work, `flepimop2` provides standard object definitions so that these parts can work together.
+
+## Example System Implementation (`SirSystem`)
+
+While any given **System** object represents a particular model world, a **System** *module* should be a way to build *many* model worlds. Thus, a module that only builds SIR is really only building one world: while that can be run with different parameters and different initial conditions and so on, there's really only one structure.
+
+For now, however, we'll stick with a module that only contains this single world. Since there's only the single world, we can implement all the pieces directly:
 
 ```python
 """Stepper function for SIR model integration tests."""
 
-from typing import Any
+from typing import Any, Literal
 
 import numpy as np
 
 from flepimop2.configuration import ModuleModel
-from flepimop2.system.abc import SystemABC
+from flepimop2.system.abc import SystemABC, SystemProtocol
 from flepimop2.typing import Float64NDArray, StateChangeEnum
 
-
-def stepper(
-    time: np.float64,  # noqa: ARG001
+def global_sir(
+    time: np.float64,
     state: Float64NDArray,
-    **kwargs: Any,  # noqa: ARG001
+    beta: np.float64,
+    gamma: np.float64,
 ) -> Float64NDArray:
     """
-    ODE for an SIR model.
+    SIR model stepper function.
 
     Args:
-        time: Current time (not used in this model).
-        state: Current state array [S, I, R].
-        **kwargs: Additional parameters (e.g. beta, gamma, etc.).
+        time: Current time point (unused in this autonomous system).
+        state: Array of [S, I, R] populations.
+        beta: Transmission rate.
+        gamma: Recovery rate.
 
     Returns:
-        The change in state.
+        Array of state derivatives [dS/dt, dI/dt, dR/dt].
     """
-    # Implementors add their own logic here
-    pass
+    return np.array([
+        -beta * state[0] * state[1],
+        beta * state[0] * state[1] - gamma * state[1],
+        gamma * state[1]
+    ])
 
-
-class SirSystem(SystemABC):
+class SirSystem(ModuleModel, SystemABC):
     """SIR model system."""
 
-    module = "flepimop2.system.sir"
-    state_change = StateChangeEnum.FLOW
+    module : Literal["flepimop2.system.sir"] = "flepimop2.system.sir"
+    state_change : StateChangeEnum = StateChangeEnum.FLOW
+    _stepper : SystemProtocol = global_sir
 
-    def __init__(self) -> None:
-        """Initialize the SIR system with the SIR stepper."""
-        self._stepper = stepper
-
-
-def build(config: dict[str, Any] | ModuleModel) -> SirSystem:  # noqa: ARG001
-    """
-    Build an SIR system.
-
-    Returns:
-        An instance of the SIR system.
-    """
-    return SirSystem()
 ```
 
 Key elements in the system implementation:
 
-- `stepper` defines the model dynamics which the engine will call it repeatedly.
-- `SirSystem` inherits `SystemABC` and assigns `_stepper` in `__init__` as well as has the required attributes `module` and `state_change`.
-- `build(...)` provides a standard entry point so `flepimop2` can construct the system from configuration data. For more details on this you can read the [Creating An External Provider Package](./creating-an-external-provider-package.md) development guide.
+- **SirSystem** inherits from **ModuleModel** and **SystemABC**. **SystemABC** adds the generic capabilities for all system objects. **ModuleModel** simplifies building the system from the configuration file (by making **SirSystem** into a Pydantic model). This simplification means you don't have to implement the standard entry point `build(...)`; for more details, see [Creating An External Provider Package](./creating-an-external-provider-package.md).
+- As required by the inherited classes, **SirSystem** defines the module namespace, the state change type (i.e. flow vs delta vs next), and the `_stepper` method.
+- Here we're setting `_stepper` to the `global_sir` definition, since **SirSystem** only builds one model world: SIR.
 
 ## Engine Implementation (`EulerEngine`)
 

--- a/src/flepimop2/_utils/_checked_partial.py
+++ b/src/flepimop2/_utils/_checked_partial.py
@@ -1,0 +1,93 @@
+import functools
+import inspect
+from collections.abc import Callable
+from typing import Any, TypeVar
+
+from flepimop2.configuration._types import IdentifierString
+
+T = TypeVar("T")
+
+
+def _checked_partial(
+    func: Callable[..., T],
+    forbidden: set[IdentifierString] | None = None,
+    params: dict[IdentifierString, Any] | None = None,
+    **kwargs: Any,
+) -> Callable[..., T]:
+    """
+    Bind static parameters to a callable, checking their validity.
+
+    Args:
+        func: The callable to bind parameters to.
+        forbidden: A set of parameter names that are not allowed to be bound.
+        params: A dictionary of parameters to statically define for the System.
+        **kwargs: Additional parameters to statically define for the System.
+
+    Returns:
+        A partial function with static parameters bound.
+
+    Raises:
+        TypeError: If offered forbidden keys, keys not in `func` signature, or
+            keys with values of incompatible types with `func` signature.
+
+    Examples:
+        >>> def example_func(a: float, b: list[float], c: float) -> float:
+        ...     return sum([a, c, *b])
+        >>> new_func = _checked_partial(example_func, forbidden={"b"}, c=5.0)
+        >>> new_func(a=1.0, b=[1.0, 2.0, 3.0])
+        12.0
+    """
+    # Combine params and kwargs, with kwargs taking precedence
+    combined_params = {**(params or {}), **kwargs}
+
+    offered_keys = set(combined_params.keys())
+    if not offered_keys:
+        return func
+
+    validation_errors = []
+
+    forbidden = forbidden or set()
+
+    # Validate that forbidden keys are not offered
+    if forbidden.intersection(offered_keys):
+        msg = f"Cannot bind forbidden keys: {forbidden}; offered keys: {offered_keys}."
+        validation_errors.append(msg)
+
+    # Validate that offered keys are in the func signature
+    signature = inspect.signature(func)
+    signature_keys = set(signature.parameters.keys())
+    if invalid_keys := offered_keys - signature_keys:
+        msg = (
+            "Offered keys are not in func signature: "
+            f"{invalid_keys}. Eligible system parameters are: "
+            f"{signature_keys - forbidden}."
+        )
+        validation_errors.append(msg)
+
+    # Validate parameter value types against signature annotations
+    for key, value in signature.parameters.items():
+        if key in offered_keys:
+            expected_type = value.annotation
+            if (
+                expected_type is not inspect.Parameter.empty
+                and expected_type is not Any
+            ):
+                try:
+                    casted_value = expected_type(combined_params[key])
+                    combined_params[key] = casted_value
+                except (ValueError, TypeError) as e:
+                    offered_type = type(combined_params[key])
+                    msg = (
+                        f"Parameter '{key}' (type {offered_type.__name__}) "
+                        f"could not be cast to {expected_type.__name__}. Error: {e!s}"
+                    )
+                    validation_errors.append(msg)
+
+    if validation_errors:
+        validation_errors = [
+            "Setting System static parameters failed.",
+            *validation_errors,
+        ]
+        raise TypeError("\n".join(validation_errors))
+
+    return functools.partial(func, **combined_params)

--- a/src/flepimop2/system/abc/__init__.py
+++ b/src/flepimop2/system/abc/__init__.py
@@ -1,14 +1,23 @@
 """Abstract class for Dynamic Systems."""
 
-__all__ = ["SystemABC", "SystemProtocol", "build"]
+__all__ = [
+    "Flepimop2ValidationError",
+    "SystemABC",
+    "SystemProtocol",
+    "ValidationIssue",
+    "build",
+]
 
 import inspect
 from typing import Any, Protocol, runtime_checkable
 
 import numpy as np
 
+from flepimop2._utils._checked_partial import _checked_partial
 from flepimop2._utils._module import _build
 from flepimop2.configuration import ModuleModel
+from flepimop2.configuration._types import IdentifierString
+from flepimop2.exceptions import Flepimop2ValidationError, ValidationIssue
 from flepimop2.module import ModuleABC
 from flepimop2.typing import Float64NDArray, StateChangeEnum
 
@@ -86,6 +95,38 @@ class SystemABC(ModuleABC):
             **kwargs: Keyword arguments.
         """
         self._stepper = _no_step_function
+
+    def bind(
+        self,
+        params: dict[IdentifierString, Any] | None = None,
+        **kwargs: Any,
+    ) -> SystemProtocol:
+        """
+        Bind static parameters to the system's stepper function.
+
+        Args:
+            params: A dictionary of parameters to statically define for the system.
+            **kwargs: Additional parameters to statically define for the system.
+
+        Returns:
+            A stepper function for this system with static parameters defined.
+
+        Notes:
+            The `time` and `state` arguments to the underlying stepper function cannot
+            be statically defined via params or kwargs. Doing so will result in a
+            `TypeError`.
+
+            Additionally, any parameters not defined in the system's stepper function
+            signature, or any parameter values that are incompatible with the system
+            definition, will also result in a `TypeError`.
+
+        """
+        return _checked_partial(
+            func=self._stepper,
+            forbidden={"time", "state"},
+            params=params,
+            **kwargs,
+        )
 
     def step(
         self, time: np.float64, state: Float64NDArray, **params: Any

--- a/tests/_utils/_checked_partial/test__checked_partial.py
+++ b/tests/_utils/_checked_partial/test__checked_partial.py
@@ -1,0 +1,90 @@
+"""
+Tests for the `_checked_partial` function.
+
+Helper for functools.partial with validation of offered parameters against a
+function signature.
+"""
+
+from collections.abc import Callable
+from typing import Any
+
+import pytest
+
+from flepimop2._utils._checked_partial import _checked_partial
+
+
+def dummy_func(a: int, b: int, c: int) -> int:
+    """A dummy function for testing _checked_partial.
+
+    Args:
+        a: An integer parameter.
+        b: An integer parameter.
+        c: An integer parameter.
+
+    Returns:
+        The product of a, b, and c.
+    """
+    return a * b * c
+
+
+def dumb_func(a, b: Any, c):  # type: ignore[no-untyped-def] # noqa: ANN001, ANN201, ANN401
+    """A function for testing _checked_partial. Deliberately missing annotations.
+
+    Args:
+        a: An unannotated-but-should-be-integer parameter.
+        b: An unannotated-but-should-be-integer parameter.
+        c: An unannotated-but-should-be-integer parameter.
+
+    Returns:
+        The product of a, b, and c.
+    """
+    return a * b * c
+
+
+pars = pytest.mark.parametrize("func", [dummy_func])
+badfun = pytest.mark.parametrize("func", [dumb_func])
+
+
+@pars
+def test_set_valid_static_parameters(func: Callable[..., int]) -> None:
+    """Confirm no errors when setting all valid parameters."""
+    newfun = _checked_partial(func, forbidden={"b"}, a=5)
+    assert newfun(b=10, c=2) == 100
+    assert newfun(a=2, c=2, b=10) == 40
+    newfun = _checked_partial(func, forbidden={"b"}, params={"a": 10})
+    assert newfun(b=10, c=2) == 200
+    newfun = _checked_partial(func)
+    assert newfun(a=1, b=10, c=2) == 20
+
+
+@pars
+@pytest.mark.xfail(
+    reason="Currently allows using the function with static parameters, "
+    "but should raise error.",
+    strict=True,
+)
+def test_static_parameters_fixed(func: Callable[..., int]) -> None:
+    """Confirm errors when calling with a static parameter set."""
+    newfun = _checked_partial(func, forbidden={"b"}, a=5)
+    with pytest.raises(TypeError):
+        newfun(a=5, b=10, c=2)
+
+
+@pars
+def test_set_static_parameter_throws_error_on_fixed_time(
+    func: Callable[..., int],
+) -> None:
+    """Confirm errors raised for various invalid scenarios."""
+    with pytest.raises(TypeError):
+        _checked_partial(func, forbidden={"b"}, b=100)
+    with pytest.raises(TypeError):
+        _checked_partial(func, nonexistent_param=5.0)
+    with pytest.raises(TypeError):
+        _checked_partial(func, c="invalid_string")
+
+
+@badfun
+def test_unannotated_function_raises(func: Callable[..., int]) -> None:
+    """Confirm that a function without annotations does not raise an error."""
+    _checked_partial(func, a="a string")
+    _checked_partial(func, b="57.5")

--- a/tests/system/test_system_bind.py
+++ b/tests/system/test_system_bind.py
@@ -1,0 +1,41 @@
+"""Tests `SystemABC` ability to bind static parameters."""
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from flepimop2.system.abc import SystemABC, build
+from flepimop2.typing import StateChangeEnum
+
+TEST_SCRIPT = Path(__file__).parent / "system_wrapper_assets" / "dummy_system.py"
+system = build({"script": TEST_SCRIPT, "state_change": StateChangeEnum.DELTA})
+
+par = pytest.mark.parametrize("test_system", [system])
+
+
+@par
+def test_set_valid_static_parameters(test_system: SystemABC) -> None:
+    """Confirm no errors when setting all valid parameters."""
+    offset = 5.0
+    time = np.float64(1.0)
+    initial_state = np.array([1.0, 2.0, 3.0], dtype=np.float64)
+    newproto = test_system.bind(offset=offset)
+    assert all(newproto(time, initial_state) == (initial_state + offset))
+    newproto = test_system.bind(params={"offset": offset * 2})
+    assert all(newproto(time, initial_state) == (initial_state + offset * 2))
+
+
+@par
+def test_set_static_parameter_throws_error_on_fixed_state(
+    test_system: SystemABC,
+) -> None:
+    """Confirm error thrown when attempting to fix state parameter."""
+    with pytest.raises(TypeError):
+        test_system.bind(time=100)
+    with pytest.raises(TypeError):
+        test_system.bind(state=[1.0, 2.0, 3.0])
+    with pytest.raises(TypeError):
+        test_system.bind(nonexistent_param=5.0)
+    with pytest.raises(TypeError):
+        test_system.bind(offset="invalid_string")

--- a/tests/system/test_system_wrapper.py
+++ b/tests/system/test_system_wrapper.py
@@ -15,10 +15,11 @@ TEST_SCRIPT = Path(__file__).parent / "system_wrapper_assets" / "dummy_system.py
 def test_wrapper_system(config: dict[str, Any]) -> None:
     """Test `WrapperSystem` loads a script and uses its `stepper` function."""
     system = build(config)
-    result = system.step(
-        np.float64(1.0), np.array([1.0, 2.0, 3.0], dtype=np.float64), offset=1.0
-    )
-    expected = np.array([2.0, 3.0, 4.0], dtype=np.float64)
+    time = np.float64(1.0)
+    offset = 1.0
+    init_state = np.array([1.0, 2.0, 3.0], dtype=np.float64)
+    result = system.step(time, init_state, offset=offset)
+    expected = init_state + offset
     np.testing.assert_array_equal(result, expected)
 
 


### PR DESCRIPTION
Added a way to "bind" parameters to a `SystmABC` which will return the
`_stepper` of said system wrapped in a partial of the given parameters.

- Added private `_checked_partial` utility function as a thin wrapper
  around `functools.partial` but with custom validation.
- Implemented `SystemABC.bind` which is itself a thin wrapper around
  `_checked_partial`.
- Modified the "Implementing Custom Engines and Systems" documentation
  to include conceptual descriptions of systems/engines.