### PR TITLE
Address CI issues with #182

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "numpy>=2.2.6",
     "pydantic>=2.12.2",
     "pyyaml>=6.0.3",
+    "typing-extensions>=4.15.0",
 ]
 classifiers = [
     "Development Status :: 3 - Alpha",

--- a/src/flepimop2/_utils/_module.py
+++ b/src/flepimop2/_utils/_module.py
@@ -98,7 +98,7 @@ def _load_module(path: PathLike[str], mod_name: str) -> ModuleType:
 
 
 def _load_builder(
-    mod_name: str, _enforced_type: type[T_co] | ABCMeta
+    mod_name: str, _enforced_type: type[T_co] | ABCMeta | None = None
 ) -> Buildable[T_co]:
     """
     Load a Python module from a given file path as a given name.
@@ -124,18 +124,16 @@ def _load_builder(
 
     target_class = _find_target_class(mod, mod_name)
     if target_class is None:
-        msg = f"Module '{mod_name}' lacks a 'build' function or valid BaseModel."
+        msg = f"Module '{mod_name}' does not have a valid 'build' function."
         raise AttributeError(msg)
+    builder_class: type[BaseModel] = target_class
 
-    # We define the internal function. Note that 'target_class'
-    # needs to be cast to T_co since we're promising the caller a T_co.
-    def dynamic_build(config: dict[IdentifierString, Any] | ModuleModel) -> T_co:
-        # Validate returns an instance of the class; we cast it to the expected T_co
-        return cast("T_co", target_class.model_validate(_as_dict(config)))
+    class _BuilderWrapper:
+        def build(self, config: dict[Any, Any] | ModuleModel) -> T_co:  # noqa: PLR6301
+            # Validate returns an instance of the class; we cast it to the expected T_co
+            return cast("T_co", builder_class.model_validate(_as_dict(config)))
 
-    res = cast("Buildable[T_co]", mod)
-    res.build = dynamic_build
-    return res
+    return _BuilderWrapper()
 
 
 def _validate_function(module: ModuleType, func_name: str) -> bool:

--- a/src/flepimop2/system/abc/__init__.py
+++ b/src/flepimop2/system/abc/__init__.py
@@ -9,8 +9,9 @@ __all__ = [
 ]
 
 import inspect
+import sys
 from abc import abstractmethod
-from typing import Any, Literal, override
+from typing import Any, Literal
 
 import numpy as np
 
@@ -25,6 +26,11 @@ from flepimop2.typing import (
     StateChangeEnum,
     SystemProtocol,
 )
+
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from typing_extensions import override
 
 
 class SystemABC(ModuleABC):
@@ -216,7 +222,7 @@ def wrap(
 
     Raises:
         TypeError: If the provided stepper function does not conform to the expected
-        signature or if offered an erroneous state_change.
+            signature or if offered an erroneous state_change.
     """
     if not isinstance(state_change, StateChangeEnum):
         msg = (

--- a/tests/integration/external_provider/sir.py
+++ b/tests/integration/external_provider/sir.py
@@ -1,7 +1,8 @@
 """Stepper function for SIR model integration tests."""
 
 import functools
-from typing import Any, ParamSpec, override
+import sys
+from typing import Any, ParamSpec
 
 import numpy as np
 
@@ -13,6 +14,11 @@ from flepimop2.typing import (
     StateChangeEnum,
     SystemProtocol,
 )
+
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from typing_extensions import override
 
 
 def sir_stepper(


### PR DESCRIPTION
- Added `typing_extensions` as a dependency.
- Fixed issues with `@override` prior to python 3.12 by utilizing `typing_extensions.override`.
- Changed the return of `_load_builder` to be an instance of the `_BuilderWrapper` shim class to satisfy the `Buildable` protocol.
- Fixed indent in the documentation of `flepimop2.system.abc.wrap` helper to address warning from MkDocs.