### PR TITLE
Add axis-aware parameter values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a parent class, `ModuleABC`, for all customizable modules that sets a required `module` attribute and provides infrastructure for non-standardized properties information. Also extended said infrastructure to allow for standardized property information for `SystemABC`. See [#113](https://github.com/ACCIDDA/flepimop2/issues/113), [#126](https://github.com/ACCIDDA/flepimop2/issues/126), [#129](https://github.com/ACCIDDA/flepimop2/discussions/129).
 - Add "binding" to `SystemABC` objects to convert fully generic signature to a simulation needs-specific signature.
 - Introduced the axis concept as a way to represent aligned shapes across parameters, systems, etc. Added two kinds of axes, categorical and continuous, to represent different kinds of dimensions. Also added an `axes` top level key to the `ConfigurationModel` so users can provide these axes via configuration, but setting this currently results in a warning since it has no effect. See [#147](https://github.com/ACCIDDA/flepimop2/issues/147).
+- Added runtime axis resolution via `flepimop2.axis`, structured `ParameterValue` outputs, and system-declared `requested_parameters()`/`model_state()` contracts so parameters, initial conditions, and system inputs are shaped from named axes and passed through the simulation runtime as structured values instead of hard-coded scalar state. See [#115](https://github.com/ACCIDDA/flepimop2/issues/115).
 
 ### Changed
 

--- a/docs/assets/SIR.py
+++ b/docs/assets/SIR.py
@@ -2,21 +2,26 @@
 
 import numpy as np
 
+from flepimop2.axis import AxisCollection
+from flepimop2.parameter.abc import (
+    ModelStateSpecification,
+    ParameterValue,
+)
 from flepimop2.typing import Float64NDArray
 
 
 def stepper(
-    t: float,  # noqa: ARG001
-    y: Float64NDArray,
-    beta: float,
-    gamma: float,
+    time: float,  # noqa: ARG001
+    state: Float64NDArray,
+    beta: ParameterValue,
+    gamma: ParameterValue,
 ) -> Float64NDArray:
     """
     Compute dY/dt for the SIR model.
 
     Args:
-        t: The current time (not used in this model, but included for compatibility).
-        y: A numpy array containing the current values [S, I, R].
+        time: The current time (not used in this model, but included for compatibility).
+        state: A numpy array containing the current values [S, I, R].
         beta: The infection rate.
         gamma: The recovery rate.
 
@@ -24,8 +29,21 @@ def stepper(
         A numpy array containing the derivatives [dS/dt, dI/dt, dR/dt].
 
     """
-    y_s, y_i, _ = np.asarray(y, dtype=float)
-    infection = (beta * y_s * y_i) / np.sum(y)
-    recovery = gamma * y_i
+    y_s, y_i, _ = np.asarray(state, dtype=float)
+    infection = (beta.item() * y_s * y_i) / np.sum(state)
+    recovery = gamma.item() * y_i
     dydt = [-infection, infection - recovery, recovery]
     return np.array(dydt, dtype=float)
+
+
+def model_state(axes: AxisCollection) -> ModelStateSpecification:  # noqa: ARG001
+    """
+    Declare how parameter entries assemble the SIR state vector.
+
+    Returns:
+        The model-state specification for the SIR system.
+    """
+    return ModelStateSpecification(
+        parameter_names=("s0", "i0", "r0"),
+        labels=("S", "I", "R"),
+    )

--- a/docs/assets/solve_ivp.py
+++ b/docs/assets/solve_ivp.py
@@ -1,10 +1,12 @@
 """ODE solver plugin that wraps `scipy.integrate.solve_ivp` for flepimop2 demo."""
 
+from collections.abc import Mapping
 from typing import Any
 
 import numpy as np
 from scipy.integrate import solve_ivp
 
+from flepimop2.parameter.abc import ModelStateSpecification, ParameterValue
 from flepimop2.system.abc import SystemProtocol
 from flepimop2.typing import Float64NDArray
 
@@ -12,18 +14,22 @@ from flepimop2.typing import Float64NDArray
 def runner(
     fun: SystemProtocol,
     times: Float64NDArray,
-    y0: Float64NDArray,
-    params: dict[str, Any] | None = None,
+    initial_state: dict[str, ParameterValue],
+    params: Mapping[str, ParameterValue] | None = None,
+    *,
+    model_state: ModelStateSpecification | None = None,
     **solver_options: Any,
 ) -> Float64NDArray:
     """Solve an initial value problem using scipy.solve_ivp.
 
     Args:
-        fun (SystemProtocol): A function that computes derivatives.
-        times (Float64NDArray): sequence of time points where we evaluate the
-          solution. Must have length >= 1.
-        y0 (Float64NDArray): Initial condition.
+        fun: A function that computes derivatives.
+        times: sequence of time points where we evaluate the solution. Must have
+            length >= 1.
+        initial_state: Structured initial-state entries.
         params: Optional dict of keyword parameters forwarded to fun.
+        model_state: Specification describing how to order the initial-state
+          entries into a numeric state array.
         **solver_options: Additional keyword options forwarded to
           scipy.integrate.solve_ivp.
 
@@ -39,6 +45,9 @@ def runner(
     if not (times.ndim == 1 and times.size >= 1):
         msg = "times must be a 1D sequence of time points"
         raise ValueError(msg)
+    if model_state is None:
+        msg = "model_state must be provided to assemble the initial condition."
+        raise ValueError(msg)
 
     times.sort()
 
@@ -47,6 +56,9 @@ def runner(
         msg = f"times[0] must be >= 0; got times[0]={times[0]}"
         raise ValueError(msg)
 
+    y0 = np.stack([
+        initial_state[name].value for name in model_state.parameter_names
+    ]).astype(np.float64)
     args = tuple(val for val in params.values()) if params is not None else None
     result = solve_ivp(
         fun,

--- a/docs/development/implementing-custom-engines-and-systems.md
+++ b/docs/development/implementing-custom-engines-and-systems.md
@@ -32,14 +32,15 @@ from typing import Any, Literal
 import numpy as np
 
 from flepimop2.configuration import ModuleModel
+from flepimop2.parameter.abc import ParameterValue
 from flepimop2.system.abc import SystemABC, SystemProtocol
 from flepimop2.typing import Float64NDArray, StateChangeEnum
 
 def global_sir(
     time: np.float64,
     state: Float64NDArray,
-    beta: np.float64,
-    gamma: np.float64,
+    beta: ParameterValue,
+    gamma: ParameterValue,
 ) -> Float64NDArray:
     """
     SIR model stepper function.
@@ -54,9 +55,9 @@ def global_sir(
         Array of state derivatives [dS/dt, dI/dt, dR/dt].
     """
     return np.array([
-        -beta * state[0] * state[1],
-        beta * state[0] * state[1] - gamma * state[1],
-        gamma * state[1]
+        -beta.item() * state[0] * state[1],
+        beta.item() * state[0] * state[1] - gamma.item() * state[1],
+        gamma.item() * state[1]
     ])
 
 class SirSystem(ModuleModel, SystemABC):
@@ -86,6 +87,7 @@ import numpy as np
 from flepimop2.configuration import IdentifierString, ModuleModel
 from flepimop2.engine.abc import EngineABC
 from flepimop2.exceptions import ValidationIssue
+from flepimop2.parameter.abc import ModelStateSpecification, ParameterValue
 from flepimop2.system.abc import SystemABC, SystemProtocol
 from flepimop2.typing import Float64NDArray
 
@@ -93,8 +95,9 @@ from flepimop2.typing import Float64NDArray
 def runner(
     stepper: SystemProtocol,
     times: Float64NDArray,
-    state: Float64NDArray,
-    params: dict[IdentifierString, Any],
+    initial_state: dict[IdentifierString, ParameterValue],
+    params: dict[IdentifierString, ParameterValue],
+    model_state: ModelStateSpecification | None = None,
     **kwargs: Any,  # noqa: ARG001
 ) -> Float64NDArray:
     """
@@ -103,8 +106,9 @@ def runner(
     Args:
         stepper: The system stepper function.
         times: Array of time points.
-        state: The current state array.
-        params: Additional parameters for the stepper.
+        initial_state: Structured initial-state parameters.
+        params: Additional structured parameters for the stepper.
+        model_state: Specification describing how to order the initial state.
         **kwargs: Additional keyword arguments for the engine. Unused by this runner.
 
     Returns:

--- a/src/flepimop2/_cli/_simulate_command.py
+++ b/src/flepimop2/_cli/_simulate_command.py
@@ -4,11 +4,8 @@ __all__ = []
 
 from pathlib import Path
 
-import numpy as np
-
 from flepimop2._cli._cli_command import CliCommand
 from flepimop2.configuration import ConfigurationModel
-from flepimop2.parameter.abc import build as build_parameter
 from flepimop2.simulator import Simulator
 
 
@@ -40,24 +37,8 @@ class SimulateCommand(CliCommand):
         """
         config_model = ConfigurationModel.from_yaml(config)
 
-        s0 = build_parameter(config_model.parameters["s0"])
-        i0 = build_parameter(config_model.parameters["i0"])
-        r0 = build_parameter(config_model.parameters["r0"])
-        initial_state = np.array(
-            [
-                s0.sample().item(),
-                i0.sample().item(),
-                r0.sample().item(),
-            ],
-            dtype=np.float64,
-        )
-        params = {
-            k: build_parameter(v).sample().item()
-            for k, v in config_model.parameters.items()
-            if k not in {"s0", "i0", "r0"}
-        }
-
         simulator = Simulator.from_configuration_model(config_model, target=target)
+        initial_state, params = simulator.resolve_inputs()
 
         if simulator.simulate_config is None:
             msg = "simulate_config must be set before running the simulator."

--- a/src/flepimop2/_utils/_checked_partial.py
+++ b/src/flepimop2/_utils/_checked_partial.py
@@ -72,6 +72,10 @@ def _checked_partial(
                 expected_type is not inspect.Parameter.empty
                 and expected_type is not Any
             ):
+                if isinstance(expected_type, type) and isinstance(
+                    combined_params[key], expected_type
+                ):
+                    continue
                 try:
                     casted_value = expected_type(combined_params[key])
                     combined_params[key] = casted_value

--- a/src/flepimop2/axis.py
+++ b/src/flepimop2/axis.py
@@ -1,0 +1,401 @@
+"""Runtime axis types and helpers."""
+
+__all__ = ["Axis", "AxisCollection", "ResolvedAxisConfig", "ResolvedShape"]
+
+from collections.abc import Iterator, Mapping, Sequence
+from dataclasses import dataclass
+from itertools import pairwise
+from typing import Literal, TypeVar, overload
+
+import numpy as np
+from pydantic import TypeAdapter
+
+from flepimop2.configuration._axes import (
+    AxesGroupModel,
+    CategoricalAxisModel,
+    ContinuousAxisModel,
+)
+from flepimop2.configuration._types import IdentifierString
+
+ResolvedAxisConfig = (
+    AxesGroupModel | Mapping[IdentifierString, object] | dict[IdentifierString, object]
+)
+T = TypeVar("T")
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvedShape:
+    """A named runtime shape resolved against a concrete axis collection."""
+
+    axis_names: tuple[IdentifierString, ...] = ()
+    sizes: tuple[int, ...] = ()
+
+    def __post_init__(self) -> None:
+        """
+        Validate the number of axis names and sizes match.
+
+        Raises:
+            ValueError: If `axis_names` and `sizes` do not have matching lengths.
+
+        Examples:
+            >>> from flepimop2.axis import ResolvedShape
+            >>> ResolvedShape(axis_names=("age", "time"), sizes=(3, 4))
+            ResolvedShape(axis_names=('age', 'time'), sizes=(3, 4))
+            >>> ResolvedShape(axis_names=("age",), sizes=(3, 4))
+            Traceback (most recent call last):
+                ...
+            ValueError: ResolvedShape axis_names and sizes must have matching lengths; got 1 names and 2 sizes.
+        """  # noqa: E501
+        if len(self.axis_names) != len(self.sizes):
+            msg = (
+                "ResolvedShape axis_names and sizes must have matching lengths; "
+                f"got {len(self.axis_names)} names and {len(self.sizes)} sizes."
+            )
+            raise ValueError(msg)
+
+
+@dataclass(frozen=True, slots=True)
+class Axis:
+    """
+    Resolved Runtime Axis.
+
+    Describe one named axis after configuration has been validated and converted
+    into runtime metadata.
+
+    Attributes:
+        name: Stable axis name used by systems and parameters.
+        kind: Whether the axis is continuous or categorical.
+        size: Number of positions along the axis.
+        labels: Optional labels for categorical axes.
+        values: Optional integer values associated with categorical labels.
+        domain: Closed numeric domain for continuous axes.
+        spacing: Spacing rule for continuous axes.
+
+    Notes:
+        Continuous axes intentionally support both point-style and bin-style
+        calculations. The same axis can expose representative points via
+        `points()` and intervals via `bins()`, so systems and parameters can use
+        whichever view is appropriate without introducing incompatible axis
+        definitions.
+    """
+
+    name: IdentifierString
+    kind: Literal["continuous", "categorical"]
+    size: int
+    labels: tuple[str, ...] | None = None
+    values: tuple[int, ...] | None = None
+    domain: tuple[float, float] | None = None
+    spacing: Literal["linear", "log"] | None = None
+
+    def _continuous_domain(self) -> tuple[float, float]:
+        """
+        Validate Continuous Axis Metadata.
+
+        Ensure this axis can support continuous point and bin helpers.
+
+        Returns:
+            The continuous axis domain as `(lower, upper)`.
+
+        Raises:
+            TypeError: If this is not a continuous axis.
+            ValueError: If the continuous axis is missing domain or spacing
+                metadata.
+
+        Examples:
+            >>> from flepimop2.axis import Axis
+            >>> axis = Axis(
+            ...     name="time",
+            ...     kind="continuous",
+            ...     size=4,
+            ...     domain=(0.0, 8.0),
+            ...     spacing="linear",
+            ... )
+            >>> axis._continuous_domain()
+            (0.0, 8.0)
+            >>> Axis(name="age", kind="categorical", size=2)._continuous_domain()
+            Traceback (most recent call last):
+                ...
+            TypeError: Axis 'age' is 'categorical'; only continuous axes support point and bin helpers.
+            >>> Axis(
+            ...     name="time",
+            ...     kind="continuous",
+            ...     size=4,
+            ... )._continuous_domain()
+            Traceback (most recent call last):
+                ...
+            ValueError: Continuous axis 'time' must define both domain and spacing to derive point or bin helpers.
+        """  # noqa: E501
+        if self.kind != "continuous":
+            msg = (
+                f"Axis '{self.name}' is {self.kind!r}; only continuous axes "
+                "support point and bin helpers."
+            )
+            raise TypeError(msg)
+        if self.domain is None or self.spacing is None:
+            msg = (
+                f"Continuous axis '{self.name}' must define both domain and "
+                "spacing to derive point or bin helpers."
+            )
+            raise ValueError(msg)
+        return self.domain
+
+    def bin_edges(self) -> tuple[float, ...]:
+        """
+        Continuous Bin Edges.
+
+        Partition a continuous axis domain into `size` bins.
+
+        Returns:
+            The bin-edge coordinates with length `size + 1`.
+
+        Notes:
+            Linear axes use `np.linspace(lower, upper, size + 1)`. Log axes use
+            `np.geomspace(lower, upper, size + 1)`.
+
+        Examples:
+            >>> from flepimop2.axis import Axis
+            >>> axis = Axis(
+            ...     name="time",
+            ...     kind="continuous",
+            ...     size=4,
+            ...     domain=(0.0, 8.0),
+            ...     spacing="linear",
+            ... )
+            >>> axis.bin_edges()
+            (0.0, 2.0, 4.0, 6.0, 8.0)
+        """
+        lo, hi = self._continuous_domain()
+        if self.spacing == "linear":
+            edges = np.linspace(lo, hi, self.size + 1, dtype=np.float64)
+        else:
+            edges = np.geomspace(lo, hi, self.size + 1, dtype=np.float64)
+        return tuple(edges.tolist())
+
+    def bins(self) -> tuple[tuple[float, float], ...]:
+        """
+        Continuous Bin Intervals.
+
+        Return half-open-style interval metadata for each continuous bin.
+
+        Returns:
+            A tuple of `(lower, upper)` bin intervals with length `size`.
+
+        Examples:
+            >>> from flepimop2.axis import Axis
+            >>> axis = Axis(
+            ...     name="time",
+            ...     kind="continuous",
+            ...     size=2,
+            ...     domain=(0.0, 4.0),
+            ...     spacing="linear",
+            ... )
+            >>> axis.bins()
+            ((0.0, 2.0), (2.0, 4.0))
+        """
+        self._continuous_domain()
+        edges = self.bin_edges()
+        return tuple(pairwise(edges))
+
+    def points(self) -> tuple[float, ...]:
+        """
+        Representative Continuous Points.
+
+        Return one representative point for each continuous bin.
+
+        Returns:
+            A tuple of representative point coordinates with length `size`.
+
+        Notes:
+            Points are sampled directly from the configured domain using
+            `np.linspace(lower, upper, size, endpoint=False)` or
+            `np.geomspace(lower, upper, size, endpoint=False)`. This keeps
+            point- and bin-based views available from the same runtime axis
+            metadata while avoiding duplication of the upper domain bound.
+
+        Examples:
+            >>> from pprint import pp
+            >>> from flepimop2.axis import Axis
+            >>> Axis(
+            ...     name="time",
+            ...     kind="continuous",
+            ...     size=4,
+            ...     domain=(0.0, 8.0),
+            ...     spacing="linear",
+            ... ).points()
+            (1.0, 3.0, 5.0, 7.0)
+            >>> pp(
+            ...     Axis(
+            ...         name="time",
+            ...         kind="continuous",
+            ...         size=4,
+            ...         domain=(1e-9, 1e-3),
+            ...         spacing="log",
+            ...     ).points()
+            ... )
+            (5.623413251903491e-09,
+             1.7782794100389227e-07,
+             5.623413251903491e-06,
+             0.0001778279410038923)
+        """
+        lo, hi = self._continuous_domain()
+        if self.spacing == "linear":
+            edges = np.linspace(lo, hi, self.size + 1, dtype=np.float64)
+            points = 0.5 * (edges[:-1] + edges[1:])
+        else:
+            edges = np.geomspace(lo, hi, self.size + 1, dtype=np.float64)
+            points = np.sqrt(edges[:-1] * edges[1:])
+        return tuple(points.tolist())
+
+    @classmethod
+    def from_model(
+        cls,
+        name: IdentifierString,
+        model: ContinuousAxisModel | CategoricalAxisModel,
+    ) -> "Axis":
+        """
+        Build an `Axis` from a configuration model.
+
+        Returns:
+            The resolved runtime axis.
+        """
+        if isinstance(model, ContinuousAxisModel):
+            return cls(
+                name=name,
+                kind=model.kind,
+                size=model.size,
+                domain=model.domain,
+                spacing=model.spacing,
+            )
+        return cls(
+            name=name,
+            kind=model.kind,
+            size=len(model.labels),
+            labels=model.labels,
+            values=model.values,
+        )
+
+
+class AxisCollection(Mapping[IdentifierString, Axis]):
+    """
+    Runtime Axis Collection.
+
+    Store resolved axes and provide lookup and named-shape helpers for systems,
+    parameters, and engines.
+
+    Notes:
+        `AxisCollection` is the runtime entry point for working with named axes.
+        Systems typically use it to resolve requested parameter shapes, while
+        parameter modules use it to interpret declared axis names and inspect
+        axis metadata such as labels or bin edges.
+
+    Examples:
+        >>> from flepimop2.axis import AxisCollection
+        >>> axes = AxisCollection.from_config({
+        ...     "age": {
+        ...         "kind": "categorical",
+        ...         "labels": ["age0_17", "age18_64", "age65_plus"],
+        ...     },
+        ...     "time": {
+        ...         "kind": "continuous",
+        ...         "domain": (0.0, 12.0),
+        ...         "size": 4,
+        ...     },
+        ... })
+        >>> axes.size("age")
+        3
+        >>> axes["age"].labels
+        ('age0_17', 'age18_64', 'age65_plus')
+        >>> axes["time"].bin_edges()
+        (0.0, 3.0, 6.0, 9.0, 12.0)
+        >>> axes.resolve_shape(("age", "time")).sizes
+        (3, 4)
+        >>> axes.resolve_shape(("region",))
+        Traceback (most recent call last):
+            ...
+        KeyError: "Unknown axis names requested: ('region',)."
+    """
+
+    def __init__(self, axes: Mapping[IdentifierString, Axis] | None = None) -> None:
+        """Initialize the collection with an optional axis mapping."""
+        self._axes = dict(axes or {})
+
+    @classmethod
+    def from_config(cls, config: ResolvedAxisConfig) -> "AxisCollection":
+        """
+        Construct a runtime axis collection from configuration data.
+
+        Returns:
+            The resolved runtime axis collection.
+        """
+        validated = TypeAdapter(AxesGroupModel).validate_python(config)
+        return cls({
+            name: Axis.from_model(name, axis) for name, axis in validated.items()
+        })
+
+    def __getitem__(self, key: IdentifierString) -> Axis:
+        """Return the axis for a given name."""
+        return self._axes[key]
+
+    def __iter__(self) -> Iterator[IdentifierString]:
+        """
+        Iterate over axis names in the collection.
+
+        Returns:
+            An iterator over axis names.
+        """
+        return iter(self._axes)
+
+    def __len__(self) -> int:
+        """Return the number of axes in the collection."""
+        return len(self._axes)
+
+    @overload
+    def get(self, name: IdentifierString, /) -> Axis | None: ...
+
+    @overload
+    def get(self, name: IdentifierString, /, default: Axis) -> Axis: ...
+
+    @overload
+    def get(self, name: IdentifierString, /, default: T) -> Axis | T: ...
+
+    def get(
+        self, name: IdentifierString, /, default: T | None = None
+    ) -> Axis | T | None:
+        """
+        Return a named axis, optionally providing a default.
+
+        Returns:
+            The resolved axis, or the provided default when missing.
+        """
+        return self._axes.get(name, default)
+
+    def size(self, name: IdentifierString) -> int:
+        """Return the size for a named axis."""
+        return self[name].size
+
+    def sizes(self, *names: IdentifierString) -> tuple[int, ...]:
+        """Return the sizes for a sequence of named axes."""
+        return tuple(self.size(name) for name in names)
+
+    def resolve_shape(self, axis_names: Sequence[IdentifierString]) -> ResolvedShape:
+        """
+        Resolve a tuple of axis names into concrete dimension sizes.
+
+        Returns:
+            The resolved named shape.
+        """
+        names = tuple(axis_names)
+        self._validate_axis_names(names)
+        return ResolvedShape(axis_names=names, sizes=self.sizes(*names))
+
+    def _validate_axis_names(self, axis_names: Sequence[IdentifierString]) -> None:
+        """
+        Validate that each named axis exists in the collection.
+
+        Raises:
+            KeyError: If any requested axis name does not exist.
+        """
+        missing = tuple(name for name in axis_names if name not in self._axes)
+        if missing:
+            msg = f"Unknown axis names requested: {missing}."
+            raise KeyError(msg)

--- a/src/flepimop2/configuration/_configuration.py
+++ b/src/flepimop2/configuration/_configuration.py
@@ -30,13 +30,7 @@ class ConfigurationModel(
     """
 
     name: str | None = None
-    axes: AxesGroupModel = Field(
-        default_factory=dict,
-        deprecated=(
-            "'axes' is currently under development and has "
-            "no effect on the configuration right now."
-        ),
-    )
+    axes: AxesGroupModel = Field(default_factory=dict)
     engines: ModuleGroupModel = Field(default_factory=dict)
     systems: ModuleGroupModel = Field(default_factory=dict)
     backends: ModuleGroupModel = Field(default_factory=dict)

--- a/src/flepimop2/engine/abc/__init__.py
+++ b/src/flepimop2/engine/abc/__init__.py
@@ -2,12 +2,14 @@
 
 __all__ = ["EngineABC", "EngineProtocol", "build"]
 
+from collections.abc import Mapping
 from typing import Any, Protocol, runtime_checkable
 
 from flepimop2._utils._module import _build
 from flepimop2.configuration import IdentifierString, ModuleModel
 from flepimop2.exceptions import ValidationIssue
 from flepimop2.module import ModuleABC
+from flepimop2.parameter.abc import ModelStateSpecification, ParameterValue
 from flepimop2.system.abc import SystemABC, SystemProtocol
 from flepimop2.typing import Float64NDArray
 
@@ -15,8 +17,9 @@ from flepimop2.typing import Float64NDArray
 def _no_run_func(
     stepper: SystemProtocol,
     times: Float64NDArray,
-    state: Float64NDArray,
-    params: dict[IdentifierString, Any],
+    initial_state: dict[IdentifierString, ParameterValue],
+    params: Mapping[IdentifierString, ParameterValue],
+    model_state: ModelStateSpecification | None = None,
     **kwargs: Any,
 ) -> Float64NDArray:
     msg = "EngineABC::_runner must be provided by a concrete implementation."
@@ -31,8 +34,9 @@ class EngineProtocol(Protocol):
         self,
         stepper: SystemProtocol,
         times: Float64NDArray,
-        state: Float64NDArray,
-        params: dict[IdentifierString, Any],
+        initial_state: dict[IdentifierString, ParameterValue],
+        params: Mapping[IdentifierString, ParameterValue],
+        model_state: ModelStateSpecification | None = None,
         **kwargs: Any,
     ) -> Float64NDArray:
         """Protocol for engine runner functions."""
@@ -61,8 +65,9 @@ class EngineABC(ModuleABC):
         self,
         system: SystemABC,
         eval_times: Float64NDArray,
-        initial_state: Float64NDArray,
-        params: dict[IdentifierString, Any],
+        initial_state: dict[IdentifierString, ParameterValue],
+        params: Mapping[IdentifierString, ParameterValue],
+        model_state: ModelStateSpecification | None = None,
         **kwargs: Any,
     ) -> Float64NDArray:
         """
@@ -71,8 +76,11 @@ class EngineABC(ModuleABC):
         Args:
             system: The dynamic system to be evolved.
             eval_times: Array of time points for evaluation.
-            initial_state: The initial state array.
+            initial_state: Structured initial-state entries sampled from
+                parameters.
             params: Additional parameters for the stepper.
+            model_state: Specification describing the semantic ordering of the
+                state entries.
             **kwargs: Additional keyword arguments for the engine.
 
         Returns:
@@ -83,6 +91,7 @@ class EngineABC(ModuleABC):
             eval_times,
             initial_state,
             params,
+            model_state=model_state,
             **kwargs,
         )
 

--- a/src/flepimop2/parameter/abc/__init__.py
+++ b/src/flepimop2/parameter/abc/__init__.py
@@ -1,25 +1,275 @@
-"""Abstract base class for parameters."""
+"""Abstract base class and runtime contracts for parameters."""
 
-__all__ = ["ParameterABC", "build"]
+__all__ = [
+    "ModelStateSpecification",
+    "ParameterABC",
+    "ParameterRequest",
+    "ParameterValue",
+    "build",
+]
 
 from abc import abstractmethod
+from dataclasses import dataclass
 from typing import Any
 
+import numpy as np
+
 from flepimop2._utils._module import _build
-from flepimop2.configuration import ModuleModel
+from flepimop2.axis import AxisCollection, ResolvedShape
+from flepimop2.configuration import IdentifierString, ModuleModel
 from flepimop2.module import ModuleABC
 from flepimop2.typing import Float64NDArray
 
 
-class ParameterABC(ModuleABC):
-    """Abstract base class for parameters."""
+@dataclass(frozen=True, slots=True)
+class ParameterRequest:
+    """
+    Request for a parameter value declared by a system.
 
-    @abstractmethod
-    def sample(self) -> Float64NDArray:
-        """Sample a value from the parameter.
+    Attributes:
+        name: Parameter name expected by the system.
+        axes: Ordered named axes the resolved parameter should align with.
+        broadcast: Whether a scalar parameter may be broadcast to the requested
+            shape.
+        optional: Whether the system can omit this parameter and rely on defaults.
+
+    Notes:
+        Systems typically create `ParameterRequest` objects in
+        `SystemABC.requested_parameters()`. Parameter modules receive the request in
+        `ParameterABC.sample()` and can use the shape metadata to decide how to
+        materialize their values.
+
+    Examples:
+        >>> from pprint import pp
+        >>> from flepimop2.parameter.abc import ParameterRequest
+        >>> request = ParameterRequest(
+        ...     name="gamma",
+        ...     axes=("age",),
+        ...     broadcast=True,
+        ... )
+        >>> pp(request)
+        ParameterRequest(name='gamma', axes=('age',), broadcast=True, optional=False)
+    """
+
+    name: IdentifierString
+    axes: tuple[IdentifierString, ...] = ()
+    broadcast: bool = False
+    optional: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class ModelStateSpecification:
+    """
+    Model State Specification.
+
+    Describe how configured parameter entries assemble the evolving model state.
+
+    Attributes:
+        parameter_names: Ordered parameter names that define the model state.
+        axes: Named axes shared by each state entry.
+        broadcast: Whether scalar state entries may broadcast to the requested axes.
+        labels: Optional human-readable labels such as compartment names.
+
+    Notes:
+        `ModelStateSpecification` defines the semantic order of model-state
+        entries, but it does not prescribe how an engine should convert them
+        into its internal representation. An ODE engine might use
+        `np.stack(...)`, while another engine might preserve the dictionary
+        form.
+
+        Each state entry currently maps to exactly one configured parameter
+        name. Reusing the same parameter name for multiple state entries is not
+        supported because it would collapse when requests are materialized into
+        a dictionary.
+
+        For an age-by-region SEIR system with age labels
+        `("age0_17", "age18_55", "age55_100")` and region labels
+        `("Region A", "Region B")`, `parameter_names` could be
+        `("S0", "E0", "I0", "R0")` and `axes` could be
+        `("region", "age")`. An engine could then stack those entries into a
+        `(4, 2, 3)` array ordered as `(compartment, region, age)`.
+
+    Examples:
+        >>> from flepimop2.parameter.abc import ModelStateSpecification
+        >>> spec = ModelStateSpecification(
+        ...     parameter_names=("s0", "i0", "r0"),
+        ...     labels=("S", "I", "R"),
+        ... )
+        >>> tuple(spec.requests())
+        ('s0', 'i0', 'r0')
+    """
+
+    parameter_names: tuple[IdentifierString, ...]
+    axes: tuple[IdentifierString, ...] = ()
+    broadcast: bool = False
+    labels: tuple[str, ...] | None = None
+
+    def __post_init__(self) -> None:
+        """
+        Validate any provided state labels align with parameter names.
+
+        Raises:
+            ValueError: If `labels` and `parameter_names` have different lengths.
+            ValueError: If `parameter_names` contains duplicates.
+
+        Examples:
+            >>> from flepimop2.parameter.abc import ModelStateSpecification
+            >>> spec = ModelStateSpecification(parameter_names=("s0",), labels=("S",))
+            >>> spec.labels
+            ('S',)
+            >>> ModelStateSpecification(
+            ...     parameter_names=("s0", "i0"),
+            ...     labels=("S",),
+            ... )
+            Traceback (most recent call last):
+                ...
+            ValueError: ModelStateSpecification labels must match ...
+            >>> ModelStateSpecification(
+            ...     parameter_names=("s0", "s0"),
+            ... )
+            Traceback (most recent call last):
+                ...
+            ValueError: ModelStateSpecification parameter_names must be unique ...
+        """
+        if self.labels is not None and len(self.labels) != len(self.parameter_names):
+            msg = (
+                "ModelStateSpecification labels must match parameter_names length; "
+                f"got {len(self.labels)} labels and {len(self.parameter_names)} "
+                "parameter names."
+            )
+            raise ValueError(msg)
+        if len(set(self.parameter_names)) != len(self.parameter_names):
+            msg = (
+                "ModelStateSpecification parameter_names must be unique so each "
+                "state entry maps to exactly one configured parameter."
+            )
+            raise ValueError(msg)
+
+    def requests(self) -> dict[IdentifierString, ParameterRequest]:
+        """
+        Convert this model-state specification into per-parameter requests.
 
         Returns:
-            A sampled value from the parameter.
+            Sampling requests for each parameter used to initialize model state.
+        """
+        return {
+            name: ParameterRequest(
+                name=name,
+                axes=self.axes,
+                broadcast=self.broadcast,
+            )
+            for name in self.parameter_names
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ParameterValue:
+    """
+    Sampled parameter value plus resolved runtime shape metadata.
+
+    Attributes:
+        value: The realized numeric value for this parameter.
+        shape: Named runtime shape resolved against a concrete axis collection.
+
+    Notes:
+        `ParameterValue` intentionally keeps the payload small: it records the value
+        itself and the resolved named shape. Richer provenance or caching metadata
+        can be added later once those workflows are designed.
+
+    Examples:
+        >>> from pprint import pp
+        >>> import numpy as np
+        >>> from flepimop2.axis import ResolvedShape
+        >>> from flepimop2.parameter.abc import ParameterValue
+        >>> value = ParameterValue(
+        ...     value=np.array([1.0, 2.0]),
+        ...     shape=ResolvedShape(axis_names=("age",), sizes=(2,)),
+        ... )
+        >>> pp(value)
+        ParameterValue(value=array([1., 2.]),
+                       shape=ResolvedShape(axis_names=('age',), sizes=(2,)))
+    """
+
+    value: Float64NDArray
+    shape: ResolvedShape
+
+    def __post_init__(self) -> None:
+        """
+        Normalize to a float64 array and validate its resolved shape.
+
+        Raises:
+            ValueError: If the array shape does not match the resolved named shape.
+
+        Examples:
+            >>> import numpy as np
+            >>> from flepimop2.axis import ResolvedShape
+            >>> from flepimop2.parameter.abc import ParameterValue
+            >>> ParameterValue(value=np.array(42.0), shape=ResolvedShape()).item()
+            42.0
+            >>> ParameterValue(
+            ...     value=np.array([1.0, 2.0]),
+            ...     shape=ResolvedShape(axis_names=("age",), sizes=(3,)),
+            ... )
+            Traceback (most recent call last):
+                ...
+            ValueError: ParameterValue shape mismatch: array has shape ...
+        """
+        value = np.asarray(self.value, dtype=np.float64)
+        if value.shape != self.shape.sizes:
+            msg = (
+                "ParameterValue shape mismatch: array has shape "
+                f"{value.shape}, but resolved shape is {self.shape.sizes} "
+                f"for axes {self.shape.axis_names}."
+            )
+            raise ValueError(msg)
+        object.__setattr__(self, "value", value)
+
+    def item(self) -> float:
+        """
+        Return the scalar item from a scalar parameter value.
+
+        Returns:
+            The scalar value as a Python float.
+
+        Examples:
+            >>> import numpy as np
+            >>> from flepimop2.axis import ResolvedShape
+            >>> from flepimop2.parameter.abc import ParameterValue
+            >>> ParameterValue(value=np.array(3.14), shape=ResolvedShape()).item()
+            3.14
+        """
+        return float(self.value.item())
+
+
+class ParameterABC(ModuleABC):
+    """
+    Abstract base class for parameter modules.
+
+    Notes:
+        Concrete parameter implementations should use `request` to decide how to
+        materialize their output for a particular system. For example, a fixed scalar
+        parameter may broadcast to a requested age axis, while a data-backed
+        parameter may validate that its loaded data already matches the requested
+        shape.
+    """
+
+    @abstractmethod
+    def sample(
+        self,
+        *,
+        axes: AxisCollection | None = None,
+        request: ParameterRequest | None = None,
+    ) -> ParameterValue:
+        """
+        Sample a value from the parameter.
+
+        Args:
+            axes: Resolved runtime axes available for this simulation.
+            request: Optional system-declared request describing the expected shape
+                and advisory type for the parameter.
+
+        Returns:
+            A sampled parameter value with resolved shape metadata.
         """
         raise NotImplementedError
 
@@ -33,6 +283,5 @@ def build(config: dict[str, Any] | ModuleModel) -> ParameterABC:
 
     Returns:
         The constructed parameter instance.
-
     """
     return _build(config, "parameter", "flepimop2.parameter.wrapper", ParameterABC)  # type: ignore[type-abstract]

--- a/src/flepimop2/parameter/fixed/__init__.py
+++ b/src/flepimop2/parameter/fixed/__init__.py
@@ -2,13 +2,13 @@
 
 __all__ = ["FixedParameter"]
 
-from typing import Literal
+from typing import Any, Literal
 
 import numpy as np
 
-from flepimop2.configuration import ModuleModel
-from flepimop2.parameter.abc import ParameterABC
-from flepimop2.typing import Float64NDArray
+from flepimop2.axis import AxisCollection, ResolvedShape
+from flepimop2.configuration import IdentifierString, ModuleModel
+from flepimop2.parameter.abc import ParameterABC, ParameterRequest, ParameterValue
 
 
 class FixedParameter(ModuleModel, ParameterABC):
@@ -18,19 +18,83 @@ class FixedParameter(ModuleModel, ParameterABC):
     Examples:
         >>> from flepimop2.parameter.fixed import FixedParameter
         >>> param = FixedParameter(value=42.0)
-        >>> param.sample()
-        array([42.])
+        >>> param.sample().item()
+        42.0
 
     """
 
     module: Literal["flepimop2.parameter.fixed"] = "flepimop2.parameter.fixed"
-    value: float
+    value: float | int | list[Any]
+    shape: tuple[IdentifierString, ...] = ()
 
-    def sample(self) -> Float64NDArray:
+    def sample(
+        self,
+        *,
+        axes: AxisCollection | None = None,
+        request: ParameterRequest | None = None,
+    ) -> ParameterValue:
         """
         Return the fixed value of the parameter.
 
+        Args:
+            axes: Resolved runtime axes available for the current simulation.
+            request: Optional system request describing the desired shape.
+
         Returns:
-            The fixed numeric value of the parameter.
+            The fixed parameter value with runtime shape metadata.
+
+        Raises:
+            ValueError: If the configured shape conflicts with the system request.
+            ValueError: If a non-scalar fixed value has no named shape context.
+            ValueError: If the configured value cannot satisfy the resolved shape.
         """
-        return np.array([self.value], dtype=np.float64)
+        axes = axes or AxisCollection()
+        value = np.asarray(self.value, dtype=np.float64)
+
+        configured_shape = axes.resolve_shape(self.shape) if self.shape else None
+        requested_shape = (
+            axes.resolve_shape(request.axes) if request is not None else None
+        )
+
+        if (
+            configured_shape is not None
+            and requested_shape is not None
+            and configured_shape != requested_shape
+        ):
+            if request is None:
+                msg = "request must be provided when validating a requested shape."
+                raise ValueError(msg)
+            msg = (
+                f"FixedParameter shape {configured_shape.axis_names} does not match "
+                f"requested shape {requested_shape.axis_names} for parameter "
+                f"'{request.name}'."
+            )
+            raise ValueError(msg)
+
+        target_shape = configured_shape or requested_shape
+        if target_shape is None:
+            if value.ndim > 0:
+                msg = (
+                    "Non-scalar FixedParameter values require either an explicit "
+                    "'shape' configuration or a system request."
+                )
+                raise ValueError(msg)
+            return ParameterValue(
+                value=value,
+                shape=ResolvedShape(),
+            )
+
+        if value.shape == target_shape.sizes:
+            return ParameterValue(value=value, shape=target_shape)
+
+        if value.ndim == 0 and (
+            configured_shape is not None or (request is not None and request.broadcast)
+        ):
+            broadcast = np.broadcast_to(value, target_shape.sizes).astype(np.float64)
+            return ParameterValue(value=broadcast, shape=target_shape)
+
+        msg = (
+            f"FixedParameter value shape {value.shape} is not compatible with "
+            f"resolved shape {target_shape.sizes} for axes {target_shape.axis_names}."
+        )
+        raise ValueError(msg)

--- a/src/flepimop2/simulator.py
+++ b/src/flepimop2/simulator.py
@@ -1,11 +1,14 @@
 """Simulation orchestration for flepimop2."""
 
 __all__ = ["Simulator"]
+
 from flepimop2._utils._click import _get_config_target
+from flepimop2.axis import AxisCollection
 from flepimop2.backend.abc import BackendABC
 from flepimop2.backend.abc import build as build_backend
 from flepimop2.configuration import (
     ConfigurationModel,
+    IdentifierString,
     ModuleModel,
     SimulateSpecificationModel,
 )
@@ -13,6 +16,11 @@ from flepimop2.engine.abc import EngineABC
 from flepimop2.engine.abc import build as build_engine
 from flepimop2.exceptions import Flepimop2ValidationError
 from flepimop2.meta import RunMeta
+from flepimop2.parameter.abc import (
+    ParameterRequest,
+    ParameterValue,
+)
+from flepimop2.parameter.abc import build as build_parameter
 from flepimop2.system.abc import SystemABC
 from flepimop2.system.abc import build as build_system
 from flepimop2.typing import Float64NDArray
@@ -42,6 +50,8 @@ class Simulator:
     system_config: ModuleModel | None = None
     engine_config: ModuleModel | None = None
     backend_config: ModuleModel | None = None
+    parameter_configs: dict[IdentifierString, ModuleModel] | None = None
+    axes: AxisCollection
 
     def __init__(  # noqa: PLR0913
         self,
@@ -54,6 +64,8 @@ class Simulator:
         system_config: ModuleModel | None = None,
         engine_config: ModuleModel | None = None,
         backend_config: ModuleModel | None = None,
+        parameter_configs: dict[IdentifierString, ModuleModel] | None = None,
+        axes: AxisCollection | None = None,
     ) -> None:
         """
         Initialize the simulator with resolved components.
@@ -67,6 +79,9 @@ class Simulator:
             system_config: The resolved system configuration model, if available.
             engine_config: The resolved engine configuration model, if available.
             backend_config: The resolved backend configuration model, if available.
+            parameter_configs: The resolved parameter configuration models, if
+                available.
+            axes: The resolved runtime axis collection for the simulation.
 
         Raises:
             Flepimop2ValidationError: If the engine is incompatible with the system.
@@ -77,6 +92,8 @@ class Simulator:
         self.system_config = system_config
         self.engine_config = engine_config
         self.backend_config = backend_config
+        self.parameter_configs = parameter_configs
+        self.axes = axes or AxisCollection()
         self.system = system
         self.engine = engine
         self.backend = backend
@@ -120,12 +137,77 @@ class Simulator:
             system_config=system_config,
             engine_config=engine_config,
             backend_config=backend_config,
+            parameter_configs=config_model.parameters,
+            axes=AxisCollection.from_config(config_model.axes),
         )
+
+    def _sample_parameter(
+        self,
+        name: IdentifierString,
+        request: ParameterRequest,
+    ) -> ParameterValue:
+        """
+        Build and sample a requested parameter from configuration.
+
+        Returns:
+            The sampled parameter value and runtime shape metadata.
+
+        Raises:
+            KeyError: If the requested parameter is missing from configuration.
+            ValueError: If parameter configuration has not been attached.
+        """
+        if self.parameter_configs is None:
+            msg = "parameter_configs must be set before resolving parameters."
+            raise ValueError(msg)
+        if name not in self.parameter_configs:
+            if request.optional:
+                msg = f"Optional parameter '{name}' was requested but not configured."
+                raise KeyError(msg)
+            msg = f"Required parameter '{name}' was requested but not configured."
+            raise KeyError(msg)
+        parameter = build_parameter(self.parameter_configs[name])
+        return parameter.sample(axes=self.axes, request=request)
+
+    def resolve_inputs(
+        self,
+    ) -> tuple[
+        dict[IdentifierString, ParameterValue],
+        dict[IdentifierString, ParameterValue],
+    ]:
+        """
+        Resolve configured parameters into an initial state and stepper inputs.
+
+        Returns:
+            Structured initial-state entries and structured stepper parameters.
+
+        Raises:
+            KeyError: If a required parameter is missing from configuration.
+            ValueError: If model state cannot be resolved for the system.
+        """
+        state_spec = self.system.model_state(self.axes)
+        if state_spec is None:
+            msg = "System did not declare model_state."
+            raise ValueError(msg)
+
+        state_samples = {
+            name: self._sample_parameter(name, request)
+            for name, request in state_spec.requests().items()
+        }
+        resolved_params: dict[IdentifierString, ParameterValue] = {}
+        for name, request in self.system.requested_parameters(self.axes).items():
+            if self.parameter_configs is None or name not in self.parameter_configs:
+                if request.optional:
+                    continue
+                msg = f"Required parameter '{name}' was requested but not configured."
+                raise KeyError(msg)
+            resolved_params[name] = self._sample_parameter(name, request)
+
+        return state_samples, resolved_params
 
     def run(
         self,
-        initial_state: Float64NDArray,
-        params: dict[str, float],
+        initial_state: dict[IdentifierString, ParameterValue] | None = None,
+        params: dict[IdentifierString, ParameterValue] | None = None,
     ) -> Float64NDArray:
         """
         Run the simulation and persist results via the backend.
@@ -140,11 +222,24 @@ class Simulator:
         if self.simulate_config is None:
             msg = "simulate_config must be set before running the simulator."
             raise ValueError(msg)
+        model_state = self.system.model_state(self.axes)
+        if model_state is None:
+            msg = "System did not declare model_state."
+            raise ValueError(msg)
+        if initial_state is None and params is None:
+            initial_state, params = self.resolve_inputs()
+        elif initial_state is None or params is None:
+            msg = (
+                "initial_state and params must either both be "
+                "provided or both be omitted."
+            )
+            raise ValueError(msg)
         res = self.engine.run(
             self.system,
             self.simulate_config.t_eval,
             initial_state,
             params,
+            model_state=model_state,
         )
         self.backend.save(res, RunMeta())
         return res

--- a/src/flepimop2/system/abc/__init__.py
+++ b/src/flepimop2/system/abc/__init__.py
@@ -15,10 +15,16 @@ import numpy as np
 
 from flepimop2._utils._checked_partial import _checked_partial
 from flepimop2._utils._module import _build
+from flepimop2.axis import AxisCollection
 from flepimop2.configuration import ModuleModel
 from flepimop2.configuration._types import IdentifierString
 from flepimop2.exceptions import Flepimop2ValidationError, ValidationIssue
 from flepimop2.module import ModuleABC
+from flepimop2.parameter.abc import (
+    ModelStateSpecification,
+    ParameterRequest,
+    ParameterValue,
+)
 from flepimop2.typing import Float64NDArray, StateChangeEnum
 
 
@@ -27,7 +33,7 @@ class SystemProtocol(Protocol):
     """Type-definition (Protocol) for system stepper functions."""
 
     def __call__(
-        self, time: np.float64, state: Float64NDArray, **kwargs: Any
+        self, time: np.float64, state: Float64NDArray, **kwargs: ParameterValue
     ) -> Float64NDArray:
         """Protocol for system stepper functions."""
         ...
@@ -36,7 +42,7 @@ class SystemProtocol(Protocol):
 def _no_step_function(
     time: np.float64,
     state: Float64NDArray,
-    **kwargs: Any,
+    **kwargs: ParameterValue,
 ) -> Float64NDArray:
     msg = "SystemABC::stepper must be provided by a concrete implementation."
     raise NotImplementedError(msg)
@@ -129,7 +135,7 @@ class SystemABC(ModuleABC):
         )
 
     def step(
-        self, time: np.float64, state: Float64NDArray, **params: Any
+        self, time: np.float64, state: Float64NDArray, **params: ParameterValue
     ) -> Float64NDArray:
         """
         Perform a single step of the system's dynamics.
@@ -143,6 +149,64 @@ class SystemABC(ModuleABC):
             The next state array after one step.
         """
         return self._stepper(time, state, **params)
+
+    def requested_parameters(
+        self,
+        axes: AxisCollection,  # noqa: ARG002
+    ) -> dict[IdentifierString, ParameterRequest]:
+        """
+        Infer parameter requests from the stepper signature by default.
+
+        Args:
+            axes: Resolved runtime axes for the active simulation.
+
+        Returns:
+            A mapping of parameter names to runtime parameter requests.
+
+        Notes:
+            Parameters with default values are treated as optional scalar inputs.
+            Subclasses are encouraged to override this method when they need
+            broadcasting behavior or named-axis shapes that cannot be recovered
+            from plain Python annotations.
+        """
+        requests: dict[IdentifierString, ParameterRequest] = {}
+        signature = inspect.signature(self._stepper)
+        for name, parameter in signature.parameters.items():
+            if name in {"time", "state"}:
+                continue
+            if parameter.kind in {
+                inspect.Parameter.VAR_KEYWORD,
+                inspect.Parameter.VAR_POSITIONAL,
+            }:
+                continue
+            requests[name] = ParameterRequest(
+                name=name,
+                optional=parameter.default is not inspect.Parameter.empty,
+            )
+        return requests
+
+    def model_state(  # noqa: PLR6301
+        self,
+        axes: AxisCollection,  # noqa: ARG002
+    ) -> ModelStateSpecification | None:
+        """
+        Return metadata describing how parameters assemble the model state.
+
+        Args:
+            axes: Resolved runtime axes for the active simulation.
+
+        Returns:
+            The runtime model-state specification, if defined.
+
+        Notes:
+            Override this in systems whose evolving state is assembled from configured
+            parameter entries. For an age-by-region SEIR system, this could return
+            `parameter_names=("S0", "E0", "I0", "R0")` with
+            `axes=("region", "age")`, allowing an engine to stack those entries into
+            an array shaped `(4, n_region, n_age)` or to keep them in dictionary form
+            if that is more natural for the engine.
+        """
+        return None
 
 
 def build(config: dict[str, Any] | ModuleModel) -> SystemABC:

--- a/src/flepimop2/system/wrapper/__init__.py
+++ b/src/flepimop2/system/wrapper/__init__.py
@@ -2,13 +2,16 @@
 
 __all__ = ["WrapperSystem"]
 
+from collections.abc import Callable
 from pathlib import Path
 from typing import Literal, Self
 
 from pydantic import model_validator
 
 from flepimop2._utils._module import _load_module, _validate_function
+from flepimop2.axis import AxisCollection
 from flepimop2.configuration import ModuleModel
+from flepimop2.parameter.abc import ModelStateSpecification, ParameterRequest
 from flepimop2.system.abc import SystemABC
 from flepimop2.typing import StateChangeEnum
 
@@ -19,6 +22,12 @@ class WrapperSystem(ModuleModel, SystemABC):
     module: Literal["flepimop2.system.wrapper"] = "flepimop2.system.wrapper"
     state_change: StateChangeEnum
     script: Path
+    _requested_parameters_func: (
+        Callable[[AxisCollection], dict[str, ParameterRequest]] | None
+    ) = None
+    _model_state_func: (
+        Callable[[AxisCollection], ModelStateSpecification | None] | None
+    ) = None
 
     @model_validator(mode="after")
     def _validate_stepper(self) -> Self:
@@ -36,4 +45,23 @@ class WrapperSystem(ModuleModel, SystemABC):
             msg = f"Module at {self.script} does not have a valid 'stepper' function."
             raise AttributeError(msg)
         self._stepper = mod.stepper
+        if _validate_function(mod, "requested_parameters"):
+            self._requested_parameters_func = mod.requested_parameters
+        if _validate_function(mod, "model_state"):
+            self._model_state_func = mod.model_state
         return self
+
+    def requested_parameters(
+        self,
+        axes: AxisCollection,
+    ) -> dict[str, ParameterRequest]:
+        """Return wrapper-system parameter requests from the script when provided."""
+        if self._requested_parameters_func is not None:
+            return self._requested_parameters_func(axes)
+        return super().requested_parameters(axes)
+
+    def model_state(self, axes: AxisCollection) -> ModelStateSpecification | None:
+        """Return wrapper-system state metadata from the script when provided."""
+        if self._model_state_func is not None:
+            return self._model_state_func(axes)
+        return super().model_state(axes)

--- a/src/flepimop2/typing.py
+++ b/src/flepimop2/typing.py
@@ -13,7 +13,12 @@ Examples:
     numpy.ndarray[tuple[typing.Any, ...], numpy.dtype[numpy.float64]]
 """
 
-__all__ = ["Float64NDArray", "RaiseOnMissing", "RaiseOnMissingType", "StateChangeEnum"]
+__all__ = [
+    "Float64NDArray",
+    "RaiseOnMissing",
+    "RaiseOnMissingType",
+    "StateChangeEnum",
+]
 
 from enum import StrEnum
 from typing import Final, Literal

--- a/tests/axis/test_axis_class.py
+++ b/tests/axis/test_axis_class.py
@@ -1,0 +1,75 @@
+"""Tests for `Axis` runtime behavior."""
+
+import pytest
+
+from flepimop2.axis import Axis
+
+
+@pytest.mark.parametrize(
+    ("axis", "expected_edges", "expected_bins", "expected_points"),
+    [
+        (
+            Axis(
+                name="time",
+                kind="continuous",
+                size=4,
+                domain=(0.0, 10.0),
+                spacing="linear",
+            ),
+            (0.0, 2.5, 5.0, 7.5, 10.0),
+            ((0.0, 2.5), (2.5, 5.0), (5.0, 7.5), (7.5, 10.0)),
+            (1.25, 3.75, 6.25, 8.75),
+        ),
+        (
+            Axis(
+                name="r_eff",
+                kind="continuous",
+                size=4,
+                domain=(-2.0, 2.0),
+                spacing="linear",
+            ),
+            (-2.0, -1.0, 0.0, 1.0, 2.0),
+            ((-2.0, -1.0), (-1.0, 0.0), (0.0, 1.0), (1.0, 2.0)),
+            (-1.5, -0.5, 0.5, 1.5),
+        ),
+        (
+            Axis(
+                name="viral_load",
+                kind="continuous",
+                size=3,
+                domain=(1.0, 1000.0),
+                spacing="log",
+            ),
+            pytest.approx((1.0, 10.0, 100.0, 1000.0)),
+            (
+                pytest.approx((1.0, 10.0)),
+                pytest.approx((10.0, 100.0)),
+                pytest.approx((100.0, 1000.0)),
+            ),
+            pytest.approx((3.16227766, 31.6227766, 316.22776602)),
+        ),
+    ],
+)
+def test_continuous_axis_supports_helpers(
+    axis: Axis,
+    expected_edges: tuple[float, ...],
+    expected_bins: tuple[tuple[float, float], ...],
+    expected_points: tuple[float, ...],
+) -> None:
+    """Continuous axes should expose consistent bin and point helpers."""
+    assert axis.bin_edges() == expected_edges
+    assert axis.bins() == expected_bins
+    assert axis.points() == expected_points
+
+
+def test_categorical_axis_rejects_continuous_helpers() -> None:
+    """Categorical axes should not expose continuous point/bin helpers."""
+    axis = Axis(
+        name="age",
+        kind="categorical",
+        size=3,
+        labels=("0-17", "18-64", "65+"),
+    )
+
+    with pytest.raises(TypeError):
+        axis.points()

--- a/tests/axis/test_axis_collection_class.py
+++ b/tests/axis/test_axis_collection_class.py
@@ -1,0 +1,188 @@
+"""Tests for `AxisCollection` runtime behavior."""
+
+from typing import Any
+
+import pytest
+
+from flepimop2.axis import Axis, AxisCollection, ResolvedShape
+
+
+@pytest.mark.parametrize(
+    ("config", "expected"),
+    [
+        (
+            {
+                "age": {
+                    "kind": "categorical",
+                    "labels": ["0-17", "18-64", "65+"],
+                },
+                "time": {
+                    "kind": "continuous",
+                    "domain": (0.0, 10.0),
+                    "size": 4,
+                },
+            },
+            {
+                "names": ("age", "time"),
+                "size_queries": ("age", "time"),
+                "sizes": (3, 4),
+                "label_query": "age",
+                "labels": ("0-17", "18-64", "65+"),
+            },
+        ),
+        (
+            {
+                "region": {
+                    "kind": "categorical",
+                    "labels": ["A", "B"],
+                },
+                "severity": {
+                    "kind": "categorical",
+                    "labels": ["low", "high"],
+                },
+            },
+            {
+                "names": ("region", "severity"),
+                "size_queries": ("region", "severity"),
+                "sizes": (2, 2),
+                "label_query": "region",
+                "labels": ("A", "B"),
+            },
+        ),
+    ],
+)
+def test_axis_collection_loads_axes_from_config(
+    config: dict[str, dict[str, Any]],
+    expected: dict[str, Any],
+) -> None:
+    """AxisCollection should preserve configured axis metadata."""
+    axes = AxisCollection.from_config(config)
+
+    expected_names = expected["names"]
+    size_queries = expected["size_queries"]
+    expected_sizes = expected["sizes"]
+    label_query = expected["label_query"]
+    expected_labels = expected["labels"]
+
+    assert isinstance(expected_names, tuple)
+    assert isinstance(size_queries, tuple)
+    assert isinstance(expected_sizes, tuple)
+    assert isinstance(label_query, str)
+    assert isinstance(expected_labels, tuple)
+
+    assert len(axes) == len(expected_names)
+    assert tuple(axes) == expected_names
+    assert axes.sizes(*size_queries) == expected_sizes
+    assert axes[label_query].labels == expected_labels
+
+
+@pytest.mark.parametrize(
+    ("axes", "axis_names", "expected_shape"),
+    [
+        (
+            AxisCollection({
+                "region": Axis(
+                    name="region",
+                    kind="categorical",
+                    size=2,
+                    labels=("A", "B"),
+                ),
+                "age": Axis(
+                    name="age",
+                    kind="categorical",
+                    size=3,
+                    labels=("0-17", "18-64", "65+"),
+                ),
+            }),
+            ("region", "age"),
+            ResolvedShape(axis_names=("region", "age"), sizes=(2, 3)),
+        ),
+        (
+            AxisCollection({
+                "time": Axis(
+                    name="time",
+                    kind="continuous",
+                    size=4,
+                    domain=(0.0, 8.0),
+                    spacing="linear",
+                ),
+            }),
+            ("time",),
+            ResolvedShape(axis_names=("time",), sizes=(4,)),
+        ),
+        (
+            AxisCollection({
+                "region": Axis(
+                    name="region",
+                    kind="categorical",
+                    size=2,
+                    labels=("A", "B"),
+                ),
+                "age": Axis(
+                    name="age",
+                    kind="categorical",
+                    size=3,
+                    labels=("0-17", "18-64", "65+"),
+                ),
+                "time": Axis(
+                    name="time",
+                    kind="continuous",
+                    size=5,
+                    domain=(0.0, 10.0),
+                    spacing="linear",
+                ),
+            }),
+            ("region", "age", "time"),
+            ResolvedShape(axis_names=("region", "age", "time"), sizes=(2, 3, 5)),
+        ),
+    ],
+)
+def test_axis_collection_resolves_named_shapes(
+    axes: AxisCollection,
+    axis_names: tuple[str, ...],
+    expected_shape: ResolvedShape,
+) -> None:
+    """AxisCollection should resolve axis names into a concrete named shape."""
+    assert axes.resolve_shape(axis_names) == expected_shape
+
+
+@pytest.mark.parametrize(
+    ("axes", "axis_names"),
+    [
+        (
+            AxisCollection({
+                "age": Axis(
+                    name="age",
+                    kind="categorical",
+                    size=3,
+                    labels=("0-17", "18-64", "65+"),
+                )
+            }),
+            ("region",),
+        ),
+        (
+            AxisCollection({
+                "region": Axis(
+                    name="region",
+                    kind="categorical",
+                    size=2,
+                    labels=("A", "B"),
+                ),
+                "age": Axis(
+                    name="age",
+                    kind="categorical",
+                    size=3,
+                    labels=("0-17", "18-64", "65+"),
+                ),
+            }),
+            ("region", "time"),
+        ),
+    ],
+)
+def test_axis_collection_rejects_unknown_axis_names(
+    axes: AxisCollection,
+    axis_names: tuple[str, ...],
+) -> None:
+    """AxisCollection should raise when asked to resolve unknown axes."""
+    with pytest.raises(KeyError, match="Unknown axis names requested"):
+        axes.resolve_shape(axis_names)

--- a/tests/engine/engine_wrapper_assets/dummy_engine.py
+++ b/tests/engine/engine_wrapper_assets/dummy_engine.py
@@ -1,21 +1,23 @@
 """A dummy stepper function for testing `WrapperEngine`."""
 
-from typing import Any
+from collections.abc import Mapping
 
 import numpy as np
 
 from flepimop2.configuration import IdentifierString
+from flepimop2.parameter.abc import ModelStateSpecification, ParameterValue
 from flepimop2.system.abc import SystemProtocol
 from flepimop2.typing import Float64NDArray
 
 
-def runner(
+def runner(  # noqa: PLR0913
     f: SystemProtocol,
     times: Float64NDArray,
-    state: Float64NDArray,
-    params: dict[IdentifierString, Any],
+    initial_state: dict[IdentifierString, ParameterValue],
+    params: Mapping[IdentifierString, ParameterValue],
     *,
-    accumulate: bool,
+    model_state: ModelStateSpecification | None = None,
+    accumulate: bool = False,
 ) -> Float64NDArray:
     """
     A dummy runner function for testing purposes: only evaluates stepper at times.
@@ -23,19 +25,31 @@ def runner(
     Args:
         f: The stepper function.
         times: Array of time points.
-        state: The current state array.
+        initial_state: Structured initial-state entries.
         params: Additional parameters for the stepper.
+        model_state: Specification describing how to order the initial-state
+            entries into a numeric state array.
         accumulate: Whether to accumulate results over time.
 
     Returns:
         The state array evaluated at each time point.
+
+    Raises:
+        ValueError: If `model_state` is not provided.
     """
-    # numpy array to hold results - first column time, rest state
-    res = np.zeros((len(times), len(state) + 1), dtype=np.float64)
+    if model_state is None:
+        msg = "model_state must be provided to assemble the initial state."
+        raise ValueError(msg)
+    state = np.stack([
+        initial_state[name].value for name in model_state.parameter_names
+    ]).astype(np.float64)
+    flat_state = state.reshape(-1)
+    res = np.zeros((len(times), flat_state.size + 1), dtype=np.float64)
     res[:, 0] = times
-    res[0, 1:] = state
-    for i, t in enumerate(times[1:]):
-        if accumulate:
-            res[i + 1, 1:] = res[i, 1:]
-        res[i + 1, 1:] += f(t, res[i, 1:], **params)
+    res[0, 1:] = flat_state
+    current_state = state
+    for i, t in enumerate(times[1:], start=1):
+        next_state = f(t, current_state, **params)
+        current_state = current_state + next_state if accumulate else next_state
+        res[i, 1:] = current_state.reshape(-1)
     return res

--- a/tests/engine/test_engine_abc.py
+++ b/tests/engine/test_engine_abc.py
@@ -1,11 +1,11 @@
 """Tests for `EngineABC` and default `WrapperEngine`."""
 
-from typing import Any, cast
-
 import numpy as np
 import pytest
 
+from flepimop2.axis import ResolvedShape
 from flepimop2.engine.abc import EngineABC
+from flepimop2.parameter.abc import ModelStateSpecification, ParameterValue
 from flepimop2.system.abc import SystemABC
 from flepimop2.typing import Float64NDArray, StateChangeEnum
 
@@ -24,7 +24,9 @@ class DummyEngine(EngineABC):
 
 
 def sample_step(
-    time: np.float64, state: Float64NDArray, **kwargs: Any
+    time: np.float64,
+    state: Float64NDArray,
+    **kwargs: ParameterValue,
 ) -> Float64NDArray:
     """
     A simple stepper function for testing purposes.
@@ -32,12 +34,12 @@ def sample_step(
     Args:
         time: The current time as a float64.
         state: The current state as a numpy array.
-        **kwargs: Additional keyword arguments, including 'offset'.
+        **kwargs: Additional keyword arguments, including `offset`.
 
     Returns:
         The updated state after applying the stepper logic.
     """
-    return (state + cast("float", kwargs["offset"])) * time
+    return (state + kwargs["offset"].item()) * time
 
 
 @pytest.mark.parametrize("engine", [DummyEngine()])
@@ -49,6 +51,11 @@ def test_abstraction_error(engine: EngineABC) -> None:
         engine.run(
             system,
             np.array([0.0], dtype=np.float64),
-            np.array([1.0, 2.0, 3.0], dtype=np.float64),
+            {
+                "s0": ParameterValue(np.array(1.0), ResolvedShape()),
+                "i0": ParameterValue(np.array(2.0), ResolvedShape()),
+                "r0": ParameterValue(np.array(3.0), ResolvedShape()),
+            },
             {},
+            model_state=ModelStateSpecification(parameter_names=("s0", "i0", "r0")),
         )

--- a/tests/engine/test_engine_wrapper.py
+++ b/tests/engine/test_engine_wrapper.py
@@ -6,8 +6,10 @@ from typing import Any, Final
 import numpy as np
 import pytest
 
+from flepimop2.axis import ResolvedShape
 from flepimop2.engine.abc import build as engine_build
 from flepimop2.exceptions import ValidationIssue
+from flepimop2.parameter.abc import ModelStateSpecification, ParameterValue
 from flepimop2.system.abc import SystemABC
 from flepimop2.system.abc import build as system_build
 from flepimop2.system.wrapper import WrapperSystem
@@ -37,23 +39,31 @@ TEST_SYSTEM_SCRIPT: Final = (
         })
     ],
 )
-@pytest.mark.parametrize("params", [{"offset": 1.0}])
+@pytest.mark.parametrize(
+    "params", [{"offset": ParameterValue(np.array(1.0), ResolvedShape())}]
+)
 def test_wrapper_system(
-    config: dict[str, Any], system: SystemABC, params: dict[str, float]
+    config: dict[str, Any],
+    system: SystemABC,
+    params: dict[str, ParameterValue],
 ) -> None:
     """Test `WrapperEngine` loads a script and uses its `runner` function."""
     engine = engine_build(config)
     result = engine.run(
         system,
         np.array([1.0, 2.0], dtype=np.float64),
-        np.array([1.0, 2.0], dtype=np.float64),
+        {
+            "x0": ParameterValue(np.array(1.0), ResolvedShape()),
+            "x1": ParameterValue(np.array(2.0), ResolvedShape()),
+        },
         params,
+        model_state=ModelStateSpecification(parameter_names=("x0", "x1")),
         accumulate=False,
     )
     expected = np.zeros((2, 3), dtype=np.float64)
     expected[:, 0] = [1.0, 2.0]
     expected[0, 1:] = [1.0, 2.0]
-    expected[1, 1:] = (expected[0, 1:] + params["offset"]) * 2.0
+    expected[1, 1:] = (expected[0, 1:] + params["offset"].item()) * 2.0
     np.testing.assert_array_equal(result, expected)
 
 

--- a/tests/integration/external_provider/config.yaml
+++ b/tests/integration/external_provider/config.yaml
@@ -1,5 +1,10 @@
 ---
 name: 'example-provider'
+axes:
+  age:
+    kind: 'continuous'
+    domain: [0.0, 90.0]
+    size: 3
 system:
   - module: 'sir'
     state_change: 'flow'
@@ -14,10 +19,19 @@ simulate:
 parameters:
   s0:
     module: 'fixed'
-    value: 999
+    value: [999, 899, 799]
+    shape: ['age']
   i0:
     module: 'fixed'
-    value: 1
+    value: [1, 1, 1]
+    shape: ['age']
   r0:
     module: 'fixed'
-    value: 0
+    value: [0, 0, 0]
+    shape: ['age']
+  gamma:
+    module: 'fixed'
+    value: 0.1
+  beta:
+    module: 'linear'
+    slope: 0.001

--- a/tests/integration/external_provider/euler.py
+++ b/tests/integration/external_provider/euler.py
@@ -1,11 +1,13 @@
 """Runner function for SIR model integration tests."""
 
+from collections.abc import Mapping
 from typing import Any
 
 import numpy as np
 
 from flepimop2.configuration import IdentifierString, ModuleModel
 from flepimop2.engine.abc import EngineABC
+from flepimop2.parameter.abc import ModelStateSpecification, ParameterValue
 from flepimop2.system.abc import SystemProtocol
 from flepimop2.typing import Float64NDArray
 
@@ -13,8 +15,9 @@ from flepimop2.typing import Float64NDArray
 def runner(
     stepper: SystemProtocol,
     times: Float64NDArray,
-    state: Float64NDArray,
-    params: dict[IdentifierString, Any],
+    initial_state: dict[IdentifierString, ParameterValue],
+    params: Mapping[IdentifierString, ParameterValue],
+    model_state: ModelStateSpecification | None = None,
     **kwargs: Any,  # noqa: ARG001
 ) -> Float64NDArray:
     """
@@ -23,22 +26,35 @@ def runner(
     Args:
         stepper: The system stepper function.
         times: Array of time points.
-        state: The current state array.
+        initial_state: Structured initial-state entries.
         params: Additional parameters for the stepper.
+        model_state: Specification describing how to order the initial-state
+            entries into a numeric state array.
         **kwargs: Additional keyword arguments for the engine. Unused by this runner.
 
     Returns:
         The evolved time x state array.
+
+    Raises:
+        ValueError: If `model_state` is not provided.
     """
-    output = np.zeros((len(times), len(state)), dtype=float)
-    output[0] = state
-    for i, t in enumerate(times[1:]):
-        if i == 0:
-            continue
+    if model_state is None:
+        msg = "model_state must be provided to assemble the initial state."
+        raise ValueError(msg)
+    state = np.stack([
+        initial_state[name].value for name in model_state.parameter_names
+    ]).astype(np.float64)
+    flat_size = state.size
+    output = np.zeros((len(times), flat_size + 1), dtype=float)
+    output[:, 0] = times
+    output[0, 1:] = state.reshape(-1)
+    current_state = state
+    for i, t in enumerate(times[1:], start=1):
         dt = t - times[i - 1]
-        dydt = stepper(times[i - 1], output[i - 1], **params)
-        output[i] = output[i - 1] + (dydt * dt)
-    return np.hstack((times.reshape(-1, 1), output))
+        dydt = stepper(times[i - 1], current_state, **params)
+        current_state += dydt * dt
+        output[i, 1:] = current_state.reshape(-1)
+    return output
 
 
 class EulerEngine(EngineABC):

--- a/tests/integration/external_provider/linear.py
+++ b/tests/integration/external_provider/linear.py
@@ -1,0 +1,57 @@
+"""Linear parameter implementation for external-provider integration tests."""
+
+from typing import Literal
+
+import numpy as np
+
+from flepimop2.axis import AxisCollection
+from flepimop2.configuration import ModuleModel
+from flepimop2.parameter.abc import ParameterABC, ParameterRequest, ParameterValue
+
+
+class LinearParameter(ModuleModel, ParameterABC):
+    """Parameter that scales one continuous axis by a configured slope."""
+
+    module: Literal["flepimop2.parameter.linear"] = "flepimop2.parameter.linear"
+    slope: float
+
+    def sample(
+        self,
+        *,
+        axes: AxisCollection | None = None,
+        request: ParameterRequest | None = None,
+    ) -> ParameterValue:
+        """
+        Sample values by multiplying one continuous axis's points by `slope`.
+
+        Args:
+            axes: Resolved runtime axes available for the current simulation.
+            request: System request describing the required parameter shape.
+
+        Returns:
+            A `ParameterValue` aligned with the requested axis.
+
+        Raises:
+            ValueError: If runtime axes are unavailable.
+            ValueError: If no request is provided.
+            ValueError: If the request does not name exactly one axis.
+        """
+        if axes is None:
+            msg = "LinearParameter requires runtime axes to sample values."
+            raise ValueError(msg)
+        if request is None:
+            msg = "LinearParameter requires a parameter request to determine shape."
+            raise ValueError(msg)
+        if len(request.axes) != 1:
+            msg = (
+                "LinearParameter currently supports exactly one requested axis; "
+                f"got {request.axes}."
+            )
+            raise ValueError(msg)
+
+        axis = axes[request.axes[0]]
+        values = self.slope * np.asarray(axis.points(), dtype=np.float64)
+        return ParameterValue(
+            value=values,
+            shape=axes.resolve_shape(request.axes),
+        )

--- a/tests/integration/external_provider/sir.py
+++ b/tests/integration/external_provider/sir.py
@@ -1,11 +1,17 @@
 """Stepper function for SIR model integration tests."""
 
-from typing import Any
+from typing import Any, cast
 
 import numpy as np
 
+from flepimop2.axis import AxisCollection
 from flepimop2.configuration import ModuleModel
-from flepimop2.system.abc import SystemABC
+from flepimop2.parameter.abc import (
+    ModelStateSpecification,
+    ParameterRequest,
+    ParameterValue,
+)
+from flepimop2.system.abc import SystemABC, SystemProtocol
 from flepimop2.typing import Float64NDArray, StateChangeEnum
 
 
@@ -13,27 +19,29 @@ def stepper(
     time: np.float64,  # noqa: ARG001
     state: Float64NDArray,
     *,
-    beta: float = 0.3,
-    gamma: float = 0.1,
+    beta: ParameterValue,
+    gamma: ParameterValue | None = None,
     **kwargs: Any,  # noqa: ARG001
 ) -> Float64NDArray:
     """
-    ODE for an SIR model.
+    ODE for an age-stratified SIR model with isolated age groups.
 
     Args:
         time: Current time (not used in this model).
-        state: Current state array [S, I, R].
-        beta: The infection rate.
-        gamma: The recovery rate.
-        **kwargs: Additional parameters (beta, gamma).
+        state: Current state array shaped `(3, n_age)`.
+        beta: Age-specific transmission rates from the external provider.
+        gamma: The recovery-rate parameter.
+        **kwargs: Additional parameters.
 
     Returns:
-        Next state array after one step.
+        Next state array after one step with shape `(3, n_age)`.
     """
-    y_s, y_i, _ = np.asarray(state, dtype=float)
-    infection = beta * y_s * y_i / np.sum(state)
-    recovery = gamma * y_i
-    return np.array([-infection, infection - recovery, recovery], dtype=float)
+    y_s, y_i, y_r = np.asarray(state, dtype=float)
+    gamma_value = gamma.item() if gamma is not None else 0.1
+    totals = y_s + y_i + y_r
+    infection = beta.value * y_s * y_i / totals
+    recovery = gamma_value * y_i
+    return np.vstack((-infection, infection - recovery, recovery)).astype(np.float64)
 
 
 class SirSystem(SystemABC):
@@ -44,7 +52,38 @@ class SirSystem(SystemABC):
 
     def __init__(self) -> None:
         """Initialize the SIR system with the SIR stepper."""
-        self._stepper = stepper
+        self._stepper = cast("SystemProtocol", stepper)
+
+    def requested_parameters(
+        self,
+        axes: AxisCollection,  # noqa: ARG002
+    ) -> dict[str, ParameterRequest]:
+        """
+        Declare the non-state parameters consumed by the SIR stepper.
+
+        Returns:
+            Runtime parameter requests for the SIR stepper.
+        """
+        return {
+            "beta": ParameterRequest(name="beta", axes=("age",)),
+            "gamma": ParameterRequest(name="gamma", optional=True),
+        }
+
+    def model_state(
+        self,
+        axes: AxisCollection,  # noqa: ARG002
+    ) -> ModelStateSpecification:
+        """
+        Declare how parameter entries assemble the SIR state vector.
+
+        Returns:
+            The model-state specification for the SIR system.
+        """
+        return ModelStateSpecification(
+            parameter_names=("s0", "i0", "r0"),
+            axes=("age",),
+            labels=("S", "I", "R"),
+        )
 
 
 def build(config: dict[str, Any] | ModuleModel) -> SirSystem:  # noqa: ARG001

--- a/tests/integration/external_provider/test_external_provider.py
+++ b/tests/integration/external_provider/test_external_provider.py
@@ -3,6 +3,7 @@
 import re
 from pathlib import Path
 
+import numpy as np
 import pytest
 
 from flepimop2.testing import external_provider_package, flepimop2_run
@@ -39,6 +40,9 @@ def test_external_provider(
             repo_root / "tests/integration/external_provider/sir.py": Path(
                 "external_provider/src/flepimop2/system/sir.py"
             ),
+            repo_root / "tests/integration/external_provider/linear.py": Path(
+                "external_provider/src/flepimop2/parameter/linear.py"
+            ),
         },
     )
     monkeypatch.chdir(tmp_path)
@@ -57,3 +61,8 @@ def test_external_provider(
     csv = model_output[0]
     assert re.match(r"^simulate_\d{8}_\d{6}\.csv$", csv.name)
     assert csv.stat().st_size > 0
+    data = np.loadtxt(csv, delimiter=",")
+    assert data.shape == (101, 10)
+    np.testing.assert_allclose(data[0, 1:4], np.array([999.0, 899.0, 799.0]))
+    np.testing.assert_allclose(data[0, 4:7], np.array([1.0, 1.0, 1.0]))
+    np.testing.assert_allclose(data[0, 7:10], np.array([0.0, 0.0, 0.0]))

--- a/tests/parameter/test_fixed_parameter_class.py
+++ b/tests/parameter/test_fixed_parameter_class.py
@@ -1,0 +1,99 @@
+"""Tests for runtime fixed-parameter sampling."""
+
+from typing import Any
+
+import numpy as np
+import pytest
+
+from flepimop2.axis import AxisCollection
+from flepimop2.parameter.abc import ParameterRequest
+from flepimop2.parameter.fixed import FixedParameter
+
+
+@pytest.mark.parametrize("value", [42.0, 123.45])
+def test_fixed_parameter_returns_scalar_parameter_value(value: float) -> None:
+    """Scalar fixed parameters should resolve to scalar runtime samples."""
+    sample = FixedParameter(value=value).sample()
+    assert sample.shape.axis_names == ()
+    assert sample.shape.sizes == ()
+    assert sample.item() == value
+
+
+@pytest.mark.parametrize(
+    ("axes_config", "value"),
+    [
+        ({"age": {"kind": "categorical", "labels": ["0-17", "18-64", "65+"]}}, 0.1),
+        ({"region": {"kind": "categorical", "labels": ["north", "south"]}}, 0.2),
+        (
+            {
+                "age": {
+                    "kind": "continuous",
+                    "size": 10,
+                    "domain": (18, 65),
+                    "spacing": "linear",
+                }
+            },
+            0.3,
+        ),
+    ],
+)
+def test_fixed_parameter_broadcasts_scalar_to_requested_shape(
+    axes_config: dict[str, Any], value: float
+) -> None:
+    """Scalar fixed parameters can broadcast to system-requested shapes."""
+    axes_name = next(iter(axes_config.keys()))
+    axes = AxisCollection.from_config(axes_config)
+    sample = FixedParameter(value=value).sample(
+        axes=axes,
+        request=ParameterRequest(name="gamma", axes=(axes_name,), broadcast=True),
+    )
+    assert sample.shape.axis_names == (axes_name,)
+    np.testing.assert_array_equal(sample.value, np.repeat(value, axes.size(axes_name)))
+
+
+def test_fixed_parameter_rejects_non_scalar_without_shape_context() -> None:
+    """Array-valued fixed parameters need explicit named shape information."""
+    with pytest.raises(
+        ValueError,
+        match=(
+            r"^Non-scalar FixedParameter values require either an "
+            r"explicit 'shape' configuration or a system request.$"
+        ),
+    ):
+        FixedParameter(value=[1.0, 2.0]).sample()
+
+
+def test_fixed_parameter_rejects_conflicting_configured_and_requested_shapes() -> None:
+    """Explicit parameter shape must match the system-requested shape."""
+    axes = AxisCollection.from_config({
+        "age": {"kind": "categorical", "labels": ["0-17", "18-64", "65+"]},
+        "region": {"kind": "categorical", "labels": ["north", "south"]},
+    })
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            r"^FixedParameter shape \('age',\) does not match requested "
+            r"shape \('region',\) for parameter 'beta'\.$"
+        ),
+    ):
+        FixedParameter(value=[0.1, 0.2, 0.3], shape=("age",)).sample(
+            axes=axes,
+            request=ParameterRequest(name="beta", axes=("region",)),
+        )
+
+
+def test_fixed_parameter_rejects_value_with_incompatible_resolved_shape() -> None:
+    """Configured values must match or broadcast to the resolved named shape."""
+    axes = AxisCollection.from_config({
+        "age": {"kind": "categorical", "labels": ["0-17", "18-64", "65+"]}
+    })
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            r"^FixedParameter value shape \(2,\) is not compatible with "
+            r"resolved shape \(3,\) for axes \('age',\)\.$"
+        ),
+    ):
+        FixedParameter(value=[0.1, 0.2], shape=("age",)).sample(axes=axes)

--- a/tests/simulator/test_simulator_class.py
+++ b/tests/simulator/test_simulator_class.py
@@ -1,0 +1,91 @@
+"""Tests for simulator input resolution from system contracts."""
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from flepimop2.configuration import ConfigurationModel
+from flepimop2.simulator import Simulator
+
+ENGINE_SCRIPT = (
+    Path(__file__).parent.parent
+    / "engine"
+    / "engine_wrapper_assets"
+    / "dummy_engine.py"
+)
+SYSTEM_SCRIPT = (
+    Path(__file__).parent.parent
+    / "system"
+    / "system_wrapper_assets"
+    / "wrapper_system_with_extras.py"
+)
+
+
+def test_simulator_resolves_inputs_and_runs(
+    tmp_path: Path,
+) -> None:
+    """Simulator should resolve structured inputs and execute the engine."""
+    output_root = tmp_path / "model_output"
+    output_root.mkdir()
+    config = ConfigurationModel.model_validate({
+        "axes": {
+            "age": {
+                "kind": "categorical",
+                "labels": ["0-17", "18-64", "65+"],
+            }
+        },
+        "systems": {
+            "demo": {
+                "module": "wrapper",
+                "script": SYSTEM_SCRIPT,
+                "state_change": "flow",
+            }
+        },
+        "engines": {
+            "demo": {
+                "module": "wrapper",
+                "script": ENGINE_SCRIPT,
+                "state_change": "flow",
+            }
+        },
+        "backends": {"demo": {"module": "csv", "root": output_root}},
+        "parameters": {
+            "s0": {"module": "fixed", "value": 100.0},
+            "i0": {"module": "fixed", "value": 1.0},
+            "r0": {"module": "fixed", "value": 0.0},
+            "beta": {"module": "fixed", "value": 0.3},
+            "gamma": {"module": "fixed", "value": 0.1},
+        },
+        "simulate": {
+            "demo": {
+                "system": "demo",
+                "engine": "demo",
+                "backend": "demo",
+                "times": [0.0, 1.0],
+            }
+        },
+    })
+
+    simulator = Simulator.from_configuration_model(config)
+    initial_state, params = simulator.resolve_inputs()
+
+    assert tuple(initial_state) == ("s0", "i0", "r0")
+    np.testing.assert_array_equal(initial_state["s0"].value, np.array([100.0] * 3))
+    np.testing.assert_array_equal(initial_state["i0"].value, np.array([1.0] * 3))
+    np.testing.assert_array_equal(initial_state["r0"].value, np.array([0.0] * 3))
+    assert params["beta"].item() == pytest.approx(0.3)
+    np.testing.assert_array_equal(params["gamma"].value, np.array([0.1, 0.1, 0.1]))
+
+    result = simulator.run(initial_state, params)
+
+    assert result.shape == (2, 10)
+    np.testing.assert_array_equal(result[:, 0], np.array([0.0, 1.0]))
+    np.testing.assert_array_equal(
+        result[0, 1:],
+        np.array([100.0, 100.0, 100.0, 1.0, 1.0, 1.0, 0.0, 0.0, 0.0]),
+    )
+    np.testing.assert_allclose(
+        result[1, 1:],
+        np.array([100.4, 100.4, 100.4, 1.4, 1.4, 1.4, 0.4, 0.4, 0.4]),
+    )

--- a/tests/system/system_wrapper_assets/dummy_system.py
+++ b/tests/system/system_wrapper_assets/dummy_system.py
@@ -1,20 +1,23 @@
 """A dummy stepper function for testing `WrapperSystem`."""
 
-import numpy as np
-
+from flepimop2.parameter.abc import ParameterValue
 from flepimop2.typing import Float64NDArray
 
 
-def stepper(time: float, state: Float64NDArray, offset: np.float64) -> Float64NDArray:
+def stepper(
+    time: float,
+    state: Float64NDArray,
+    offset: ParameterValue,
+) -> Float64NDArray:
     """
     A dummy stepper function for testing purposes: (state + offset) * time.
 
     Args:
         time: The current time.
         state: The current state array.
-        offset: An offset value to be added to the state.
+        offset: An offset parameter to be added to the state.
 
     Returns:
         The updated state array after applying the stepper logic.
     """
-    return (state + offset) * time
+    return (state + offset.item()) * time

--- a/tests/system/system_wrapper_assets/wrapper_system_with_extras.py
+++ b/tests/system/system_wrapper_assets/wrapper_system_with_extras.py
@@ -1,0 +1,58 @@
+"""A wrapper-system asset with explicit runtime parameter contracts."""
+
+from flepimop2.axis import AxisCollection
+from flepimop2.parameter.abc import (
+    ModelStateSpecification,
+    ParameterRequest,
+    ParameterValue,
+)
+from flepimop2.typing import Float64NDArray
+
+
+def stepper(
+    time: float,  # noqa: ARG001
+    state: Float64NDArray,
+    beta: ParameterValue,
+    gamma: ParameterValue,
+) -> Float64NDArray:
+    """
+    A dummy stepper using both scalar and age-indexed parameters.
+
+    Returns:
+        The updated state.
+    """
+    return state + beta.item() + gamma.value
+
+
+def requested_parameters(
+    axes: AxisCollection,  # noqa: ARG001
+) -> dict[str, ParameterRequest]:
+    """
+    Declare one scalar and one age-indexed parameter.
+
+    Returns:
+        Runtime parameter requests for the dummy system.
+    """
+    return {
+        "beta": ParameterRequest(name="beta"),
+        "gamma": ParameterRequest(
+            name="gamma",
+            axes=("age",),
+            broadcast=True,
+        ),
+    }
+
+
+def model_state(axes: AxisCollection) -> ModelStateSpecification:  # noqa: ARG001
+    """
+    Assemble the model state from parameter entries under `parameters`.
+
+    Returns:
+        The model-state specification for the dummy system.
+    """
+    return ModelStateSpecification(
+        parameter_names=("s0", "i0", "r0"),
+        axes=("age",),
+        broadcast=True,
+        labels=("S", "I", "R"),
+    )

--- a/tests/system/test_system_bind.py
+++ b/tests/system/test_system_bind.py
@@ -5,6 +5,8 @@ from pathlib import Path
 import numpy as np
 import pytest
 
+from flepimop2.axis import ResolvedShape
+from flepimop2.parameter.abc import ParameterValue
 from flepimop2.system.abc import SystemABC, build
 from flepimop2.typing import StateChangeEnum
 
@@ -17,13 +19,14 @@ par = pytest.mark.parametrize("test_system", [system])
 @par
 def test_set_valid_static_parameters(test_system: SystemABC) -> None:
     """Confirm no errors when setting all valid parameters."""
-    offset = 5.0
+    offset = ParameterValue(np.array(5.0), ResolvedShape())
     time = np.float64(1.0)
     initial_state = np.array([1.0, 2.0, 3.0], dtype=np.float64)
     newproto = test_system.bind(offset=offset)
-    assert all(newproto(time, initial_state) == (initial_state + offset))
-    newproto = test_system.bind(params={"offset": offset * 2})
-    assert all(newproto(time, initial_state) == (initial_state + offset * 2))
+    assert all(newproto(time, initial_state) == (initial_state + offset.item()))
+    doubled = ParameterValue(np.array(offset.item() * 2), ResolvedShape())
+    newproto = test_system.bind(params={"offset": doubled})
+    assert all(newproto(time, initial_state) == (initial_state + doubled.item()))
 
 
 @par

--- a/tests/system/test_system_wrapper.py
+++ b/tests/system/test_system_wrapper.py
@@ -1,14 +1,23 @@
 """Tests for `SystemABC` and default `WrapperSystem`."""
 
 from pathlib import Path
-from typing import Any
+from typing import Any, Final
 
 import numpy as np
 import pytest
 
+from flepimop2.axis import AxisCollection, ResolvedShape
+from flepimop2.parameter.abc import (
+    ModelStateSpecification,
+    ParameterRequest,
+    ParameterValue,
+)
 from flepimop2.system.abc import build
 
-TEST_SCRIPT = Path(__file__).parent / "system_wrapper_assets" / "dummy_system.py"
+TEST_SCRIPT: Final = Path(__file__).parent / "system_wrapper_assets" / "dummy_system.py"
+WRAPPER_SCRIPT_WITH_EXTRAS: Final = (
+    Path(__file__).parent / "system_wrapper_assets" / "wrapper_system_with_extras.py"
+)
 
 
 @pytest.mark.parametrize("config", [{"script": TEST_SCRIPT, "state_change": "flow"}])
@@ -16,10 +25,10 @@ def test_wrapper_system(config: dict[str, Any]) -> None:
     """Test `WrapperSystem` loads a script and uses its `stepper` function."""
     system = build(config)
     time = np.float64(1.0)
-    offset = 1.0
+    offset = ParameterValue(np.array(1.0), ResolvedShape())
     init_state = np.array([1.0, 2.0, 3.0], dtype=np.float64)
     result = system.step(time, init_state, offset=offset)
-    expected = init_state + offset
+    expected = init_state + offset.item()
     np.testing.assert_array_equal(result, expected)
 
 
@@ -31,3 +40,26 @@ def test_wrapper_system_options_available_via_option_method() -> None:
         "options": {"offset": 1.5},
     })
     assert system.option("offset") == pytest.approx(1.5)
+
+
+def test_wrapper_system_loads_requested_parameters_and_model_state() -> None:
+    """Wrapper systems should expose requested parameter and state metadata."""
+    system = build({"script": WRAPPER_SCRIPT_WITH_EXTRAS, "state_change": "flow"})
+    axes = AxisCollection.from_config({
+        "age": {"kind": "categorical", "labels": ["0-17", "18-64"]}
+    })
+
+    assert system.requested_parameters(axes) == {
+        "beta": ParameterRequest(name="beta"),
+        "gamma": ParameterRequest(
+            name="gamma",
+            axes=("age",),
+            broadcast=True,
+        ),
+    }
+    assert system.model_state(axes) == ModelStateSpecification(
+        parameter_names=("s0", "i0", "r0"),
+        axes=("age",),
+        broadcast=True,
+        labels=("S", "I", "R"),
+    )


### PR DESCRIPTION
This changes the `Simulator` class to treat parameters as structured,
axis-aware values rather than raw scalars or arrays. Systems now declare
the parameter and model-state they need, parameters resolve against
named axes at runtime, and engines receive structured initial conditions
and parameters without hard-coded assumptions about state shape.

- Added `flepimop2.axis` module to represent axis/collection of axis.
- Changed `ParameterABC.sample()` to return frozen `ParameterValue`
  objects with resolved shape and values.
- Placed developer-facing parameter related types under the
  `flepimop2.parameter.abc` subpackage.
- Added `SystemABC.requested_parameters()/model_state()` methods to
  request parameters needed for the stepper or declare internal model
  state, namely initial conditions.
- Kept initial conditions under parameters and represent model state as
  ordered parameter keys via `ModelStateSpecification`.
- `ParameterValue` objects are now passed through
  simulator/engine/system so steppers can unwrap and manipulate the
  parameter as needed.
- Removed the legacy hard-coded s0/i0/r0 initial conditions in the
  `flepimop2 simulate` command.
- Added helpers for continuous bins, bin edits, points from continous
  axis objects.
- Updated wrapper assets, examples, docs, and tests to use the new
  structured parameter contract.

Closes #115. Closes #133.