### PR TITLE
Add structured containers for parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Introduced the axis concept as a way to represent aligned shapes across parameters, systems, etc. Added two kinds of axes, categorical and continuous, to represent different kinds of dimensions. Also added an `axes` top level key to the `ConfigurationModel` so users can provide these axes via configuration and `flepimop2.axis` module for realizing & manipulating axes from configuration. See [#147](https://github.com/ACCIDDA/flepimop2/issues/147).
+- Added ways to specify shape for parameters based on `axes` by changing `ParameterABC.sample` to return a `ParameterValue` that contains both the underlying value as a numpy array as well as shape metadata, and is easily extensible to other metadata and underlying value types in the future. Also added `ModelStateSpecification`, `ParameterRequest` types for systems to advertise their underlying state and request parameters to comply with said state specification, but yet to wire into `SystemABC`.
 
 ### Changed
 

--- a/src/flepimop2/parameter/abc/__init__.py
+++ b/src/flepimop2/parameter/abc/__init__.py
@@ -13,28 +13,278 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
-"""Abstract base class for parameters."""
+"""Abstract base class and runtime contracts for parameters."""
 
-__all__ = ["ParameterABC", "build"]
+__all__ = [
+    "ModelStateSpecification",
+    "ParameterABC",
+    "ParameterRequest",
+    "ParameterValue",
+    "build",
+]
 
 from abc import abstractmethod
+from dataclasses import dataclass
 from typing import Any
 
+import numpy as np
+
 from flepimop2._utils._module import _build
+from flepimop2.axis import AxisCollection, ResolvedShape
 from flepimop2.configuration import ModuleModel
 from flepimop2.module import ModuleABC
-from flepimop2.typing import Float64NDArray
+from flepimop2.typing import Float64NDArray, IdentifierString
+
+
+@dataclass(frozen=True, slots=True)
+class ParameterRequest:
+    """
+    Request for a parameter value declared by a system.
+
+    Attributes:
+        name: Parameter name expected by the system.
+        axes: Ordered named axes the resolved parameter should align with.
+        broadcast: Whether a scalar parameter may be broadcast to the requested
+            shape.
+        optional: Whether the system can omit this parameter and rely on defaults.
+
+    Notes:
+        Systems typically create `ParameterRequest` objects in
+        `SystemABC.requested_parameters()`. Parameter modules receive the request in
+        `ParameterABC.sample()` and can use the shape metadata to decide how to
+        materialize their values.
+
+    Examples:
+        >>> from pprint import pp
+        >>> from flepimop2.parameter.abc import ParameterRequest
+        >>> request = ParameterRequest(
+        ...     name="gamma",
+        ...     axes=("age",),
+        ...     broadcast=True,
+        ... )
+        >>> pp(request)
+        ParameterRequest(name='gamma', axes=('age',), broadcast=True, optional=False)
+    """
+
+    name: IdentifierString
+    axes: tuple[IdentifierString, ...] = ()
+    broadcast: bool = False
+    optional: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class ModelStateSpecification:
+    """
+    Model State Specification.
+
+    Describe how configured parameter entries assemble the evolving model state.
+
+    Attributes:
+        parameter_names: Ordered parameter names that define the model state.
+        axes: Named axes shared by each state entry.
+        broadcast: Whether scalar state entries may broadcast to the requested axes.
+        labels: Optional human-readable labels such as compartment names.
+
+    Notes:
+        `ModelStateSpecification` defines the semantic order of model-state
+        entries, but it does not prescribe how an engine should convert them
+        into its internal representation. An ODE engine might use
+        `np.stack(...)`, while another engine might preserve the dictionary
+        form.
+
+        Each state entry currently maps to exactly one configured parameter
+        name. Reusing the same parameter name for multiple state entries is not
+        supported because it would collapse when requests are materialized into
+        a dictionary.
+
+        For an age-by-region SEIR system with age labels
+        `("age0_17", "age18_55", "age55_100")` and region labels
+        `("Region A", "Region B")`, `parameter_names` could be
+        `("S0", "E0", "I0", "R0")` and `axes` could be
+        `("region", "age")`. An engine could then stack those entries into a
+        `(4, 2, 3)` array ordered as `(compartment, region, age)`.
+
+    Examples:
+        >>> from flepimop2.parameter.abc import ModelStateSpecification
+        >>> spec = ModelStateSpecification(
+        ...     parameter_names=("s0", "i0", "r0"),
+        ...     labels=("S", "I", "R"),
+        ... )
+        >>> tuple(spec.requests())
+        ('s0', 'i0', 'r0')
+    """
+
+    parameter_names: tuple[IdentifierString, ...]
+    axes: tuple[IdentifierString, ...] = ()
+    broadcast: bool = False
+    labels: tuple[str, ...] | None = None
+
+    def __post_init__(self) -> None:
+        """
+        Validate any provided state labels align with parameter names.
+
+        Raises:
+            ValueError: If `labels` and `parameter_names` have different lengths.
+            ValueError: If `parameter_names` contains duplicates.
+
+        Examples:
+            >>> from flepimop2.parameter.abc import ModelStateSpecification
+            >>> spec = ModelStateSpecification(parameter_names=("s0",), labels=("S",))
+            >>> spec.labels
+            ('S',)
+            >>> ModelStateSpecification(
+            ...     parameter_names=("s0", "i0"),
+            ...     labels=("S",),
+            ... )
+            Traceback (most recent call last):
+                ...
+            ValueError: ModelStateSpecification labels must match ...
+            >>> ModelStateSpecification(
+            ...     parameter_names=("s0", "s0"),
+            ... )
+            Traceback (most recent call last):
+                ...
+            ValueError: ModelStateSpecification parameter_names must be unique ...
+        """
+        if self.labels is not None and len(self.labels) != len(self.parameter_names):
+            msg = (
+                "ModelStateSpecification labels must match parameter_names length; "
+                f"got {len(self.labels)} labels and {len(self.parameter_names)} "
+                "parameter names."
+            )
+            raise ValueError(msg)
+        if len(set(self.parameter_names)) != len(self.parameter_names):
+            msg = (
+                "ModelStateSpecification parameter_names must be unique so each "
+                "state entry maps to exactly one configured parameter."
+            )
+            raise ValueError(msg)
+
+    def requests(self) -> dict[IdentifierString, ParameterRequest]:
+        """
+        Convert this model-state specification into per-parameter requests.
+
+        Returns:
+            Sampling requests for each parameter used to initialize model state.
+        """
+        return {
+            name: ParameterRequest(
+                name=name,
+                axes=self.axes,
+                broadcast=self.broadcast,
+            )
+            for name in self.parameter_names
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ParameterValue:
+    """
+    Sampled parameter value plus resolved runtime shape metadata.
+
+    Attributes:
+        value: The realized numeric value for this parameter.
+        shape: Named runtime shape resolved against a concrete axis collection.
+
+    Notes:
+        `ParameterValue` intentionally keeps the payload small: it records the value
+        itself and the resolved named shape. Richer provenance or caching metadata
+        can be added later once those workflows are designed.
+
+    Examples:
+        >>> from pprint import pp
+        >>> import numpy as np
+        >>> from flepimop2.axis import ResolvedShape
+        >>> from flepimop2.parameter.abc import ParameterValue
+        >>> value = ParameterValue(
+        ...     value=np.array([1.0, 2.0]),
+        ...     shape=ResolvedShape(axis_names=("age",), sizes=(2,)),
+        ... )
+        >>> pp(value)
+        ParameterValue(value=array([1., 2.]),
+                       shape=ResolvedShape(axis_names=('age',), sizes=(2,)))
+    """
+
+    value: Float64NDArray
+    shape: ResolvedShape
+
+    def __post_init__(self) -> None:
+        """
+        Normalize to a float64 array and validate its resolved shape.
+
+        Raises:
+            ValueError: If the array shape does not match the resolved named shape.
+
+        Examples:
+            >>> import numpy as np
+            >>> from flepimop2.axis import ResolvedShape
+            >>> from flepimop2.parameter.abc import ParameterValue
+            >>> ParameterValue(value=np.array(42.0), shape=ResolvedShape()).item()
+            42.0
+            >>> ParameterValue(
+            ...     value=np.array([1.0, 2.0]),
+            ...     shape=ResolvedShape(axis_names=("age",), sizes=(3,)),
+            ... )
+            Traceback (most recent call last):
+                ...
+            ValueError: ParameterValue shape mismatch: array has shape ...
+        """
+        value = np.asarray(self.value, dtype=np.float64)
+        if value.shape != self.shape.sizes:
+            msg = (
+                "ParameterValue shape mismatch: array has shape "
+                f"{value.shape}, but resolved shape is {self.shape.sizes} "
+                f"for axes {self.shape.axis_names}."
+            )
+            raise ValueError(msg)
+        object.__setattr__(self, "value", value)
+
+    def item(self) -> float:
+        """
+        Return the scalar item from a scalar parameter value.
+
+        Returns:
+            The scalar value as a Python float.
+
+        Examples:
+            >>> import numpy as np
+            >>> from flepimop2.axis import ResolvedShape
+            >>> from flepimop2.parameter.abc import ParameterValue
+            >>> ParameterValue(value=np.array(3.14), shape=ResolvedShape()).item()
+            3.14
+        """
+        return float(self.value.item())
 
 
 class ParameterABC(ModuleABC, module_namespace="parameter"):
-    """Abstract base class for parameters."""
+    """
+    Abstract base class for parameter modules.
+
+    Notes:
+        Concrete parameter implementations should use `request` to decide how to
+        materialize their output for a particular system. For example, a fixed scalar
+        parameter may broadcast to a requested age axis, while a data-backed
+        parameter may validate that its loaded data already matches the requested
+        shape.
+    """
 
     @abstractmethod
-    def sample(self) -> Float64NDArray:
-        """Sample a value from the parameter.
+    def sample(
+        self,
+        *,
+        axes: AxisCollection | None = None,
+        request: ParameterRequest | None = None,
+    ) -> ParameterValue:
+        """
+        Sample a value from the parameter.
+
+        Args:
+            axes: Resolved runtime axes available for this simulation.
+            request: Optional system-declared request describing the expected shape
+                and advisory type for the parameter.
 
         Returns:
-            A sampled value from the parameter.
+            A sampled parameter value with resolved shape metadata.
         """
         raise NotImplementedError
 
@@ -48,6 +298,5 @@ def build(config: dict[str, Any] | ModuleModel) -> ParameterABC:
 
     Returns:
         The constructed parameter instance.
-
     """
     return _build(config, "parameter", "flepimop2.parameter.wrapper", ParameterABC)

--- a/src/flepimop2/parameter/fixed/__init__.py
+++ b/src/flepimop2/parameter/fixed/__init__.py
@@ -17,11 +17,15 @@
 
 __all__ = ["FixedParameter"]
 
+
+from typing import Any
+
 import numpy as np
 
+from flepimop2.axis import AxisCollection, ResolvedShape
 from flepimop2.configuration import ModuleModel
-from flepimop2.parameter.abc import ParameterABC
-from flepimop2.typing import Float64NDArray
+from flepimop2.parameter.abc import ParameterABC, ParameterRequest, ParameterValue
+from flepimop2.typing import IdentifierString
 
 
 class FixedParameter(ModuleModel, ParameterABC, module="fixed"):
@@ -31,18 +35,81 @@ class FixedParameter(ModuleModel, ParameterABC, module="fixed"):
     Examples:
         >>> from flepimop2.parameter.fixed import FixedParameter
         >>> param = FixedParameter(value=42.0)
-        >>> param.sample()
-        array([42.])
-
+        >>> param.sample().item()
+        42.0
     """
 
-    value: float
+    value: float | int | list[Any]
+    shape: tuple[IdentifierString, ...] = ()
 
-    def sample(self) -> Float64NDArray:
+    def sample(
+        self,
+        *,
+        axes: AxisCollection | None = None,
+        request: ParameterRequest | None = None,
+    ) -> ParameterValue:
         """
         Return the fixed value of the parameter.
 
+        Args:
+            axes: Resolved runtime axes available for the current simulation.
+            request: Optional system request describing the desired shape.
+
         Returns:
-            The fixed numeric value of the parameter.
+            The fixed parameter value with runtime shape metadata.
+
+        Raises:
+            ValueError: If the configured shape conflicts with the system request.
+            ValueError: If a non-scalar fixed value has no named shape context.
+            ValueError: If the configured value cannot satisfy the resolved shape.
         """
-        return np.array([self.value], dtype=np.float64)
+        axes = axes or AxisCollection()
+        value = np.asarray(self.value, dtype=np.float64)
+
+        configured_shape = axes.resolve_shape(self.shape) if self.shape else None
+        requested_shape = (
+            axes.resolve_shape(request.axes) if request is not None else None
+        )
+
+        if (
+            configured_shape is not None
+            and requested_shape is not None
+            and configured_shape != requested_shape
+        ):
+            if request is None:
+                msg = "request must be provided when validating a requested shape."
+                raise ValueError(msg)
+            msg = (
+                f"FixedParameter shape {configured_shape.axis_names} does not match "
+                f"requested shape {requested_shape.axis_names} for parameter "
+                f"'{request.name}'."
+            )
+            raise ValueError(msg)
+
+        target_shape = configured_shape or requested_shape
+        if target_shape is None:
+            if value.ndim > 0:
+                msg = (
+                    "Non-scalar FixedParameter values require either an explicit "
+                    "'shape' configuration or a system request."
+                )
+                raise ValueError(msg)
+            return ParameterValue(
+                value=value,
+                shape=ResolvedShape(),
+            )
+
+        if value.shape == target_shape.sizes:
+            return ParameterValue(value=value, shape=target_shape)
+
+        if value.ndim == 0 and (
+            configured_shape is not None or (request is not None and request.broadcast)
+        ):
+            broadcast = np.broadcast_to(value, target_shape.sizes).astype(np.float64)
+            return ParameterValue(value=broadcast, shape=target_shape)
+
+        msg = (
+            f"FixedParameter value shape {value.shape} is not compatible with "
+            f"resolved shape {target_shape.sizes} for axes {target_shape.axis_names}."
+        )
+        raise ValueError(msg)

--- a/tests/parameter/test_fixed_parameter_class.py
+++ b/tests/parameter/test_fixed_parameter_class.py
@@ -1,0 +1,114 @@
+# flepimop2: The FLExible Pipeline for Interchangeable MOdel Processing
+# Copyright (C) 2026  Carl Pearson, Joshua Macdonald, Timothy Willard
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Tests for runtime fixed-parameter sampling."""
+
+from typing import Any
+
+import numpy as np
+import pytest
+
+from flepimop2.axis import AxisCollection
+from flepimop2.parameter.abc import ParameterRequest
+from flepimop2.parameter.fixed import FixedParameter
+
+
+@pytest.mark.parametrize("value", [42.0, 123.45])
+def test_fixed_parameter_returns_scalar_parameter_value(value: float) -> None:
+    """Scalar fixed parameters should resolve to scalar runtime samples."""
+    sample = FixedParameter(value=value).sample()
+    assert sample.shape.axis_names == ()
+    assert sample.shape.sizes == ()
+    assert sample.item() == value
+
+
+@pytest.mark.parametrize(
+    ("axes_config", "value"),
+    [
+        ({"age": {"kind": "categorical", "labels": ["0-17", "18-64", "65+"]}}, 0.1),
+        ({"region": {"kind": "categorical", "labels": ["north", "south"]}}, 0.2),
+        (
+            {
+                "age": {
+                    "kind": "continuous",
+                    "size": 10,
+                    "domain": (18, 65),
+                    "spacing": "linear",
+                }
+            },
+            0.3,
+        ),
+    ],
+)
+def test_fixed_parameter_broadcasts_scalar_to_requested_shape(
+    axes_config: dict[str, Any], value: float
+) -> None:
+    """Scalar fixed parameters can broadcast to system-requested shapes."""
+    axes_name = next(iter(axes_config.keys()))
+    axes = AxisCollection.from_config(axes_config)
+    sample = FixedParameter(value=value).sample(
+        axes=axes,
+        request=ParameterRequest(name="gamma", axes=(axes_name,), broadcast=True),
+    )
+    assert sample.shape.axis_names == (axes_name,)
+    np.testing.assert_array_equal(sample.value, np.repeat(value, axes.size(axes_name)))
+
+
+def test_fixed_parameter_rejects_non_scalar_without_shape_context() -> None:
+    """Array-valued fixed parameters need explicit named shape information."""
+    with pytest.raises(
+        ValueError,
+        match=(
+            r"^Non-scalar FixedParameter values require either an "
+            r"explicit 'shape' configuration or a system request.$"
+        ),
+    ):
+        FixedParameter(value=[1.0, 2.0]).sample()
+
+
+def test_fixed_parameter_rejects_conflicting_configured_and_requested_shapes() -> None:
+    """Explicit parameter shape must match the system-requested shape."""
+    axes = AxisCollection.from_config({
+        "age": {"kind": "categorical", "labels": ["0-17", "18-64", "65+"]},
+        "region": {"kind": "categorical", "labels": ["north", "south"]},
+    })
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            r"^FixedParameter shape \('age',\) does not match requested "
+            r"shape \('region',\) for parameter 'beta'\.$"
+        ),
+    ):
+        FixedParameter(value=[0.1, 0.2, 0.3], shape=("age",)).sample(
+            axes=axes,
+            request=ParameterRequest(name="beta", axes=("region",)),
+        )
+
+
+def test_fixed_parameter_rejects_value_with_incompatible_resolved_shape() -> None:
+    """Configured values must match or broadcast to the resolved named shape."""
+    axes = AxisCollection.from_config({
+        "age": {"kind": "categorical", "labels": ["0-17", "18-64", "65+"]}
+    })
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            r"^FixedParameter value shape \(2,\) is not compatible with "
+            r"resolved shape \(3,\) for axes \('age',\)\.$"
+        ),
+    ):
+        FixedParameter(value=[0.1, 0.2], shape=("age",)).sample(axes=axes)


### PR DESCRIPTION
Introduced `ParameterValue` as the return type for `ParameterABC.sample`
that contains the underlying value as a numpy array as well as metadata,
which at this point is the `ResolvedShape`. This container type is
extensible for further metadata in the future such as type info and
could easily be converted to a generic to generalize the underlying
value, e.g. to use jax arrays or similar.

Also added `ModelStateSpecification`, `ParameterRequest` as a way for
systems to specify their underlying state and shape as well as request
parameters that match that specification. However, this is not connected
to systems yet.

Currently the shapes are not utilized in simulation, but existing
engines/systems should work as is due to the simulate command reducing
parameters to scalars before calling `Simulator.run`