### PR TITLE
Add system parameter requests & model state spec

### DIFF
--- a/src/flepimop2/_utils/_checked_partial.py
+++ b/src/flepimop2/_utils/_checked_partial.py
@@ -145,6 +145,10 @@ def _checked_partial(
                 and expected_type is not Any
             ):
                 try:
+                    if isinstance(expected_type, type) and isinstance(
+                        params[key], expected_type
+                    ):
+                        continue
                     casted_value = expected_type(params[key])
                     params[key] = casted_value
                 except (ValueError, TypeError) as e:

--- a/src/flepimop2/_utils/_inspect.py
+++ b/src/flepimop2/_utils/_inspect.py
@@ -1,0 +1,73 @@
+# flepimop2: The FLExible Pipeline for Interchangeable MOdel Processing
+# Copyright (C) 2026  Carl Pearson, Joshua Macdonald, Timothy Willard
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Small helpers for inspecting runtime type annotations."""
+
+from typing import Annotated, get_args, get_origin
+
+import numpy as np
+
+
+def _unwrap_annotation(annotation: object) -> object:
+    """
+    Strip simple wrappers like `Annotated[...]` from runtime annotations.
+
+    Returns:
+        The innermost annotation after peeling supported typing wrappers.
+
+    Examples:
+        >>> from typing import Annotated
+        >>> _unwrap_annotation(float)
+        <class 'float'>
+        >>> _unwrap_annotation(Annotated[float, "units"])
+        <class 'float'>
+        >>> _unwrap_annotation(Annotated[Annotated[int, "a"], "b"])
+        <class 'int'>
+    """
+    while get_origin(annotation) is Annotated:
+        annotation = get_args(annotation)[0]
+    return annotation
+
+
+def _is_ndarray_annotation(annotation: object) -> bool:
+    """
+    Return whether an annotation refers to a NumPy ndarray payload.
+
+    Returns:
+        `True` if the annotation is `np.ndarray` or an `Annotated` wrapper around it,
+        `False` otherwise.
+
+    Examples:
+        >>> from typing import Annotated
+        >>> _is_ndarray_annotation(np.ndarray)
+        True
+        >>> import numpy.typing as npt
+        >>> _is_ndarray_annotation(npt.NDArray)
+        True
+        >>> _is_ndarray_annotation(npt.NDArray[np.float64])
+        True
+        >>> _is_ndarray_annotation(Annotated[np.ndarray, "array payload"])
+        True
+        >>> _is_ndarray_annotation(
+        ...     Annotated[npt.NDArray[np.float64], "array payload"]
+        ... )
+        True
+        >>> _is_ndarray_annotation(list[float])
+        False
+        >>> _is_ndarray_annotation(float)
+        False
+    """
+    annotation = _unwrap_annotation(annotation)
+    return annotation is np.ndarray or get_origin(annotation) is np.ndarray

--- a/src/flepimop2/system/abc/__init__.py
+++ b/src/flepimop2/system/abc/__init__.py
@@ -26,15 +26,22 @@ __all__ = [
 import inspect
 import sys
 from abc import abstractmethod
+from collections.abc import Callable
 from typing import Any
 
 import numpy as np
 
 from flepimop2._utils._checked_partial import _checked_partial, _consolidate_args
 from flepimop2._utils._module import _build
+from flepimop2.axis import AxisCollection
 from flepimop2.configuration import ModuleModel
 from flepimop2.exceptions import Flepimop2ValidationError, ValidationIssue
 from flepimop2.module import ModuleABC
+from flepimop2.parameter.abc import (
+    ModelStateSpecification,
+    ParameterRequest,
+    ParameterValue,
+)
 from flepimop2.typing import (
     Float64NDArray,
     IdentifierString,
@@ -142,7 +149,7 @@ class SystemABC(ModuleABC, module_namespace="system"):
         raise NotImplementedError(msg)
 
     def step(
-        self, time: np.float64, state: Float64NDArray, **params: Any
+        self, time: np.float64, state: Float64NDArray, **params: ParameterValue
     ) -> Float64NDArray:
         """
         Perform a single step of the system's dynamics.
@@ -162,6 +169,64 @@ class SystemABC(ModuleABC, module_namespace="system"):
         """
         return self.bind()(time, state, **params)
 
+    def requested_parameters(
+        self,
+        axes: AxisCollection,  # noqa: ARG002
+    ) -> dict[IdentifierString, ParameterRequest]:
+        """
+        Infer parameter requests from the unbound stepper signature by default.
+
+        Args:
+            axes: Resolved runtime axes for the active simulation.
+
+        Returns:
+            A mapping of parameter names to runtime parameter requests.
+
+        Notes:
+            Parameters with default values are treated as optional scalar inputs.
+            Subclasses are encouraged to override this method when they need
+            broadcasting behavior or named-axis shapes that cannot be recovered
+            from plain Python annotations.
+        """
+        requests: dict[IdentifierString, ParameterRequest] = {}
+        signature = inspect.signature(self.bind())
+        for name, parameter in signature.parameters.items():
+            if name in {"time", "state"}:
+                continue
+            if parameter.kind in {
+                inspect.Parameter.VAR_KEYWORD,
+                inspect.Parameter.VAR_POSITIONAL,
+            }:
+                continue
+            requests[name] = ParameterRequest(
+                name=name,
+                optional=parameter.default is not inspect.Parameter.empty,
+            )
+        return requests
+
+    def model_state(  # noqa: PLR6301
+        self,
+        axes: AxisCollection,  # noqa: ARG002
+    ) -> ModelStateSpecification | None:
+        """
+        Return metadata describing how parameters assemble the model state.
+
+        Args:
+            axes: Resolved runtime axes for the active simulation.
+
+        Returns:
+            The runtime model-state specification, if defined.
+
+        Notes:
+            Override this in systems whose evolving state is assembled from configured
+            parameter entries. For an age-by-region SEIR system, this could return
+            `parameter_names=("S0", "E0", "I0", "R0")` with
+            `axes=("region", "age")`, allowing an engine to stack those entries into
+            an array shaped `(4, n_region, n_age)` or to keep them in dictionary form
+            if that is more natural for the engine.
+        """
+        return None
+
 
 class _AdapterSystem(SystemABC, module="wrapper"):
     """A `SystemABC` which wraps a user-defined function."""
@@ -169,12 +234,22 @@ class _AdapterSystem(SystemABC, module="wrapper"):
     state_change: StateChangeEnum
     stepper: SystemProtocol
     options: dict[IdentifierString, Any]
+    _requested_parameters_func: (
+        Callable[[AxisCollection], dict[IdentifierString, ParameterRequest]] | None
+    )
+    _model_state_func: Callable[[AxisCollection], ModelStateSpecification | None] | None
 
     def __init__(
         self,
         state_change: StateChangeEnum,
         stepper: SystemProtocol,
         options: dict[IdentifierString, Any] | None = None,
+        requested_parameters: (
+            Callable[[AxisCollection], dict[IdentifierString, ParameterRequest]] | None
+        ) = None,
+        model_state: (
+            Callable[[AxisCollection], ModelStateSpecification | None] | None
+        ) = None,
     ) -> None:
         """
         Initialize the AdapterSystem with a state change and a stepper.
@@ -183,11 +258,17 @@ class _AdapterSystem(SystemABC, module="wrapper"):
             state_change: The type of state change for the system.
             stepper: A user-defined function that implements the system's dynamics.
             options: Optional dictionary of additional information about the system.
+            requested_parameters: Optional callback declaring runtime parameter
+                requests for the system.
+            model_state: Optional callback declaring how parameters assemble the
+                evolving model state.
 
         """
         self.state_change = state_change
         self.stepper = stepper
         self.options = options or {}
+        self._requested_parameters_func = requested_parameters
+        self._model_state_func = model_state
 
     @override
     def _bind_impl(
@@ -197,6 +278,23 @@ class _AdapterSystem(SystemABC, module="wrapper"):
             func=self.stepper,
             params=params,
         )
+
+    @override
+    def requested_parameters(
+        self,
+        axes: AxisCollection,
+    ) -> dict[IdentifierString, ParameterRequest]:
+        """Return adapter parameter requests from an explicit callback when provided."""
+        if self._requested_parameters_func is not None:
+            return self._requested_parameters_func(axes)
+        return super().requested_parameters(axes)
+
+    @override
+    def model_state(self, axes: AxisCollection) -> ModelStateSpecification | None:
+        """Return adapter model-state metadata from an explicit callback."""
+        if self._model_state_func is not None:
+            return self._model_state_func(axes)
+        return super().model_state(axes)
 
 
 def build(config: dict[IdentifierString, Any] | ModuleModel) -> SystemABC:
@@ -222,6 +320,13 @@ def wrap(
     stepper: SystemProtocol,
     state_change: StateChangeEnum,
     options: dict[IdentifierString, Any] | None = None,
+    *,
+    requested_parameters: (
+        Callable[[AxisCollection], dict[IdentifierString, ParameterRequest]] | None
+    ) = None,
+    model_state: (
+        Callable[[AxisCollection], ModelStateSpecification | None] | None
+    ) = None,
 ) -> SystemABC:
     """
     Adapt a user-defined function into a `SystemABC`.
@@ -230,6 +335,10 @@ def wrap(
         stepper: A user-defined function that implements the system's dynamics.
         state_change: The type of state change for the system.
         options: Optional dictionary of additional information about the system.
+        requested_parameters: Optional callback declaring runtime parameter requests
+            for the system.
+        model_state: Optional callback declaring how parameters assemble the evolving
+            model state.
 
     Returns:
         A `SystemABC` instance that wraps the provided stepper function.
@@ -252,4 +361,6 @@ def wrap(
         state_change=state_change,
         stepper=stepper,
         options=options,
+        requested_parameters=requested_parameters,
+        model_state=model_state,
     )

--- a/src/flepimop2/system/wrapper/__init__.py
+++ b/src/flepimop2/system/wrapper/__init__.py
@@ -15,21 +15,303 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """A `SystemABC` which wraps a user-defined script file."""
 
-from typing import Any
+import functools
+import inspect
+import math
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any, Literal, cast
 
-from flepimop2._utils._checked_partial import _checked_partial as _checked_partial
+import numpy as np
+from pydantic import BaseModel, Field, field_validator
+
+from flepimop2._utils._inspect import _is_ndarray_annotation, _unwrap_annotation
 from flepimop2._utils._module import _as_dict, _load_module, _validate_function
+from flepimop2.axis import AxisCollection
 from flepimop2.configuration import ModuleModel
+from flepimop2.parameter.abc import (
+    ModelStateSpecification,
+    ParameterRequest,
+    ParameterValue,
+)
 from flepimop2.system.abc import SystemABC
 from flepimop2.system.abc import wrap as system_wrap
 from flepimop2.typing import (
+    Float64NDArray,
     IdentifierString,
     StateChangeEnum,
     as_system_protocol,
 )
-from flepimop2.typing import (
-    SystemProtocol as SystemProtocol,
-)
+
+
+class _ParameterRequestConfiguration(BaseModel):
+    """
+    Declarative wrapper-system parameter request configuration.
+
+    Attributes:
+        axes: Ordered axis names the parameter should align with.
+        broadcast: Whether scalar parameter values may broadcast to `axes`.
+        optional: Whether the system may omit this parameter and rely on a
+            stepper default.
+    """
+
+    axes: tuple[IdentifierString, ...] = ()
+    broadcast: bool = False
+    optional: bool = False
+
+
+class _ModelStateConfiguration(BaseModel):
+    """
+    Declarative wrapper-system model-state configuration.
+
+    Attributes:
+        parameter_names: Ordered parameter names used to assemble model state.
+        axes: Ordered axis names shared by each state entry.
+        broadcast: Whether scalar state entries may broadcast to `axes`.
+        labels: Optional human-readable labels for state entries.
+    """
+
+    parameter_names: tuple[IdentifierString, ...]
+    axes: tuple[IdentifierString, ...] = ()
+    broadcast: bool = False
+    labels: tuple[str, ...] | None = None
+
+
+class _WrapperSystemConfig(ModuleModel):
+    """
+    Validated configuration for `flepimop2.system.wrapper`.
+
+    Attributes:
+        module: Wrapper-system module identifier.
+        script: Path to the wrapped Python script containing `stepper`.
+        state_change: State-change convention declared by the wrapped system.
+        options: Opaque wrapper-system options exposed through `ModuleABC.option`.
+        requested_parameters: Optional declarative runtime parameter metadata.
+        model_state: Optional declarative model-state metadata.
+    """
+
+    module: Literal["flepimop2.system.wrapper", "wrapper"] = "flepimop2.system.wrapper"
+    script: Path
+    state_change: StateChangeEnum
+    options: dict[IdentifierString, Any] = Field(default_factory=dict)
+    requested_parameters: (
+        dict[IdentifierString, _ParameterRequestConfiguration] | None
+    ) = None
+    model_state: _ModelStateConfiguration | None = None
+
+    @field_validator("requested_parameters", mode="before")
+    @classmethod
+    def _normalize_requested_parameters(
+        cls,
+        value: object,
+    ) -> object:
+        """
+        Normalize shorthand parameter-request entries to empty dictionaries.
+
+        This allows YAML values such as `beta:`, `beta: ~`, or `beta: null` to
+        resolve to the default `ParameterRequest` configuration.
+
+        Returns:
+            The original value when no normalization is needed, or a copy of the
+            parameter mapping with `None` entries replaced by empty dictionaries.
+
+        Examples:
+            >>> config = _WrapperSystemConfig.model_validate({
+            ...     "module": "wrapper",
+            ...     "script": "system.py",
+            ...     "state_change": "flow",
+            ... })
+            >>> config.requested_parameters is None
+            True
+            >>> config = _WrapperSystemConfig.model_validate({
+            ...     "module": "wrapper",
+            ...     "script": "system.py",
+            ...     "state_change": "flow",
+            ...     "requested_parameters": {"beta": None},
+            ... })
+            >>> config.requested_parameters["beta"]
+            _ParameterRequestConfiguration(axes=(), broadcast=False, optional=False)
+            >>> config = _WrapperSystemConfig.model_validate({
+            ...     "module": "wrapper",
+            ...     "script": "system.py",
+            ...     "state_change": "flow",
+            ...     "requested_parameters": {
+            ...         "beta": None,
+            ...         "gamma": {"axes": ["age"], "broadcast": True},
+            ...     },
+            ... })
+            >>> config.requested_parameters["beta"]
+            _ParameterRequestConfiguration(axes=(), broadcast=False, optional=False)
+            >>> config.requested_parameters["gamma"]
+            _ParameterRequestConfiguration(axes=('age',), broadcast=True, optional=False)
+        """  # noqa: E501
+        if value is None:
+            return value
+        if not isinstance(value, dict):
+            return value
+        return {name: {} if spec is None else spec for name, spec in value.items()}
+
+    def requested_parameters_function(
+        self,
+    ) -> Callable[[AxisCollection], dict[IdentifierString, ParameterRequest]] | None:
+        """
+        Build a runtime parameter-request callback from config.
+
+        Returns:
+            A callback returning configured parameter requests, or `None` when the
+            wrapper configuration omits `requested_parameters`.
+        """
+        if self.requested_parameters is None:
+            return None
+        requests = {
+            name: ParameterRequest(
+                name=name,
+                axes=spec.axes,
+                broadcast=spec.broadcast,
+                optional=spec.optional,
+            )
+            for name, spec in self.requested_parameters.items()
+        }
+
+        def _requested_parameters(
+            _axes: AxisCollection,
+        ) -> dict[IdentifierString, ParameterRequest]:
+            return requests.copy()
+
+        return _requested_parameters
+
+    def model_state_function(
+        self,
+    ) -> Callable[[AxisCollection], ModelStateSpecification] | None:
+        """
+        Build a runtime model-state callback from config.
+
+        Returns:
+            A callback returning configured model-state metadata, or `None` when the
+            wrapper configuration omits `model_state`.
+        """
+        if self.model_state is None:
+            return None
+        specification = ModelStateSpecification(
+            parameter_names=self.model_state.parameter_names,
+            axes=self.model_state.axes,
+            broadcast=self.model_state.broadcast,
+            labels=self.model_state.labels,
+        )
+
+        def _model_state(_axes: AxisCollection) -> ModelStateSpecification:
+            return specification
+
+        return _model_state
+
+
+def _binding_annotation(annotation: object) -> object:
+    """Return a bind-time validator compatible with `_checked_partial`."""
+    annotation = _unwrap_annotation(annotation)
+    if annotation in {inspect.Parameter.empty, Any}:
+        return Any
+    if annotation is ParameterValue:
+        return ParameterValue
+    if annotation in {float, int}:
+
+        def _validate_scalar(value: object) -> object:
+            if isinstance(value, ParameterValue):
+                value.item()
+                return value
+            annotation(value)
+            return value
+
+        _validate_scalar.__name__ = f"coercible_{annotation.__name__}"
+        return _validate_scalar
+    if _is_ndarray_annotation(annotation):
+
+        def _validate_array(value: object) -> object:
+            if isinstance(value, ParameterValue):
+                return value
+            return np.asarray(value, dtype=np.float64)
+
+        _validate_array.__name__ = "coercible_ndarray"
+        return _validate_array
+    return Any
+
+
+def _coerce_parameter_value(
+    name: str,
+    annotation: object,
+    value: object,
+) -> object:
+    """
+    Coerce `ParameterValue` objects to the wrapped stepper's expected payload.
+
+    Returns:
+        The original value for pass-through annotations, or an unwrapped scalar/array
+        payload when the wrapped stepper expects one.
+
+    Raises:
+        TypeError: If a scalar annotation receives a non-scalar `ParameterValue`.
+    """
+    if not isinstance(value, ParameterValue):
+        return value
+    annotation = _unwrap_annotation(annotation)
+    if annotation in {float, int}:
+        try:
+            scalar = value.item()
+        except ValueError as exc:
+            msg = (
+                f"Parameter '{name}' expects a scalar {annotation.__name__}, "
+                f"but received shape {value.shape.sizes}."
+            )
+            raise TypeError(msg) from exc
+        if annotation is int and not math.isclose(scalar, round(scalar)):
+            msg = (
+                f"Parameter '{name}' is annotated as int "
+                f"but received non-integer value {scalar}."
+            )
+            raise TypeError(msg)
+        return annotation(scalar)
+    if _is_ndarray_annotation(annotation):
+        return value.value
+    return value
+
+
+def _adapt_wrapper_stepper(stepper: Callable[..., Any]) -> Callable[..., Any]:
+    """
+    Adapt a wrapped stepper to coerce `ParameterValue` inputs by annotation.
+
+    Returns:
+        A callable with the wrapped stepper's signature that unwraps
+        `ParameterValue` arguments into scalars or arrays as requested by the
+        wrapped stepper's annotations.
+    """
+    raw_signature = inspect.signature(stepper)
+    adapted_parameters = []
+    for name, parameter in raw_signature.parameters.items():
+        if name in {"time", "state"} or parameter.kind in {
+            inspect.Parameter.VAR_POSITIONAL,
+            inspect.Parameter.VAR_KEYWORD,
+        }:
+            adapted_parameters.append(parameter)
+            continue
+        adapted_parameters.append(
+            parameter.replace(annotation=_binding_annotation(parameter.annotation))
+        )
+    adapted_signature = raw_signature.replace(parameters=adapted_parameters)
+
+    @functools.wraps(stepper)
+    def _adapted_stepper(*args: Any, **kwargs: Any) -> Float64NDArray:
+        bound = raw_signature.bind_partial(*args, **kwargs)
+        for name, parameter in raw_signature.parameters.items():
+            if name in {"time", "state"} or name not in bound.arguments:
+                continue
+            bound.arguments[name] = _coerce_parameter_value(
+                name,
+                parameter.annotation,
+                bound.arguments[name],
+            )
+        return cast("Float64NDArray", stepper(*bound.args, **bound.kwargs))
+
+    _adapted_stepper.__signature__ = adapted_signature  # type: ignore[attr-defined]
+    return _adapted_stepper
 
 
 def build(config: dict[IdentifierString, Any] | ModuleModel) -> SystemABC:
@@ -45,28 +327,21 @@ def build(config: dict[IdentifierString, Any] | ModuleModel) -> SystemABC:
     Raises:
         AttributeError: If the loaded module does not have a valid 'stepper' function.
     """
-    config = _as_dict(config)
-    config_options = config.get("options", {})
-
-    if script := config.get("script", config_options.get("script")):
-        mod = _load_module(script, "flepimop2.system.wrapped")
-        if not _validate_function(mod, "stepper"):
-            msg = f"Module at {script} does not have a valid 'stepper' function."
-            raise AttributeError(msg)
-
-        stepper = as_system_protocol(mod.stepper)
-        state_change: StateChangeEnum = StateChangeEnum(
-            config.get("state_change", StateChangeEnum.ERROR)
+    wrapper_config = _WrapperSystemConfig.model_validate(_as_dict(config))
+    mod = _load_module(wrapper_config.script, "flepimop2.system.wrapped")
+    if not _validate_function(mod, "stepper"):
+        msg = (
+            f"Module at {wrapper_config.script} does not have a valid "
+            "'stepper' function."
         )
-        config_options["script"] = script
-        return system_wrap(
-            stepper,
-            state_change,
-            config_options,
-        )
-
-    msg = (
-        "Configuration must have a 'script' key either at the top level "
-        "or within 'options'."
+        raise AttributeError(msg)
+    stepper = as_system_protocol(_adapt_wrapper_stepper(mod.stepper))
+    options = wrapper_config.options.copy()
+    options["script"] = wrapper_config.script
+    return system_wrap(
+        stepper,
+        wrapper_config.state_change,
+        options,
+        requested_parameters=wrapper_config.requested_parameters_function(),
+        model_state=wrapper_config.model_state_function(),
     )
-    raise AttributeError(msg)

--- a/tests/engine/test_engine_wrapper.py
+++ b/tests/engine/test_engine_wrapper.py
@@ -21,8 +21,10 @@ from typing import Any, Final
 import numpy as np
 import pytest
 
+from flepimop2.axis import ResolvedShape
 from flepimop2.engine.abc import build as engine_build
 from flepimop2.exceptions import ValidationIssue
+from flepimop2.parameter.abc import ParameterValue
 from flepimop2.system.abc import SystemABC
 from flepimop2.system.abc import build as system_build
 from flepimop2.typing import StateChangeEnum
@@ -51,9 +53,13 @@ TEST_SYSTEM_SCRIPT: Final = (
         })
     ],
 )
-@pytest.mark.parametrize("params", [{"offset": 1.0}])
+@pytest.mark.parametrize(
+    "params", [{"offset": ParameterValue(np.array(1.0), ResolvedShape())}]
+)
 def test_wrapper_system(
-    config: dict[str, Any], system: SystemABC, params: dict[str, float]
+    config: dict[str, Any],
+    system: SystemABC,
+    params: dict[str, ParameterValue],
 ) -> None:
     """Test `WrapperEngine` loads a script and uses its `runner` function."""
     engine = engine_build(config)
@@ -67,7 +73,7 @@ def test_wrapper_system(
     expected = np.zeros((2, 3), dtype=np.float64)
     expected[:, 0] = [1.0, 2.0]
     expected[0, 1:] = [1.0, 2.0]
-    expected[1, 1:] = (expected[0, 1:] + params["offset"]) * 2.0
+    expected[1, 1:] = (expected[0, 1:] + params["offset"].item()) * 2.0
     np.testing.assert_array_equal(result, expected)
 
 

--- a/tests/system/system_wrapper_assets/wrapper_system_with_extras.py
+++ b/tests/system/system_wrapper_assets/wrapper_system_with_extras.py
@@ -13,25 +13,21 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
-"""A dummy stepper function for testing `WrapperSystem`."""
+"""A wrapper-system asset with a stepper only."""
 
 from flepimop2.typing import Float64NDArray
 
 
 def stepper(
-    time: float,
+    time: float,  # noqa: ARG001
     state: Float64NDArray,
-    offset: float,
+    beta: float,
+    gamma: Float64NDArray,
 ) -> Float64NDArray:
     """
-    A dummy stepper function for testing purposes: (state + offset) * time.
-
-    Args:
-        time: The current time.
-        state: The current state array.
-        offset: An offset value to be added to the state.
+    A dummy stepper using both scalar and age-indexed parameters.
 
     Returns:
-        The updated state array after applying the stepper logic.
+        The updated state.
     """
-    return (state + offset) * time
+    return state + beta + gamma

--- a/tests/system/test_system_adapter.py
+++ b/tests/system/test_system_adapter.py
@@ -18,12 +18,14 @@
 import numpy as np
 import pytest
 
+from flepimop2.axis import ResolvedShape
+from flepimop2.parameter.abc import ParameterValue
 from flepimop2.system.abc import SystemProtocol, wrap
 from flepimop2.typing import Float64NDArray, StateChangeEnum
 
 
 def stepper(
-    time: np.float64, state: Float64NDArray, offset: np.float64
+    time: np.float64, state: Float64NDArray, offset: ParameterValue
 ) -> Float64NDArray:
     """
     A dummy stepper function for testing purposes: (state + offset) * time.
@@ -36,7 +38,7 @@ def stepper(
     Returns:
         The updated state array after applying the stepper logic.
     """
-    return (state + offset) * time
+    return (state + offset.item()) * time
 
 
 @pytest.mark.parametrize("stepper", [stepper])
@@ -45,8 +47,8 @@ def test_wrapper_system(stepper: SystemProtocol, state_change: StateChangeEnum) 
     """Test `AdapterSystem` uses a `stepper` function directly."""
     system = wrap(stepper, state_change)
     time = np.float64(1.0)
-    offset = 1.0
+    offset = ParameterValue(np.array(1.0), ResolvedShape())
     init_state = np.array([1.0, 2.0, 3.0], dtype=np.float64)
     result = system.step(time, init_state, offset=offset)
-    expected = (init_state + offset) * time
+    expected = (init_state + offset.item()) * time
     np.testing.assert_array_equal(result, expected)

--- a/tests/system/test_system_bind.py
+++ b/tests/system/test_system_bind.py
@@ -20,6 +20,8 @@ from pathlib import Path
 import numpy as np
 import pytest
 
+from flepimop2.axis import ResolvedShape
+from flepimop2.parameter.abc import ParameterValue
 from flepimop2.system.abc import SystemABC, build
 from flepimop2.typing import StateChangeEnum
 
@@ -32,13 +34,14 @@ par = pytest.mark.parametrize("test_system", [system])
 @par
 def test_set_valid_static_parameters(test_system: SystemABC) -> None:
     """Confirm no errors when setting all valid parameters."""
-    offset = 5.0
+    offset = ParameterValue(np.array(5.0), ResolvedShape())
     time = np.float64(1.0)
     initial_state = np.array([1.0, 2.0, 3.0], dtype=np.float64)
     newproto = test_system.bind(offset=offset)
-    assert all(newproto(time, initial_state) == (initial_state + offset))
-    newproto = test_system.bind(params={"offset": offset * 2})
-    assert all(newproto(time, initial_state) == (initial_state + offset * 2))
+    assert all(newproto(time, initial_state) == (initial_state + offset.item()))
+    doubled = ParameterValue(np.array(offset.item() * 2), ResolvedShape())
+    newproto = test_system.bind(params={"offset": doubled})
+    assert all(newproto(time, initial_state) == (initial_state + doubled.item()))
 
 
 @par

--- a/tests/system/test_system_wrapper.py
+++ b/tests/system/test_system_wrapper.py
@@ -16,14 +16,23 @@
 """Tests for `SystemABC` and default `WrapperSystem`."""
 
 from pathlib import Path
-from typing import Any
+from typing import Any, Final
 
 import numpy as np
 import pytest
 
+from flepimop2.axis import AxisCollection, ResolvedShape
+from flepimop2.parameter.abc import (
+    ModelStateSpecification,
+    ParameterRequest,
+    ParameterValue,
+)
 from flepimop2.system.abc import build
 
-TEST_SCRIPT = Path(__file__).parent / "system_wrapper_assets" / "dummy_system.py"
+TEST_SCRIPT: Final = Path(__file__).parent / "system_wrapper_assets" / "dummy_system.py"
+WRAPPER_SCRIPT_WITH_EXTRAS: Final = (
+    Path(__file__).parent / "system_wrapper_assets" / "wrapper_system_with_extras.py"
+)
 
 
 @pytest.mark.parametrize("config", [{"script": TEST_SCRIPT, "state_change": "flow"}])
@@ -31,11 +40,16 @@ def test_wrapper_system(config: dict[str, Any]) -> None:
     """Test `WrapperSystem` loads a script and uses its `stepper` function."""
     system = build(config)
     time = np.float64(1.0)
-    offset = 1.0
+    offset = ParameterValue(np.array(1.0), ResolvedShape())
     init_state = np.array([1.0, 2.0, 3.0], dtype=np.float64)
     result = system.step(time, init_state, offset=offset)
-    expected = init_state + offset
+    expected = init_state + offset.item()
     np.testing.assert_array_equal(result, expected)
+    axes = AxisCollection()
+    assert system.requested_parameters(axes) == {
+        "offset": ParameterRequest(name="offset"),
+    }
+    assert system.model_state(axes) is None
 
 
 def test_wrapper_system_options_available_via_option_method() -> None:
@@ -46,3 +60,54 @@ def test_wrapper_system_options_available_via_option_method() -> None:
         "options": {"offset": 1.5},
     })
     assert system.option("offset") == pytest.approx(1.5)
+
+
+def test_wrapper_system_loads_requested_parameters_and_model_state_from_config() -> (
+    None
+):
+    """Wrapper systems should expose parameter and state metadata from config."""
+    system = build({
+        "script": WRAPPER_SCRIPT_WITH_EXTRAS,
+        "state_change": "flow",
+        "requested_parameters": {
+            "beta": None,
+            "gamma": {
+                "axes": ["age"],
+                "broadcast": True,
+            },
+        },
+        "model_state": {
+            "parameter_names": ["s0", "i0", "r0"],
+            "axes": ["age"],
+            "broadcast": True,
+            "labels": ["S", "I", "R"],
+        },
+    })
+    axes = AxisCollection.from_config({
+        "age": {"kind": "categorical", "labels": ["0-17", "18-64"]}
+    })
+
+    assert system.requested_parameters(axes) == {
+        "beta": ParameterRequest(name="beta"),
+        "gamma": ParameterRequest(
+            name="gamma",
+            axes=("age",),
+            broadcast=True,
+        ),
+    }
+    assert system.model_state(axes) == ModelStateSpecification(
+        parameter_names=("s0", "i0", "r0"),
+        axes=("age",),
+        broadcast=True,
+        labels=("S", "I", "R"),
+    )
+    result = system.step(
+        np.float64(1.0),
+        np.array([1.0, 2.0], dtype=np.float64),
+        beta=ParameterValue(np.array(0.5), ResolvedShape()),
+        gamma=ParameterValue(
+            np.array([0.2, 0.4], dtype=np.float64),
+            ResolvedShape(axis_names=("age",), sizes=(2,)),
+        ),
+    )
+    np.testing.assert_array_equal(result, np.array([1.7, 2.9], dtype=np.float64))


### PR DESCRIPTION
Added `SystemABC.requested_parameters()/model_state()` to allow systems
to provide information about their underlying state specification,
including shape, as well as request parameters that comply with said
requirements. Also integrated this work into the existing wrapper system
to demonstrate the functionality.

- Added `requested_parameters()/model_state()` methods to `SystemABC`.
- Extended `wrap()`/`_AdapterSystem` to accept explicit parameter
  request and model state callbacks.
- Updated `_checked_partial()` so already materialized `ParameterValue`
  instances are preserved when binding static parameters.
- Simplified the documentation quick start wrapper config to the minimal
  valid example.