### PR TITLE
Add `flepimop2.axis` module for realized axes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- ...
+- Introduced the axis concept as a way to represent aligned shapes across parameters, systems, etc. Added two kinds of axes, categorical and continuous, to represent different kinds of dimensions. Also added an `axes` top level key to the `ConfigurationModel` so users can provide these axes via configuration and `flepimop2.axis` module for realizing & manipulating axes from configuration. See [#147](https://github.com/ACCIDDA/flepimop2/issues/147).
 
 ### Changed
 
@@ -62,7 +62,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `flepimop.testing` with functionality for integration testing, both for `flepimop2` itself and for external provider packages. See [#107](https://github.com/ACCIDDA/flepimop2/issues/107).
 - Added a parent class, `ModuleABC`, for all customizable modules that sets a required `module` attribute and provides infrastructure for non-standardized properties information. Also extended said infrastructure to allow for standardized property information for `SystemABC`. See [#113](https://github.com/ACCIDDA/flepimop2/issues/113), [#126](https://github.com/ACCIDDA/flepimop2/issues/126), [#129](https://github.com/ACCIDDA/flepimop2/discussions/129).
 - Add "binding" to `SystemABC` objects to convert fully generic signature to a simulation needs-specific signature.
-- Introduced the axis concept as a way to represent aligned shapes across parameters, systems, etc. Added two kinds of axes, categorical and continuous, to represent different kinds of dimensions. Also added an `axes` top level key to the `ConfigurationModel` so users can provide these axes via configuration, but setting this currently results in a warning since it has no effect. See [#147](https://github.com/ACCIDDA/flepimop2/issues/147).
 - Refactor `SystemABC` type approach to binding (and fix knock on mypy typing issues, circular dependency issues). Briefly, a `SystemABC` implementation now only needs to provide `_bind_impl` which fixes (or not) parameters in the system. This update adds another internal implementation (`AdapterSystem`) for directly creating a system from locally `def`d function (vs `WrapperSystem` which reads from a file).
 - Added infrastructure for submitting package to PyPI. See [#123](https://github.com/ACCIDDA/flepimop2/issues/123), [#142](https://github.com/ACCIDDA/flepimop2/issues/142), [#195](https://github.com/ACCIDDA/flepimop2/issues/195), [#196](https://github.com/ACCIDDA/flepimop2/issues/196).
 - Modules can now declare their name via the `module` keyword argument to class declaration to simplify naming for developers. See [#88](https://github.com/ACCIDDA/flepimop2/issues/88).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -84,6 +84,7 @@ nav:
   - Reference:
       - API:
           - Abcs: reference/api/abcs.md
+          - Axis: reference/api/axis.md
           - Backend: reference/api/backend.md
           - Configuration: reference/api/configuration.md
           - Engine: reference/api/engine.md

--- a/src/flepimop2/axis.py
+++ b/src/flepimop2/axis.py
@@ -1,0 +1,414 @@
+# flepimop2: The FLExible Pipeline for Interchangeable MOdel Processing
+# Copyright (C) 2026  Carl Pearson, Joshua Macdonald, Timothy Willard
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Runtime axis types and helpers."""
+
+__all__ = ["Axis", "AxisCollection", "ResolvedAxisConfig", "ResolvedShape"]
+
+from collections.abc import Iterator, Mapping, Sequence
+from dataclasses import dataclass
+from itertools import pairwise
+from typing import Literal, TypeVar, overload
+
+import numpy as np
+from pydantic import TypeAdapter
+
+from flepimop2.configuration._axes import (
+    AxesGroupModel,
+    CategoricalAxisModel,
+    ContinuousAxisModel,
+)
+from flepimop2.typing import IdentifierString
+
+ResolvedAxisConfig = (
+    AxesGroupModel | Mapping[IdentifierString, object] | dict[IdentifierString, object]
+)
+T = TypeVar("T")
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvedShape:
+    """A named runtime shape resolved against a concrete axis collection."""
+
+    axis_names: tuple[IdentifierString, ...] = ()
+    sizes: tuple[int, ...] = ()
+
+    def __post_init__(self) -> None:
+        """
+        Validate the number of axis names and sizes match.
+
+        Raises:
+            ValueError: If `axis_names` and `sizes` do not have matching lengths.
+
+        Examples:
+            >>> from flepimop2.axis import ResolvedShape
+            >>> ResolvedShape(axis_names=("age", "time"), sizes=(3, 4))
+            ResolvedShape(axis_names=('age', 'time'), sizes=(3, 4))
+            >>> ResolvedShape(axis_names=("age",), sizes=(3, 4))
+            Traceback (most recent call last):
+                ...
+            ValueError: ResolvedShape axis_names and sizes must have matching lengths; got 1 names and 2 sizes.
+        """  # noqa: E501
+        if len(self.axis_names) != len(self.sizes):
+            msg = (
+                "ResolvedShape axis_names and sizes must have matching lengths; "
+                f"got {len(self.axis_names)} names and {len(self.sizes)} sizes."
+            )
+            raise ValueError(msg)
+
+
+@dataclass(frozen=True, slots=True)
+class Axis:
+    """
+    Resolved Runtime Axis.
+
+    Describe one named axis after configuration has been validated and converted
+    into runtime metadata.
+
+    Attributes:
+        name: Stable axis name used by systems and parameters.
+        kind: Whether the axis is continuous or categorical.
+        size: Number of positions along the axis.
+        labels: Optional labels for categorical axes.
+        values: Optional integer values associated with categorical labels.
+        domain: Closed numeric domain for continuous axes.
+        spacing: Spacing rule for continuous axes.
+
+    Notes:
+        Continuous axes intentionally support both point-style and bin-style
+        calculations. The same axis can expose representative points via
+        `points()` and intervals via `bins()`, so systems and parameters can use
+        whichever view is appropriate without introducing incompatible axis
+        definitions.
+    """
+
+    name: IdentifierString
+    kind: Literal["continuous", "categorical"]
+    size: int
+    labels: tuple[str, ...] | None = None
+    values: tuple[int, ...] | None = None
+    domain: tuple[float, float] | None = None
+    spacing: Literal["linear", "log"] | None = None
+
+    def _continuous_domain(self) -> tuple[float, float]:
+        """
+        Validate Continuous Axis Metadata.
+
+        Ensure this axis can support continuous point and bin helpers.
+
+        Returns:
+            The continuous axis domain as `(lower, upper)`.
+
+        Raises:
+            TypeError: If this is not a continuous axis.
+            ValueError: If the continuous axis is missing domain or spacing
+                metadata.
+
+        Examples:
+            >>> from flepimop2.axis import Axis
+            >>> axis = Axis(
+            ...     name="time",
+            ...     kind="continuous",
+            ...     size=4,
+            ...     domain=(0.0, 8.0),
+            ...     spacing="linear",
+            ... )
+            >>> axis._continuous_domain()
+            (0.0, 8.0)
+            >>> Axis(name="age", kind="categorical", size=2)._continuous_domain()
+            Traceback (most recent call last):
+                ...
+            TypeError: Axis 'age' is 'categorical'; only continuous axes support point and bin helpers.
+            >>> Axis(
+            ...     name="time",
+            ...     kind="continuous",
+            ...     size=4,
+            ... )._continuous_domain()
+            Traceback (most recent call last):
+                ...
+            ValueError: Continuous axis 'time' must define both domain and spacing to derive point or bin helpers.
+        """  # noqa: E501
+        if self.kind != "continuous":
+            msg = (
+                f"Axis '{self.name}' is {self.kind!r}; only continuous axes "
+                "support point and bin helpers."
+            )
+            raise TypeError(msg)
+        if self.domain is None or self.spacing is None:
+            msg = (
+                f"Continuous axis '{self.name}' must define both domain and "
+                "spacing to derive point or bin helpers."
+            )
+            raise ValueError(msg)
+        return self.domain
+
+    def bin_edges(self) -> tuple[float, ...]:
+        """
+        Continuous Bin Edges.
+
+        Partition a continuous axis domain into `size` bins.
+
+        Returns:
+            The bin-edge coordinates with length `size + 1`.
+
+        Notes:
+            Linear axes use `np.linspace(lower, upper, size + 1)`. Log axes use
+            `np.geomspace(lower, upper, size + 1)`.
+
+        Examples:
+            >>> from flepimop2.axis import Axis
+            >>> axis = Axis(
+            ...     name="time",
+            ...     kind="continuous",
+            ...     size=4,
+            ...     domain=(0.0, 8.0),
+            ...     spacing="linear",
+            ... )
+            >>> axis.bin_edges()
+            (0.0, 2.0, 4.0, 6.0, 8.0)
+        """
+        lo, hi = self._continuous_domain()
+        if self.spacing == "linear":
+            edges = np.linspace(lo, hi, self.size + 1, dtype=np.float64)
+        else:
+            edges = np.geomspace(lo, hi, self.size + 1, dtype=np.float64)
+        return tuple(edges.tolist())
+
+    def bins(self) -> tuple[tuple[float, float], ...]:
+        """
+        Continuous Bin Intervals.
+
+        Return half-open-style interval metadata for each continuous bin.
+
+        Returns:
+            A tuple of `(lower, upper)` bin intervals with length `size`.
+
+        Examples:
+            >>> from flepimop2.axis import Axis
+            >>> axis = Axis(
+            ...     name="time",
+            ...     kind="continuous",
+            ...     size=2,
+            ...     domain=(0.0, 4.0),
+            ...     spacing="linear",
+            ... )
+            >>> axis.bins()
+            ((0.0, 2.0), (2.0, 4.0))
+        """
+        self._continuous_domain()
+        edges = self.bin_edges()
+        return tuple(pairwise(edges))
+
+    def points(self) -> tuple[float, ...]:
+        """
+        Representative Continuous Points.
+
+        Return one representative point for each continuous bin.
+
+        Returns:
+            A tuple of representative point coordinates with length `size`.
+
+        Notes:
+            Points are the centroids of the bins returned by
+            [Axis.bins][flepimop2.axis.Axis.bins], arithmetic midpoints for linear
+            spacing and geometric means for log spacing.
+
+        Examples:
+            >>> from pprint import pp
+            >>> from flepimop2.axis import Axis
+            >>> Axis(
+            ...     name="time",
+            ...     kind="continuous",
+            ...     size=4,
+            ...     domain=(0.0, 8.0),
+            ...     spacing="linear",
+            ... ).points()
+            (1.0, 3.0, 5.0, 7.0)
+            >>> pp(
+            ...     Axis(
+            ...         name="time",
+            ...         kind="continuous",
+            ...         size=4,
+            ...         domain=(1e-9, 1e-3),
+            ...         spacing="log",
+            ...     ).points()
+            ... )
+            (5.623413251903491e-09,
+             1.7782794100389227e-07,
+             5.623413251903491e-06,
+             0.0001778279410038923)
+        """
+        lo, hi = self._continuous_domain()
+        if self.spacing == "linear":
+            edges = np.linspace(lo, hi, self.size + 1, dtype=np.float64)
+            points = 0.5 * (edges[:-1] + edges[1:])
+        else:
+            edges = np.geomspace(lo, hi, self.size + 1, dtype=np.float64)
+            points = np.sqrt(edges[:-1] * edges[1:])
+        return tuple(points.tolist())
+
+    @classmethod
+    def from_model(
+        cls,
+        name: IdentifierString,
+        model: ContinuousAxisModel | CategoricalAxisModel,
+    ) -> "Axis":
+        """
+        Build an `Axis` from a configuration model.
+
+        Returns:
+            The resolved runtime axis.
+        """
+        if isinstance(model, ContinuousAxisModel):
+            return cls(
+                name=name,
+                kind=model.kind,
+                size=model.size,
+                domain=model.domain,
+                spacing=model.spacing,
+            )
+        return cls(
+            name=name,
+            kind=model.kind,
+            size=len(model.labels),
+            labels=model.labels,
+            values=model.values,
+        )
+
+
+class AxisCollection(Mapping[IdentifierString, Axis]):
+    """
+    Runtime Axis Collection.
+
+    Store resolved axes and provide lookup and named-shape helpers for systems,
+    parameters, and engines.
+
+    Notes:
+        `AxisCollection` is the runtime entry point for working with named axes.
+        Systems typically use it to resolve requested parameter shapes, while
+        parameter modules use it to interpret declared axis names and inspect
+        axis metadata such as labels or bin edges.
+
+    Examples:
+        >>> from flepimop2.axis import AxisCollection
+        >>> axes = AxisCollection.from_config({
+        ...     "age": {
+        ...         "kind": "categorical",
+        ...         "labels": ["age0_17", "age18_64", "age65_plus"],
+        ...     },
+        ...     "time": {
+        ...         "kind": "continuous",
+        ...         "domain": (0.0, 12.0),
+        ...         "size": 4,
+        ...     },
+        ... })
+        >>> axes.size("age")
+        3
+        >>> axes["age"].labels
+        ('age0_17', 'age18_64', 'age65_plus')
+        >>> axes["time"].bin_edges()
+        (0.0, 3.0, 6.0, 9.0, 12.0)
+        >>> axes.resolve_shape(("age", "time")).sizes
+        (3, 4)
+        >>> axes.resolve_shape(("region",))
+        Traceback (most recent call last):
+            ...
+        KeyError: "Unknown axis names requested: ('region',)."
+    """
+
+    def __init__(self, axes: Mapping[IdentifierString, Axis] | None = None) -> None:
+        """Initialize the collection with an optional axis mapping."""
+        self._axes = dict(axes or {})
+
+    @classmethod
+    def from_config(cls, config: ResolvedAxisConfig) -> "AxisCollection":
+        """
+        Construct a runtime axis collection from configuration data.
+
+        Returns:
+            The resolved runtime axis collection.
+        """
+        validated = TypeAdapter(AxesGroupModel).validate_python(config)
+        return cls({
+            name: Axis.from_model(name, axis) for name, axis in validated.items()
+        })
+
+    def __getitem__(self, key: IdentifierString) -> Axis:
+        """Return the axis for a given name."""
+        return self._axes[key]
+
+    def __iter__(self) -> Iterator[IdentifierString]:
+        """
+        Iterate over axis names in the collection.
+
+        Returns:
+            An iterator over axis names.
+        """
+        return iter(self._axes)
+
+    def __len__(self) -> int:
+        """Return the number of axes in the collection."""
+        return len(self._axes)
+
+    @overload
+    def get(self, name: IdentifierString, /) -> Axis | None: ...
+
+    @overload
+    def get(self, name: IdentifierString, /, default: Axis) -> Axis: ...
+
+    @overload
+    def get(self, name: IdentifierString, /, default: T) -> Axis | T: ...
+
+    def get(
+        self, name: IdentifierString, /, default: T | None = None
+    ) -> Axis | T | None:
+        """
+        Return a named axis, optionally providing a default.
+
+        Returns:
+            The resolved axis, or the provided default when missing.
+        """
+        return self._axes.get(name, default)
+
+    def size(self, name: IdentifierString) -> int:
+        """Return the size for a named axis."""
+        return self[name].size
+
+    def sizes(self, *names: IdentifierString) -> tuple[int, ...]:
+        """Return the sizes for a sequence of named axes."""
+        return tuple(self.size(name) for name in names)
+
+    def resolve_shape(self, axis_names: Sequence[IdentifierString]) -> ResolvedShape:
+        """
+        Resolve a tuple of axis names into concrete dimension sizes.
+
+        Returns:
+            The resolved named shape.
+        """
+        names = tuple(axis_names)
+        self._validate_axis_names(names)
+        return ResolvedShape(axis_names=names, sizes=self.sizes(*names))
+
+    def _validate_axis_names(self, axis_names: Sequence[IdentifierString]) -> None:
+        """
+        Validate that each named axis exists in the collection.
+
+        Raises:
+            KeyError: If any requested axis name does not exist.
+        """
+        missing = tuple(name for name in axis_names if name not in self._axes)
+        if missing:
+            msg = f"Unknown axis names requested: {missing}."
+            raise KeyError(msg)

--- a/src/flepimop2/configuration/_configuration.py
+++ b/src/flepimop2/configuration/_configuration.py
@@ -45,13 +45,7 @@ class ConfigurationModel(
     """
 
     name: str | None = None
-    axes: AxesGroupModel = Field(
-        default_factory=dict,
-        deprecated=(
-            "'axes' is currently under development and has "
-            "no effect on the configuration right now."
-        ),
-    )
+    axes: AxesGroupModel = Field(default_factory=dict)
     engines: ModuleGroupModel = Field(default_factory=dict)
     systems: ModuleGroupModel = Field(default_factory=dict)
     backends: ModuleGroupModel = Field(default_factory=dict)

--- a/tests/axis/test_axis_class.py
+++ b/tests/axis/test_axis_class.py
@@ -1,0 +1,90 @@
+# flepimop2: The FLExible Pipeline for Interchangeable MOdel Processing
+# Copyright (C) 2026  Carl Pearson, Joshua Macdonald, Timothy Willard
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Tests for `Axis` runtime behavior."""
+
+import pytest
+
+from flepimop2.axis import Axis
+
+
+@pytest.mark.parametrize(
+    ("axis", "expected_edges", "expected_bins", "expected_points"),
+    [
+        (
+            Axis(
+                name="time",
+                kind="continuous",
+                size=4,
+                domain=(0.0, 10.0),
+                spacing="linear",
+            ),
+            (0.0, 2.5, 5.0, 7.5, 10.0),
+            ((0.0, 2.5), (2.5, 5.0), (5.0, 7.5), (7.5, 10.0)),
+            (1.25, 3.75, 6.25, 8.75),
+        ),
+        (
+            Axis(
+                name="r_eff",
+                kind="continuous",
+                size=4,
+                domain=(-2.0, 2.0),
+                spacing="linear",
+            ),
+            (-2.0, -1.0, 0.0, 1.0, 2.0),
+            ((-2.0, -1.0), (-1.0, 0.0), (0.0, 1.0), (1.0, 2.0)),
+            (-1.5, -0.5, 0.5, 1.5),
+        ),
+        (
+            Axis(
+                name="viral_load",
+                kind="continuous",
+                size=3,
+                domain=(1.0, 1000.0),
+                spacing="log",
+            ),
+            pytest.approx((1.0, 10.0, 100.0, 1000.0)),
+            (
+                pytest.approx((1.0, 10.0)),
+                pytest.approx((10.0, 100.0)),
+                pytest.approx((100.0, 1000.0)),
+            ),
+            pytest.approx((3.16227766, 31.6227766, 316.22776602)),
+        ),
+    ],
+)
+def test_continuous_axis_supports_helpers(
+    axis: Axis,
+    expected_edges: tuple[float, ...],
+    expected_bins: tuple[tuple[float, float], ...],
+    expected_points: tuple[float, ...],
+) -> None:
+    """Continuous axes should expose consistent bin and point helpers."""
+    assert axis.bin_edges() == expected_edges
+    assert axis.bins() == expected_bins
+    assert axis.points() == expected_points
+
+
+def test_categorical_axis_rejects_continuous_helpers() -> None:
+    """Categorical axes should not expose continuous point/bin helpers."""
+    axis = Axis(
+        name="age",
+        kind="categorical",
+        size=3,
+        labels=("0-17", "18-64", "65+"),
+    )
+
+    with pytest.raises(TypeError):
+        axis.points()

--- a/tests/axis/test_axis_collection_class.py
+++ b/tests/axis/test_axis_collection_class.py
@@ -1,0 +1,203 @@
+# flepimop2: The FLExible Pipeline for Interchangeable MOdel Processing
+# Copyright (C) 2026  Carl Pearson, Joshua Macdonald, Timothy Willard
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Tests for `AxisCollection` runtime behavior."""
+
+from typing import Any
+
+import pytest
+
+from flepimop2.axis import Axis, AxisCollection, ResolvedShape
+
+
+@pytest.mark.parametrize(
+    ("config", "expected"),
+    [
+        (
+            {
+                "age": {
+                    "kind": "categorical",
+                    "labels": ["0-17", "18-64", "65+"],
+                },
+                "time": {
+                    "kind": "continuous",
+                    "domain": (0.0, 10.0),
+                    "size": 4,
+                },
+            },
+            {
+                "names": ("age", "time"),
+                "size_queries": ("age", "time"),
+                "sizes": (3, 4),
+                "label_query": "age",
+                "labels": ("0-17", "18-64", "65+"),
+            },
+        ),
+        (
+            {
+                "region": {
+                    "kind": "categorical",
+                    "labels": ["A", "B"],
+                },
+                "severity": {
+                    "kind": "categorical",
+                    "labels": ["low", "high"],
+                },
+            },
+            {
+                "names": ("region", "severity"),
+                "size_queries": ("region", "severity"),
+                "sizes": (2, 2),
+                "label_query": "region",
+                "labels": ("A", "B"),
+            },
+        ),
+    ],
+)
+def test_axis_collection_loads_axes_from_config(
+    config: dict[str, dict[str, Any]],
+    expected: dict[str, Any],
+) -> None:
+    """AxisCollection should preserve configured axis metadata."""
+    axes = AxisCollection.from_config(config)
+
+    expected_names = expected["names"]
+    size_queries = expected["size_queries"]
+    expected_sizes = expected["sizes"]
+    label_query = expected["label_query"]
+    expected_labels = expected["labels"]
+
+    assert isinstance(expected_names, tuple)
+    assert isinstance(size_queries, tuple)
+    assert isinstance(expected_sizes, tuple)
+    assert isinstance(label_query, str)
+    assert isinstance(expected_labels, tuple)
+
+    assert len(axes) == len(expected_names)
+    assert tuple(axes) == expected_names
+    assert axes.sizes(*size_queries) == expected_sizes
+    assert axes[label_query].labels == expected_labels
+
+
+@pytest.mark.parametrize(
+    ("axes", "axis_names", "expected_shape"),
+    [
+        (
+            AxisCollection({
+                "region": Axis(
+                    name="region",
+                    kind="categorical",
+                    size=2,
+                    labels=("A", "B"),
+                ),
+                "age": Axis(
+                    name="age",
+                    kind="categorical",
+                    size=3,
+                    labels=("0-17", "18-64", "65+"),
+                ),
+            }),
+            ("region", "age"),
+            ResolvedShape(axis_names=("region", "age"), sizes=(2, 3)),
+        ),
+        (
+            AxisCollection({
+                "time": Axis(
+                    name="time",
+                    kind="continuous",
+                    size=4,
+                    domain=(0.0, 8.0),
+                    spacing="linear",
+                ),
+            }),
+            ("time",),
+            ResolvedShape(axis_names=("time",), sizes=(4,)),
+        ),
+        (
+            AxisCollection({
+                "region": Axis(
+                    name="region",
+                    kind="categorical",
+                    size=2,
+                    labels=("A", "B"),
+                ),
+                "age": Axis(
+                    name="age",
+                    kind="categorical",
+                    size=3,
+                    labels=("0-17", "18-64", "65+"),
+                ),
+                "time": Axis(
+                    name="time",
+                    kind="continuous",
+                    size=5,
+                    domain=(0.0, 10.0),
+                    spacing="linear",
+                ),
+            }),
+            ("region", "age", "time"),
+            ResolvedShape(axis_names=("region", "age", "time"), sizes=(2, 3, 5)),
+        ),
+    ],
+)
+def test_axis_collection_resolves_named_shapes(
+    axes: AxisCollection,
+    axis_names: tuple[str, ...],
+    expected_shape: ResolvedShape,
+) -> None:
+    """AxisCollection should resolve axis names into a concrete named shape."""
+    assert axes.resolve_shape(axis_names) == expected_shape
+
+
+@pytest.mark.parametrize(
+    ("axes", "axis_names"),
+    [
+        (
+            AxisCollection({
+                "age": Axis(
+                    name="age",
+                    kind="categorical",
+                    size=3,
+                    labels=("0-17", "18-64", "65+"),
+                )
+            }),
+            ("region",),
+        ),
+        (
+            AxisCollection({
+                "region": Axis(
+                    name="region",
+                    kind="categorical",
+                    size=2,
+                    labels=("A", "B"),
+                ),
+                "age": Axis(
+                    name="age",
+                    kind="categorical",
+                    size=3,
+                    labels=("0-17", "18-64", "65+"),
+                ),
+            }),
+            ("region", "time"),
+        ),
+    ],
+)
+def test_axis_collection_rejects_unknown_axis_names(
+    axes: AxisCollection,
+    axis_names: tuple[str, ...],
+) -> None:
+    """AxisCollection should raise when asked to resolve unknown axes."""
+    with pytest.raises(KeyError, match="Unknown axis names requested"):
+        axes.resolve_shape(axis_names)


### PR DESCRIPTION
Added the `axis` module for realizing and manipulating axes from configuration. Includes:

- `ResolvedShape` as a container for metadata about the shape of an object based on its axes.
- `Axis` as a data class for a realized axis that objects which need axes can use to do their calculations.
- `AxisCollection` as a mapping of `Axis` objects that simplify access when multiple axes are needed.
- Dropped deprecation warning from using the `axes` attribute of `ConfigurationModel`.

Follow up to #147, #164.