### PR TITLE
Infrastructure to submit package to PyPI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,8 +56,28 @@ jobs:
         uses: './.github/actions/setup-just-and-uv'
       - name: 'run quality checks'
         run: 'just quality'
+  package:
+    name: 'package'
+    runs-on: 'ubuntu-latest'
+    steps:
+      - name: 'checkout repository'
+        uses: 'actions/checkout@v6'
+        with:
+          persist-credentials: false
+      - name: 'setup just and uv'
+        uses: './.github/actions/setup-just-and-uv'
+        with:
+          python-version: '3.12'
+      - name: 'check package artifacts'
+        run: 'just build-check'
+        env:
+          UV_PYTHON_VERSION: '3.12'
   tests:
     name: 'tests (${{ matrix.python-version }}-${{ matrix.coverage }})'
+    needs:
+      - 'docs'
+      - 'package'
+      - 'quality'
     runs-on: 'ubuntu-latest'
     strategy:
       fail-fast: false

--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -5,10 +5,23 @@ name: 'github pages'
   push:
     branches:
       - 'main'
-  release:
-    types:
-      - 'published'
+  workflow_call:
+    inputs:
+      deploy-mode:
+        description: 'Deployment mode used to determine docs aliases'
+        required: false
+        default: 'push'
+        type: 'string'
   workflow_dispatch:
+    inputs:
+      deploy-mode:
+        description: 'Deployment mode used to determine docs aliases'
+        required: false
+        default: 'push'
+        type: 'choice'
+        options:
+          - 'push'
+          - 'release'
 
 permissions:
   contents: 'read'
@@ -49,10 +62,25 @@ jobs:
           rm version.py
       - name: 'build reference'
         run: 'just reference'
+      - name: 'determine deploy mode'
+        id: determine-mode
+        run: |
+          if [ "${EVENT_NAME}" = "workflow_call" ]; then
+            echo "deploy-mode=${CALL_MODE}" >> "${GITHUB_OUTPUT}"
+          elif [ "${EVENT_NAME}" = "workflow_dispatch" ] \
+            && [ -n "${DISPATCH_MODE}" ]; then
+            echo "deploy-mode=${DISPATCH_MODE}" >> "${GITHUB_OUTPUT}"
+          else
+            echo "deploy-mode=push" >> "${GITHUB_OUTPUT}"
+          fi
+        env:
+          CALL_MODE: '${{ inputs.deploy-mode }}'
+          DISPATCH_MODE: '${{ github.event.inputs.deploy-mode }}'
+          EVENT_NAME: '${{ github.event_name }}'
       - name: 'deploy to github pages'
         run: |
           uv run mike set-default latest
-          if [ "${EVENT_NAME}" == "release" ] || [[ $VERSION == 0* ]]; then
+          if [ "${DEPLOY_MODE}" = "release" ] || [[ $VERSION == 0* ]]; then
             ALIAS=latest
           else
             ALIAS=dev
@@ -61,6 +89,6 @@ jobs:
             --push --update-aliases \
             ${VERSION} ${ALIAS}
         env:
-          EVENT_NAME: "${{ github.event_name }}"
+          DEPLOY_MODE: "${{ steps.determine-mode.outputs.deploy-mode }}"
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           VERSION: "${{ steps.extract-version.outputs.version }}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,121 @@
+---
+name: 'Release'
+
+'on':
+  workflow_dispatch:
+    inputs:
+      publish-target:
+        description: 'Package publish target'
+        required: true
+        default: 'none'
+        type: 'choice'
+        options:
+          - 'none'
+          - 'testpypi'
+          - 'pypi'
+      create-github-release:
+        description: 'Create the GitHub release after publishing'
+        required: true
+        default: false
+        type: 'boolean'
+      deploy-docs:
+        description: 'Deploy versioned docs after creating the GitHub release'
+        required: true
+        default: false
+        type: 'boolean'
+
+permissions:
+  contents: 'read'
+
+jobs:
+  validate:
+    name: 'validate release'
+    runs-on: 'ubuntu-latest'
+    steps:
+      - name: 'fail if PyPI publish is requested'
+        if: "${{ github.event.inputs.publish-target == 'pypi' }}"
+        run: |
+          # `flepimop2` is not ready for submission to PyPI yet.
+          echo "Publishing to PyPI is intentionally disabled for this"
+          echo "repository."
+          exit 1
+      - name: 'checkout repository'
+        uses: 'actions/checkout@v6'
+        with:
+          fetch-depth: 0
+      - name: 'setup just and uv'
+        uses: './.github/actions/setup-just-and-uv'
+        with:
+          python-version: '3.12'
+      - name: 'run release preflight'
+        run: 'just release-validate'
+        env:
+          GH_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+          UV_PYTHON_VERSION: '3.12'
+      - name: 'upload package artifacts'
+        uses: 'actions/upload-artifact@v6'
+        with:
+          name: 'dist'
+          path: 'dist/*'
+          if-no-files-found: 'error'
+  publish-pypi:
+    name: 'publish to PyPI'
+    needs:
+      - 'validate'
+    runs-on: 'ubuntu-latest'
+    if: "${{ github.event.inputs.publish-target == 'testpypi' }}"
+    permissions:
+      id-token: 'write'
+    steps:
+      - name: 'download package artifacts'
+        uses: 'actions/download-artifact@v8'
+        with:
+          name: 'dist'
+          path: 'dist'
+      - name: 'publish package to TestPyPI'
+        uses: 'pypa/gh-action-pypi-publish@release/v1'
+        with:
+          repository-url: 'https://test.pypi.org/legacy/'
+  create-github-release:
+    name: 'create GitHub release'
+    needs:
+      - 'validate'
+      - 'publish-pypi'
+    if: >-
+      ${{
+        github.event.inputs.create-github-release == 'true' &&
+        (github.event.inputs.publish-target == 'none' ||
+        needs.publish-pypi.result == 'success')
+      }}
+    runs-on: 'ubuntu-latest'
+    permissions:
+      contents: 'write'
+    steps:
+      - name: 'checkout repository'
+        uses: 'actions/checkout@v6'
+        with:
+          fetch-depth: 0
+      - name: 'setup just and uv'
+        uses: './.github/actions/setup-just-and-uv'
+        with:
+          python-version: '3.12'
+      - name: 'create release'
+        run: 'just release --create'
+        env:
+          GH_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+          UV_PYTHON_VERSION: '3.12'
+  deploy-docs:
+    name: 'deploy release docs'
+    needs:
+      - 'create-github-release'
+    if: >-
+      ${{
+        github.event.inputs.deploy-docs == 'true' &&
+        needs.create-github-release.result == 'success'
+      }}
+    permissions:
+      contents: 'write'
+    uses: './.github/workflows/gh-pages.yaml'
+    with:
+      deploy-mode: 'release'
+    secrets: 'inherit'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add "binding" to `SystemABC` objects to convert fully generic signature to a simulation needs-specific signature.
 - Introduced the axis concept as a way to represent aligned shapes across parameters, systems, etc. Added two kinds of axes, categorical and continuous, to represent different kinds of dimensions. Also added an `axes` top level key to the `ConfigurationModel` so users can provide these axes via configuration, but setting this currently results in a warning since it has no effect. See [#147](https://github.com/ACCIDDA/flepimop2/issues/147).
 - Refactor `SystemABC` type approach to binding (and fix knock on mypy typing issues, circular dependency issues). Briefly, a `SystemABC` implementation now only needs to provide `_bind_impl` which fixes (or not) parameters in the system. This update adds another internal implementation (`AdapterSystem`) for directly creating a system from locally `def`d function (vs `WrapperSystem` which reads from a file).
+- Added infrastructure for submitting package to PyPI. See [#123](https://github.com/ACCIDDA/flepimop2/issues/123), [#142](https://github.com/ACCIDDA/flepimop2/issues/142), [#195](https://github.com/ACCIDDA/flepimop2/issues/195), [#196](https://github.com/ACCIDDA/flepimop2/issues/196).
 
 ### Changed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,6 +133,20 @@ To preview documentation changes locally you can run `just serve` which will bui
 
 In addition to unit tests and doctests, code contained in the documentation is also tested. This is run as a part of pytest-based commands (`just test`, `just cov`, `just pytest`). Each documentation page is treated as if it were one script so code blocks can reference previously created variables. To support this type of testing we use [`Sybil`](https://sybil.readthedocs.io/en/latest/).
 
+## Packaging
+
+Packaging checks are available through the `build` recipe group:
+
+- `just build-check` - Build the source distribution and wheel, then run
+  `twine check --strict` on the generated artifacts.
+- `just build-test` - Build the wheel, install it into a clean-room virtual
+  environment, export the current development dependencies, and run the
+  non-integration test suite against the installed wheel.
+- `just build-all` - Run both `build-check` and `build-test`.
+
+These commands are useful when preparing a release or when making changes that
+could affect packaging metadata, installability, or build artifacts.
+
 ## Pull Request Process
 
 ### Before Submitting
@@ -144,6 +158,8 @@ In addition to unit tests and doctests, code contained in the documentation is a
 - `just docs` - Documentation build checks.
 
 In GitHub Actions, these correspond to the `quality`, `tests`, and `docs` jobs in `.github/workflows/ci.yaml`.
+
+The separate `package` job runs `just build-check` on Python 3.12.
 
 If you edit YAML files, also run `just yamllint`. YAML linting is separate from `just ci`.
 
@@ -165,6 +181,7 @@ If you edit YAML files, also run `just yamllint`. YAML linting is separate from 
 
 - Tests run in CI against Python 3.11, 3.12, 3.13, and 3.14.
 - Quality checks and documentation build checks run in CI on Python 3.12.
+- Package validation runs in CI on Python 3.12.
 - At least one maintainer approval is required before merging.
 - Branches must be up to date against `main` before merging and have a linear history. Only rebases are allowed for merging.
 

--- a/docs/development/creating-a-release.md
+++ b/docs/development/creating-a-release.md
@@ -1,0 +1,94 @@
+# Creating A Release
+
+This guide covers the `flepimop2` release process, from preparing the changelog to running the manual GitHub Actions release workflow.
+
+## Prerequisites
+
+- You have write access to the [`ACCIDDA/flepimop2`](https://github.com/ACCIDDA/flepimop2) repository.
+- The version has already been updated in `pyproject.toml`.
+- The release notes for that version have already been added to `CHANGELOG.md`.
+- Your local environment is synced with a supported Python version via `uv sync --python 3.12 --group dev`.
+- You have [GitHub's `gh` CLI](https://cli.github.com/) installed and authenticated.
+
+## 1. Format The Changelog
+
+The release workflow validates `CHANGELOG.md` using `scripts/release.py`, so the changelog format must match what that script expects.
+
+For a release, the top section of `CHANGELOG.md` must:
+
+- Not contain a `## [Unreleased]` heading.
+- Start with a heading in the form `## [X.Y.Z] - YYYY-MM-DD`.
+- Use the current release version and the current date.
+- Contain at least one non-empty bullet point.
+
+Example:
+
+```md
+## [0.1.0] - 2026-04-07
+
+### Added
+
+- Added packaging validation and release workflow infrastructure.
+```
+
+If the top heading, date, or bullet formatting is wrong, `just release-check` and the release workflow will fail before anything is published.
+
+## 2. Run The Local Release Preflight
+
+Use the `just release-validate` recipe to run the following checks locally:
+
+- `build-check`: Build the source distribution and wheel, then run `twine check --strict` on the generated artifacts.
+- `build-test`: Build the wheel, install it into a clean virtual environment, install the current development dependency set exported from `uv`, and run the non-integration test suite against the installed wheel.
+- `release-check`: Run `uv run python scripts/release.py` without `--create` to ensure the `CHANGELOG.md` is formatted correctly and the version is releasable.
+
+## 3. Run The Release Workflow
+
+Releases are created through the manual GitHub Actions workflow in `.github/workflows/release.yaml`.
+
+If you are testing the workflow before the pull request is merged, add `--ref <branch-name>` to the `gh workflow run` command. Without `--ref`, GitHub dispatches the workflow definition from the repository's default branch. Using `--ref <branch-name>` means the workflow validates, builds, and publishes artifacts from that branch rather than from `main`.
+
+### Dry Run
+
+Use this to validate the release end to end without publishing to TestPyPI, creating a GitHub release, or deploying docs:
+
+```shell
+gh workflow run release.yaml \
+  --repo ACCIDDA/flepimop2 \
+  --ref <branch-name> \
+  --field publish-target=none \
+  --field create-github-release=false \
+  --field deploy-docs=false
+```
+
+This runs the `validate` job only. It still enforces the changelog and release metadata checks through `just release-validate`.
+
+### TestPyPI
+
+Use this to publish the built artifacts to TestPyPI without creating the GitHub release or deploying docs:
+
+```shell
+gh workflow run release.yaml \
+  --repo ACCIDDA/flepimop2 \
+  --ref <branch-name> \
+  --field publish-target=testpypi \
+  --field create-github-release=false \
+  --field deploy-docs=false
+```
+
+This is the safest way to test the release workflow against a real package index before publishing to PyPI.
+
+When testing from a branch, keep `create-github-release=false` and `deploy-docs=false`. The documentation deployment workflow checks out `main`, so it is not intended for pre-merge branch testing.
+
+### PyPI
+
+If `publish-target=pypi` is selected, the workflow intentionally fails early. That option is present to preserve the future workflow shape, but real PyPI publication is not enabled for `flepimop2` yet.
+
+## 4. Trusted Publishing Setup
+
+The TestPyPI publish job uses PyPI Trusted Publishing rather than a stored API token. To enable publishing to TestPyPI, configure the trusted publisher entry for:
+
+- Owner: `ACCIDDA`.
+- Repository: `flepimop2`.
+- Workflow file: `release.yaml`.
+
+If that configuration is missing, the TestPyPI publish job will fail even if validation passes.

--- a/justfile
+++ b/justfile
@@ -46,6 +46,7 @@ mypy:
 clean:
     rm -rf .*cache
     rm -rf .venv
+    rm -rf dist
     rm -rf site
     rm -f uv.lock
 
@@ -78,6 +79,42 @@ docs: reference
 serve: reference
     uv run mkdocs serve --livereload
 
+# Build sdist and wheel, then validate package metadata
+[unix]
+[group('build')]
+build-check:
+    rm -rf dist/
+    uv run python -m build
+    uv run python -m twine check --strict dist/*
+
+# Install the built wheel into a clean room and run non-integration tests
+[unix]
+[group('build')]
+build-test:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    CLEANROOM="$(mktemp -d)"
+    HAD_LOCK='false'
+    if [ -f uv.lock ]; then
+        HAD_LOCK='true'
+    fi
+    trap 'rm -rf "${CLEANROOM}"; if [ "${HAD_LOCK}" = "false" ]; then rm -f uv.lock; fi' EXIT
+    uv lock --python "${UV_PYTHON_VERSION:-3.12}"
+    uv export --frozen --only-group dev --no-emit-project --format requirements.txt --no-hashes --output-file "${CLEANROOM}/dev-requirements.txt" >/dev/null
+    uv run python -m build --wheel --outdir "${CLEANROOM}/dist"
+    uv venv --python "${UV_PYTHON_VERSION:-3.12}" "${CLEANROOM}/venv"
+    uv pip install --python "${CLEANROOM}/venv/bin/python" "${CLEANROOM}"/dist/*.whl
+    uv pip install --python "${CLEANROOM}/venv/bin/python" -r "${CLEANROOM}/dev-requirements.txt"
+    cp pyproject.toml "${CLEANROOM}/pyproject.toml"
+    cp -R tests "${CLEANROOM}/tests"
+    cp conftest.py "${CLEANROOM}/conftest.py"
+    cd "${CLEANROOM}"
+    "${CLEANROOM}/venv/bin/pytest" --import-mode=importlib tests --quiet --exitfirst -m "not integration"
+
+# Run all package build validations
+[group('build')]
+build-all: build-check build-test
+
 # Lint YAML files using `yamllint`
 [group('lint')]
 yamllint:
@@ -107,3 +144,17 @@ changelog:
         exit 1
     fi
     echo "CHANGELOG.md check passed"
+
+# Validate release metadata without creating a GitHub release
+[group('release')]
+release-check:
+    uv run python scripts/release.py
+
+# Create the GitHub release after all checks pass
+[group('release')]
+release +FLAGS='':
+    uv run python scripts/release.py {{FLAGS}}
+
+# Run the full local release preflight
+[group('release')]
+release-validate: build-all release-check

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -74,6 +74,7 @@ nav:
       - Implementing Custom Engines and Systems: development/implementing-custom-engines-and-systems.md
       - Integration Testing: development/integration-testing.md
       - Adding A New CLI Command: development/adding-a-new-cli-command.md
+      - Creating A Release: development/creating-a-release.md
   - Reference:
       - API:
           - Abcs: reference/api/abcs.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ build-backend = "hatchling.build"
 
 [dependency-groups]
 dev = [
+    "build>=1.4.2",
     "mike>=2.1.3",
     "mkdocs>=1.6.1",
     "mkdocs-autorefs>=1.4.3",
@@ -55,6 +56,7 @@ dev = [
     "scipy>=1.17.0",
     "scipy-stubs>=1.17.0.2",
     "sybil[pytest]>=9.2.0",
+    "twine>=6.2.0",
     "types-pyyaml>=6.0.12.20250915",
     "yamllint>=1.37.1",
 ]
@@ -132,6 +134,16 @@ strict = true
 [tool.hatch.build.targets.wheel]
 packages = ["src/flepimop2"]
 include = ["src/flepimop2/templates"]
+
+[tool.hatch.build.targets.sdist]
+include = [
+    "src/flepimop2",
+    "CHANGELOG.md",
+    "CONTRIBUTING.md",
+    "LICENSE",
+    "README.md",
+    "pyproject.toml",
+]
 
 [tool.coverage.report]
 fail_under = 75

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1,0 +1,307 @@
+"""Validate release readiness and create a GitHub release."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import shutil
+import subprocess  # noqa: S404
+import sys
+import tempfile
+import tomllib
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Final, Literal
+from zoneinfo import ZoneInfo
+
+from pydantic import TypeAdapter
+
+REPO_ROOT: Final[Path] = Path(__file__).resolve().parents[1]
+SEMVER_PATTERN: Final[re.Pattern[str]] = re.compile(r"^(\d+)\.(\d+)\.(\d+)$")
+GH_RELEASE_LIST_TYPE: Final[TypeAdapter[list[dict[Literal["tagName"], str]]]] = (
+    TypeAdapter(list[dict[Literal["tagName"], str]])
+)
+
+
+@dataclass(frozen=True, order=True)
+class SemVer:
+    """Semantic version container."""
+
+    major: int
+    minor: int
+    patch: int
+
+    @classmethod
+    def parse(cls, raw: str) -> SemVer:
+        """
+        Parse a semantic version string.
+
+        Args:
+            raw: The semantic version string to parse.
+
+        Returns:
+            The parsed semantic version.
+
+        Raises:
+            ValueError: If `raw` is not a valid `X.Y.Z` semantic version string.
+        """
+        match = SEMVER_PATTERN.fullmatch(raw)
+        if match is None:
+            msg = f"Invalid semantic version: {raw!r}."
+            raise ValueError(msg)
+        major, minor, patch = (int(part) for part in match.groups())
+        return cls(major=major, minor=minor, patch=patch)
+
+    def __str__(self) -> str:
+        """
+        Format semantic version.
+
+        Returns:
+            The semantic version formatted as `X.Y.Z`.
+        """
+        return f"{self.major}.{self.minor}.{self.patch}"
+
+    def is_next_increment_from(self, previous: SemVer) -> bool:
+        """Return whether this version is the next semantic increment."""
+        is_patch = (
+            self.major == previous.major
+            and self.minor == previous.minor
+            and self.patch == previous.patch + 1
+        )
+        is_minor = (
+            self.major == previous.major
+            and self.minor == previous.minor + 1
+            and self.patch == 0
+        )
+        is_major = (
+            self.major == previous.major + 1 and self.minor == 0 and self.patch == 0
+        )
+        return is_patch or is_minor or is_major
+
+
+def get_gh_bin() -> str:
+    """
+    Resolve the GitHub CLI path or raise if unavailable.
+
+    Returns:
+        The path to the `gh` executable.
+
+    Raises:
+        FileNotFoundError: If `gh` is not available on `PATH`.
+    """
+    gh_bin = shutil.which("gh")
+    if gh_bin is None:
+        msg = "GitHub CLI (`gh`) not found on PATH."
+        raise FileNotFoundError(msg)
+    return gh_bin
+
+
+def get_version() -> SemVer:
+    """
+    Read and validate the project version from pyproject.toml.
+
+    Returns:
+        The parsed project semantic version.
+    """
+    pyproject = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text())
+    return SemVer.parse(str(pyproject["project"]["version"]))
+
+
+def collapse_bullet_lines(lines: list[str]) -> list[str]:
+    """
+    Collapse wrapped markdown bullet text to one line per bullet.
+
+    Bullet indentation is preserved to maintain nesting levels.
+
+    Args:
+        lines: The raw changelog lines to normalize.
+
+    Returns:
+        The normalized lines with multi-line bullets collapsed.
+    """
+    collapsed: list[str] = []
+    bullet_prefix: str | None = None
+    bullet_parts: list[str] = []
+
+    def flush_bullet() -> None:
+        nonlocal bullet_prefix, bullet_parts
+        if bullet_prefix is None:
+            return
+        joined = " ".join(part for part in bullet_parts if part).strip()
+        collapsed.append(
+            f"{bullet_prefix}{joined}" if joined else bullet_prefix.rstrip()
+        )
+        bullet_prefix = None
+        bullet_parts = []
+
+    for line in lines:
+        bullet_match = re.match(r"^(?P<indent>\s*)-\s+(?P<text>.*)$", line)
+        if bullet_match is not None:
+            flush_bullet()
+            bullet_prefix = f"{bullet_match.group('indent')}- "
+            bullet_parts = [bullet_match.group("text").strip()]
+            continue
+        if bullet_prefix is None:
+            collapsed.append(line)
+            continue
+        stripped = line.strip()
+        if not stripped:
+            flush_bullet()
+            collapsed.append(line)
+            continue
+        bullet_parts.append(stripped)
+
+    flush_bullet()
+    return collapsed
+
+
+def validate_and_extract_changelog_section(
+    version: SemVer, *, create: bool = False
+) -> str:
+    """
+    Validate changelog format and return release notes for the current version.
+
+    Args:
+        version: The release version expected at the top of the changelog.
+        create: Whether the caller is creating a release instead of doing a dry run.
+
+    Returns:
+        The validated release notes body for the current version.
+
+    Raises:
+        ValueError: If the changelog headings, date, or release notes are invalid.
+    """
+    changelog_lines = (REPO_ROOT / "CHANGELOG.md").read_text().splitlines()
+
+    h2_headings = [line for line in changelog_lines if line.startswith("## ")]
+    if not h2_headings:
+        msg = "CHANGELOG.md must contain at least one level-2 release heading."
+        raise ValueError(msg)
+
+    if any(h.lower() == "## [unreleased]" for h in h2_headings):
+        msg = "CHANGELOG.md must not contain a `## [Unreleased]` heading."
+        raise ValueError(msg)
+
+    today = datetime.now(ZoneInfo("America/New_York")).date().isoformat()
+    expected_heading = f"## [{version}] - {today}"
+    if h2_headings[0] != expected_heading:
+        msg = (
+            "Top CHANGELOG.md heading must match current version and today's date: "
+            f"`{expected_heading}`."
+        )
+        raise ValueError(msg)
+
+    header_idx = changelog_lines.index(expected_heading)
+    section_lines: list[str] = []
+    for line in changelog_lines[header_idx + 1 :]:
+        if line.startswith("## "):
+            break
+        stripped = line.strip()
+        if stripped.startswith("-") and re.search(r"[A-Za-z0-9]", stripped) is None:
+            msg = f"Invalid changelog bullet point: {line!r}."
+            raise ValueError(msg)
+        section_lines.append(line)
+    notes = "\n".join(collapse_bullet_lines(section_lines)).strip()
+    if not notes:
+        msg = f"CHANGELOG section for {version} is empty."
+        raise ValueError(msg)
+    if not create:
+        sys.stdout.write(
+            f"Extracted release notes for version {version}:\n\n{notes}\n\n"
+        )
+
+    return notes
+
+
+def validate_release_state(version: SemVer) -> None:
+    """
+    Validate version state against existing GitHub releases.
+
+    Args:
+        version: The version being prepared for release.
+
+    Raises:
+        ValueError: If the version already exists or is not the next increment.
+    """
+    proc = subprocess.run(  # noqa: S603
+        [
+            get_gh_bin(),
+            "release",
+            "list",
+            "--json",
+            "tagName",
+            "--limit",
+            "1",
+            "--order",
+            "desc",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    releases = GH_RELEASE_LIST_TYPE.validate_json(proc.stdout)
+    if not releases:
+        return
+    latest_tag = str(releases[0]["tagName"])
+    latest_version_raw = latest_tag.removeprefix("v")
+    latest_version = SemVer.parse(latest_version_raw)
+    if version == latest_version:
+        msg = f"Version {version} already exists as a GitHub release ({latest_tag})."
+        raise ValueError(msg)
+    if not version.is_next_increment_from(latest_version):
+        msg = (
+            "Current version must be the next semantic increment from the latest "
+            f"release. current={version}, latest={latest_version}."
+        )
+        raise ValueError(msg)
+
+
+def create_release(version: SemVer, notes: str, *, create: bool = False) -> None:
+    """Create GitHub release using gh CLI."""
+    tag = f"v{version}"
+    with tempfile.NamedTemporaryFile(
+        mode="w",
+        encoding="utf-8",
+        suffix=".md",
+        prefix="flepimop2-release-notes-",
+        delete=False,
+    ) as temp_file:
+        temp_file.write(notes)
+        temp_file.close()
+        command = [
+            get_gh_bin(),
+            "release",
+            "create",
+            tag,
+            "--title",
+            tag,
+            "--notes-file",
+            temp_file.name,
+        ]
+        if version.major == 0:
+            command.append("--prerelease")
+        if create:
+            subprocess.run(command, check=True)  # noqa: S603
+            return
+        sys.stdout.write(f"Dry run of GitHub release command: {' '.join(command)}")
+
+
+def main() -> None:
+    """Run release checks and optionally create the release."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--create",
+        action="store_true",
+        help="Create the GitHub release after all checks pass.",
+    )
+    args = parser.parse_args()
+
+    version = get_version()
+    validate_release_state(version)
+    notes = validate_and_extract_changelog_section(version, create=args.create)
+    create_release(version, notes, create=args.create)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adopted release/pypi submission infrastructure from `ACCIDDA/vaxflux`, `yoavram-lab/VBPCApy`.

- Added `build`, `twine` as dev dependencies.
- Added recipes to `justfile` for building and checking the package and incorporated those into CI via `ci.yaml`.
- Added `scripts/release.py` helper script to check the formatting of the `CHANGELOG.md` file and create a GitHub release.
- Added `release.yaml` workflow for checking the package before submission, uploading to PyPI, creating a GitHub release, and updating the docs site. Updated `gh-pages.yaml` to accommodate.
- Added documentation to include a "Creating A Release" guide for the maintainers of `flepimop2`.

Currently the `release.yaml` workflow will fail when attempting to submit the package to PyPI. This is a temporary guardrail until #120 and #127 are resolved.

Closes #123. Closes #142. Closes #195. Closes #196.