### PR TITLE
Custom pytest module to collect doctests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,6 +28,8 @@ jobs:
           persist-credentials: false
       - name: 'setup just and uv'
         uses: './.github/actions/setup-just-and-uv'
+        with:
+          enable-cache: false
       - name: 'Check changelog updated'
         run: 'just changelog'
   docs:
@@ -56,11 +58,9 @@ jobs:
         run: 'just quality'
   tests:
     name: 'tests (${{ matrix.python-version }}-${{ matrix.coverage }})'
-    needs:
-      - 'docs'
-      - 'quality'
     runs-on: 'ubuntu-latest'
     strategy:
+      fail-fast: false
       matrix:
         include:
           - python-version: '3.11'

--- a/conftest.py
+++ b/conftest.py
@@ -1,10 +1,17 @@
 """Pytest test configuration."""
 
+# ruff: noqa: DOC201
+
+import re
+import sys
 from collections.abc import Generator
+from importlib.util import module_from_spec, spec_from_file_location
 from os import chdir
 from pathlib import Path
+from typing import cast
 
 import pytest
+from _pytest.doctest import DoctestModule
 from sybil import Sybil
 from sybil.parsers.markdown import PythonCodeBlockParser, SkipParser
 
@@ -40,6 +47,47 @@ def repo_root() -> Path:
 
     """
     return _find_repo_root(Path(__file__).resolve())
+
+
+REPO_ROOT = _find_repo_root(Path(__file__).resolve())
+SOURCE_ROOT = REPO_ROOT / "src" / "flepimop2"
+
+
+def _doctest_module_name(file_path: Path) -> str:
+    """
+    Build a synthetic module name for path-based doctest imports.
+
+    This avoids collisions with stdlib modules such as `abc`.
+    """
+    relative_path = file_path.relative_to(SOURCE_ROOT)
+    sanitized = re.sub(r"[^0-9A-Za-z_]", "_", relative_path.as_posix())
+    return f"_flepimop2_doctest_{sanitized}"
+
+
+class SourceDoctestModule(DoctestModule):
+    """
+    Doctest collector that imports source files by file path.
+
+    Pytest's normal module-name inference collapses several `*/abc/__init__.py`
+    files to the stdlib `abc` module when using namespace packages. Importing
+    by path avoids that collision.
+    """
+
+    def _getobj(self) -> object:
+        module_name = _doctest_module_name(self.path)
+        spec = spec_from_file_location(module_name, self.path)
+        if spec is None or spec.loader is None:
+            msg = f"Could not create an import spec for {self.path!r}."
+            raise ImportError(msg)
+
+        module = module_from_spec(spec)
+        sys.modules[module_name] = module
+        try:
+            spec.loader.exec_module(module)
+        except Exception:
+            sys.modules.pop(module_name, None)
+            raise
+        return module
 
 
 @pytest.fixture(autouse=True)
@@ -89,7 +137,7 @@ def docs_tmpdir(request: pytest.FixtureRequest, tmp_path: Path) -> Generator[Non
         yield
 
 
-pytest_collect_file = Sybil(
+_sybil_collect_file = Sybil(
     parsers=[
         PythonCodeBlockParser(),
         SkipParser(),
@@ -97,6 +145,15 @@ pytest_collect_file = Sybil(
     path=str(Path(__file__).parent / "docs"),
     pattern="**/*.md",
 ).pytest()
+
+
+def pytest_collect_file(
+    file_path: Path, parent: pytest.Collector
+) -> pytest.Collector | None:
+    """Collect doctests from source modules and Sybil docs files."""
+    if file_path.suffix == ".py" and file_path.is_relative_to(SOURCE_ROOT):
+        return SourceDoctestModule.from_parent(parent, path=file_path)
+    return cast("pytest.Collector | None", _sybil_collect_file(file_path, parent))
 
 
 def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:


### PR DESCRIPTION
Several of the doctests currently are passed because `flepimop2` is a
namespace package so pytest is unabled to load source files that are
shaddowed by other modules, namely from the stdlib, that are shaddowed.
E.g. the doctests in `src/flepimop2/system/abc/__init__.py` because it
is shaddowed by stdlib's `abc`. Added a custom pytest doctest module to
manually traverse package source and load modules.

Also disabled caching for the `changelog` job in the `ci.yaml` GitHub
actions workflow. As well as made the jobs in `ci.yaml` independent so
that they will all run to completion.

No major changes.