### PR TITLE
Integrate structured parameters into simulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Introduced the axis concept as a way to represent aligned shapes across parameters, systems, etc. Added two kinds of axes, categorical and continuous, to represent different kinds of dimensions. Also added an `axes` top level key to the `ConfigurationModel` so users can provide these axes via configuration and `flepimop2.axis` module for realizing & manipulating axes from configuration. See [#147](https://github.com/ACCIDDA/flepimop2/issues/147).
-- Added ways to specify shape for parameters based on `axes` by changing `ParameterABC.sample` to return a `ParameterValue` that contains both the underlying value as a numpy array as well as shape metadata, and is easily extensible to other metadata and underlying value types in the future. Also added `ModelStateSpecification`, `ParameterRequest` types for systems to advertise their underlying state and request parameters to comply with said state specification, but yet to wire into `SystemABC`.
+- Added ways to specify shape for parameters based on `axes` by changing `ParameterABC.sample` to return a `ParameterValue` that contains both the underlying value as a numpy array as well as shape metadata, and is easily extensible to other metadata and underlying value types in the future. Also added `ModelStateSpecification`, `ParameterRequest` types for systems to advertise their underlying state and request parameters to comply with said state specification. See [#115](https://github.com/ACCIDDA/flepimop2/issues/115), [#133](https://github.com/ACCIDDA/flepimop2/issues/133).
 
 ### Changed
 

--- a/docs/assets/quickstart_workflow/SIR.py
+++ b/docs/assets/quickstart_workflow/SIR.py
@@ -6,8 +6,8 @@ from flepimop2.typing import Float64NDArray
 
 
 def stepper(
-    t: float,  # noqa: ARG001
-    y: Float64NDArray,
+    time: float,  # noqa: ARG001
+    state: Float64NDArray,
     beta: float,
     gamma: float,
 ) -> Float64NDArray:
@@ -15,8 +15,8 @@ def stepper(
     Compute dY/dt for the SIR model.
 
     Args:
-        t: The current time (not used in this model, but included for compatibility).
-        y: A numpy array containing the current values [S, I, R].
+        time: The current time (not used in this model, but included for compatibility).
+        state: A numpy array containing the current values [S, I, R].
         beta: The infection rate.
         gamma: The recovery rate.
 
@@ -24,8 +24,8 @@ def stepper(
         A numpy array containing the derivatives [dS/dt, dI/dt, dR/dt].
 
     """
-    y_s, y_i, _ = np.asarray(y, dtype=float)
-    infection = (beta * y_s * y_i) / np.sum(y)
+    y_s, y_i, _ = np.asarray(state, dtype=float)
+    infection = (beta * y_s * y_i) / np.sum(state)
     recovery = gamma * y_i
     dydt = [-infection, infection - recovery, recovery]
     return np.array(dydt, dtype=float)

--- a/docs/assets/quickstart_workflow/config.yaml
+++ b/docs/assets/quickstart_workflow/config.yaml
@@ -5,6 +5,9 @@ system:
   - module: wrapper
     state_change: flow
     script: model_input/plugins/SIR.py
+    model_state:
+      parameter_names: [s0, i0, r0]
+      labels: [S, I, R]
 engine:
   - module: wrapper
     state_change: flow

--- a/docs/assets/quickstart_workflow/solve_ivp.py
+++ b/docs/assets/quickstart_workflow/solve_ivp.py
@@ -1,10 +1,12 @@
 """ODE solver plugin that wraps `scipy.integrate.solve_ivp` for flepimop2 demo."""
 
+from collections.abc import Mapping
 from typing import Any
 
 import numpy as np
 from scipy.integrate import solve_ivp
 
+from flepimop2.parameter.abc import ModelStateSpecification, ParameterValue
 from flepimop2.system.abc import SystemProtocol
 from flepimop2.typing import Float64NDArray
 
@@ -12,18 +14,22 @@ from flepimop2.typing import Float64NDArray
 def runner(
     fun: SystemProtocol,
     times: Float64NDArray,
-    y0: Float64NDArray,
-    params: dict[str, Any] | None = None,
+    initial_state: dict[str, ParameterValue],
+    params: Mapping[str, ParameterValue] | None = None,
+    *,
+    model_state: ModelStateSpecification | None = None,
     **solver_options: Any,
 ) -> Float64NDArray:
     """Solve an initial value problem using scipy.solve_ivp.
 
     Args:
-        fun (SystemProtocol): A function that computes derivatives.
-        times (Float64NDArray): sequence of time points where we evaluate the
-          solution. Must have length >= 1.
-        y0 (Float64NDArray): Initial condition.
+        fun: A function that computes derivatives.
+        times: sequence of time points where we evaluate the solution. Must have
+            length >= 1.
+        initial_state: Structured initial-state entries.
         params: Optional dict of keyword parameters forwarded to fun.
+        model_state: Specification describing how to order the initial-state
+          entries into a numeric state array.
         **solver_options: Additional keyword options forwarded to
           scipy.integrate.solve_ivp.
 
@@ -39,6 +45,9 @@ def runner(
     if not (times.ndim == 1 and times.size >= 1):
         msg = "times must be a 1D sequence of time points"
         raise ValueError(msg)
+    if model_state is None:
+        msg = "model_state must be provided to assemble the initial condition."
+        raise ValueError(msg)
 
     times.sort()
 
@@ -47,7 +56,10 @@ def runner(
         msg = f"times[0] must be >= 0; got times[0]={times[0]}"
         raise ValueError(msg)
 
-    args = tuple(val for val in params.values()) if params is not None else None
+    y0 = np.stack([
+        initial_state[name].value for name in model_state.parameter_names
+    ]).astype(np.float64)
+    args = tuple(val.item() for val in params.values()) if params is not None else None
     result = solve_ivp(
         fun,
         (t0, tf),

--- a/docs/assets/scenarios_config.yaml
+++ b/docs/assets/scenarios_config.yaml
@@ -3,6 +3,9 @@ system:
   - module: wrapper
     state_change: flow
     script: model_input/plugins/SIR.py
+    model_state:
+      parameter_names: [s0, i0, r0]
+      labels: [S, I, R]
 engine:
   - module: wrapper
     state_change: flow

--- a/docs/development/implementing-custom-engines-and-systems.md
+++ b/docs/development/implementing-custom-engines-and-systems.md
@@ -32,14 +32,15 @@ from typing import Any
 import numpy as np
 
 from flepimop2.configuration import ModuleModel
+from flepimop2.parameter.abc import ParameterValue
 from flepimop2.system.abc import SystemABC, SystemProtocol
 from flepimop2.typing import Float64NDArray, StateChangeEnum
 
 def global_sir(
     time: np.float64,
     state: Float64NDArray,
-    beta: np.float64,
-    gamma: np.float64,
+    beta: ParameterValue,
+    gamma: ParameterValue,
 ) -> Float64NDArray:
     """
     SIR model stepper function.
@@ -54,9 +55,9 @@ def global_sir(
         Array of state derivatives [dS/dt, dI/dt, dR/dt].
     """
     return np.array([
-        -beta * state[0] * state[1],
-        beta * state[0] * state[1] - gamma * state[1],
-        gamma * state[1]
+        -beta.item() * state[0] * state[1],
+        beta.item() * state[0] * state[1] - gamma.item() * state[1],
+        gamma.item() * state[1]
     ])
 
 class SirSystem(ModuleModel, SystemABC, module="sir"):
@@ -85,6 +86,7 @@ import numpy as np
 from flepimop2.configuration import ModuleModel
 from flepimop2.engine.abc import EngineABC
 from flepimop2.exceptions import ValidationIssue
+from flepimop2.parameter.abc import ModelStateSpecification, ParameterValue
 from flepimop2.system.abc import SystemABC, SystemProtocol
 from flepimop2.typing import Float64NDArray, IdentifierString
 
@@ -92,8 +94,9 @@ from flepimop2.typing import Float64NDArray, IdentifierString
 def runner(
     stepper: SystemProtocol,
     times: Float64NDArray,
-    state: Float64NDArray,
-    params: dict[IdentifierString, Any],
+    initial_state: dict[IdentifierString, ParameterValue],
+    params: dict[IdentifierString, ParameterValue],
+    model_state: ModelStateSpecification | None = None,
     **kwargs: Any,  # noqa: ARG001
 ) -> Float64NDArray:
     """
@@ -102,8 +105,9 @@ def runner(
     Args:
         stepper: The system stepper function.
         times: Array of time points.
-        state: The current state array.
-        params: Additional parameters for the stepper.
+        initial_state: Structured initial-state parameters.
+        params: Additional structured parameters for the stepper.
+        model_state: Specification describing how to order the initial state.
         **kwargs: Additional keyword arguments for the engine. Unused by this runner.
 
     Returns:

--- a/src/flepimop2/_cli/_simulate_command.py
+++ b/src/flepimop2/_cli/_simulate_command.py
@@ -22,12 +22,21 @@ from pathlib import Path
 import numpy as np
 
 from flepimop2._cli._cli_command import CliCommand
+from flepimop2.axis import ResolvedShape
 from flepimop2.configuration import ConfigurationModel
 from flepimop2.meta import RunMeta
-from flepimop2.parameter.abc import build as build_parameter
+from flepimop2.parameter.abc import ParameterValue
 from flepimop2.scenario.abc import build as build_scenario
 from flepimop2.simulator import Simulator
 from flepimop2.typing import ExitCode
+
+
+def _scenario_value(
+    value: object,
+    template: ParameterValue | None = None,
+) -> ParameterValue:
+    shape = template.shape if template is not None else ResolvedShape()
+    return ParameterValue(np.asarray(value, dtype=np.float64), shape)
 
 
 class SimulateCommand(CliCommand):
@@ -59,48 +68,12 @@ class SimulateCommand(CliCommand):
         config_model = ConfigurationModel.from_yaml(config)
 
         simulator = Simulator.from_configuration_model(config_model, target=target)
+        initial_state, params = simulator.resolve_inputs()
 
         if simulator.simulate_config is None:
             msg = "simulate_config must be set before running the simulator."
             self.error(msg)
             return ExitCode.CONFIGURATION
-
-        ic_map: dict[str, str] | None = simulator.system.option(
-            "initial_state",
-            default=None,
-        )
-        if ic_map is not None:
-            state_names: tuple[str, ...] = simulator.system.option("state_names")
-            ic_param_names = set(ic_map.values())
-            initial_state = np.array(
-                [
-                    build_parameter(config_model.parameters[ic_map[s]]).sample().item()
-                    for s in state_names
-                ],
-                dtype=np.float64,
-            )
-            params = {
-                k: build_parameter(v).sample().item()
-                for k, v in config_model.parameters.items()
-                if k not in ic_param_names
-            }
-        else:
-            s0 = build_parameter(config_model.parameters["s0"])
-            i0 = build_parameter(config_model.parameters["i0"])
-            r0 = build_parameter(config_model.parameters["r0"])
-            initial_state = np.array(
-                [
-                    s0.sample().item(),
-                    i0.sample().item(),
-                    r0.sample().item(),
-                ],
-                dtype=np.float64,
-            )
-            params = {
-                k: build_parameter(v).sample().item()
-                for k, v in config_model.parameters.items()
-                if k not in {"s0", "i0", "r0"}
-            }
 
         for component in ["system", "engine", "backend"]:
             name = getattr(simulator.simulate_config, component)
@@ -118,9 +91,22 @@ class SimulateCommand(CliCommand):
             scenario_config = build_scenario(config_model.scenarios[scenario_name])
             for counter, scenario_tuple in enumerate(scenario_config.scenarios()):
                 self.info(f"Running scenario: {scenario_tuple}")
+                scenario_initial_state = initial_state.copy()
+                scenario_params = params.copy()
+                for key, value in scenario_tuple._asdict().items():
+                    if key in scenario_initial_state:
+                        scenario_initial_state[key] = _scenario_value(
+                            value,
+                            scenario_initial_state[key],
+                        )
+                    else:
+                        scenario_params[key] = _scenario_value(
+                            value,
+                            scenario_params.get(key),
+                        )
                 simulator.run(
-                    initial_state,
-                    (params | scenario_tuple._asdict()),
+                    scenario_initial_state,
+                    scenario_params,
                     meta=RunMeta(name=f"scenario_{counter}"),
                 )
         else:

--- a/src/flepimop2/_utils/_checked_partial.py
+++ b/src/flepimop2/_utils/_checked_partial.py
@@ -138,26 +138,24 @@ def _checked_partial(
 
     # Validate parameter value types against signature annotations
     for key, value in signature.parameters.items():
-        if key in offered_keys:
-            expected_type = value.annotation
-            if (
-                expected_type is not inspect.Parameter.empty
-                and expected_type is not Any
+        if key not in offered_keys:
+            continue
+        expected_type = value.annotation
+        if expected_type is inspect.Parameter.empty or expected_type is Any:
+            continue
+        try:
+            if isinstance(expected_type, type) and isinstance(
+                params[key], expected_type
             ):
-                try:
-                    if isinstance(expected_type, type) and isinstance(
-                        params[key], expected_type
-                    ):
-                        continue
-                    casted_value = expected_type(params[key])
-                    params[key] = casted_value
-                except (ValueError, TypeError) as e:
-                    offered_type = type(params[key])
-                    msg = (
-                        f"Parameter '{key}' (type {offered_type.__name__}) "
-                        f"could not be cast to {expected_type.__name__}. Error: {e!s}"
-                    )
-                    validation_errors.append(msg)
+                continue
+            params[key] = expected_type(params[key])
+        except (ValueError, TypeError) as e:
+            offered_type = type(params[key])
+            msg = (
+                f"Parameter '{key}' (type {offered_type.__name__}) "
+                f"could not be cast to {expected_type.__name__}. Error: {e!s}"
+            )
+            validation_errors.append(msg)
 
     if validation_errors:
         validation_errors = [

--- a/src/flepimop2/engine/abc/__init__.py
+++ b/src/flepimop2/engine/abc/__init__.py
@@ -17,26 +17,45 @@
 
 __all__ = ["EngineABC", "EngineProtocol", "build"]
 
-from typing import Any
+from collections.abc import Mapping
+from typing import Any, Protocol, runtime_checkable
 
 from flepimop2._utils._module import _build
 from flepimop2.configuration import ModuleModel
 from flepimop2.exceptions import ValidationIssue
 from flepimop2.module import ModuleABC
+from flepimop2.parameter.abc import ModelStateSpecification, ParameterValue
 from flepimop2.system.abc import SystemABC
 from flepimop2.typing import (
-    EngineProtocol,
     Float64NDArray,
     IdentifierString,
     SystemProtocol,
 )
 
 
+@runtime_checkable
+class EngineProtocol(Protocol):
+    """Type-definition (Protocol) for engine runner functions."""
+
+    def __call__(
+        self,
+        stepper: SystemProtocol,
+        times: Float64NDArray,
+        initial_state: dict[IdentifierString, ParameterValue],
+        params: Mapping[IdentifierString, ParameterValue],
+        model_state: ModelStateSpecification | None = None,
+        **kwargs: Any,
+    ) -> Float64NDArray:
+        """Protocol for engine runner functions."""
+        ...
+
+
 def _no_run_func(
     stepper: SystemProtocol,
     times: Float64NDArray,
-    state: Float64NDArray,
-    params: dict[IdentifierString, Any],
+    initial_state: dict[IdentifierString, ParameterValue],
+    params: Mapping[IdentifierString, ParameterValue],
+    model_state: ModelStateSpecification | None = None,
     **kwargs: Any,
 ) -> Float64NDArray:
     msg = "EngineABC::_runner must be provided by a concrete implementation."
@@ -65,8 +84,9 @@ class EngineABC(ModuleABC, module_namespace="engine"):
         self,
         system: SystemABC,
         eval_times: Float64NDArray,
-        initial_state: Float64NDArray,
-        params: dict[IdentifierString, Any],
+        initial_state: dict[IdentifierString, ParameterValue],
+        params: Mapping[IdentifierString, ParameterValue],
+        model_state: ModelStateSpecification | None = None,
         **kwargs: Any,
     ) -> Float64NDArray:
         """
@@ -75,8 +95,11 @@ class EngineABC(ModuleABC, module_namespace="engine"):
         Args:
             system: The dynamic system to be evolved.
             eval_times: Array of time points for evaluation.
-            initial_state: The initial state array.
+            initial_state: Structured initial-state entries sampled from
+                parameters.
             params: Additional parameters for the stepper.
+            model_state: Specification describing the semantic ordering of the
+                state entries.
             **kwargs: Additional keyword arguments for the engine.
 
         Returns:
@@ -87,6 +110,7 @@ class EngineABC(ModuleABC, module_namespace="engine"):
             eval_times,
             initial_state,
             params,
+            model_state=model_state,
             **kwargs,
         )
 

--- a/src/flepimop2/simulator.py
+++ b/src/flepimop2/simulator.py
@@ -16,7 +16,9 @@
 """Simulation orchestration for flepimop2."""
 
 __all__ = ["Simulator"]
+
 from flepimop2._utils._click import _get_config_target
+from flepimop2.axis import AxisCollection
 from flepimop2.backend.abc import BackendABC
 from flepimop2.backend.abc import build as build_backend
 from flepimop2.configuration import (
@@ -28,9 +30,14 @@ from flepimop2.engine.abc import EngineABC
 from flepimop2.engine.abc import build as build_engine
 from flepimop2.exceptions import Flepimop2ValidationError
 from flepimop2.meta import RunMeta
+from flepimop2.parameter.abc import (
+    ParameterRequest,
+    ParameterValue,
+)
+from flepimop2.parameter.abc import build as build_parameter
 from flepimop2.system.abc import SystemABC
 from flepimop2.system.abc import build as build_system
-from flepimop2.typing import Float64NDArray
+from flepimop2.typing import Float64NDArray, IdentifierString
 
 
 class Simulator:
@@ -57,6 +64,8 @@ class Simulator:
     system_config: ModuleModel | None = None
     engine_config: ModuleModel | None = None
     backend_config: ModuleModel | None = None
+    parameter_configs: dict[IdentifierString, ModuleModel] | None = None
+    axes: AxisCollection
 
     def __init__(  # noqa: PLR0913
         self,
@@ -69,6 +78,8 @@ class Simulator:
         system_config: ModuleModel | None = None,
         engine_config: ModuleModel | None = None,
         backend_config: ModuleModel | None = None,
+        parameter_configs: dict[IdentifierString, ModuleModel] | None = None,
+        axes: AxisCollection | None = None,
     ) -> None:
         """
         Initialize the simulator with resolved components.
@@ -82,6 +93,9 @@ class Simulator:
             system_config: The resolved system configuration model, if available.
             engine_config: The resolved engine configuration model, if available.
             backend_config: The resolved backend configuration model, if available.
+            parameter_configs: The resolved parameter configuration models, if
+                available.
+            axes: The resolved runtime axis collection for the simulation.
 
         Raises:
             Flepimop2ValidationError: If the engine is incompatible with the system.
@@ -92,6 +106,8 @@ class Simulator:
         self.system_config = system_config
         self.engine_config = engine_config
         self.backend_config = backend_config
+        self.parameter_configs = parameter_configs
+        self.axes = axes or AxisCollection()
         self.system = system
         self.engine = engine
         self.backend = backend
@@ -135,20 +151,82 @@ class Simulator:
             system_config=system_config,
             engine_config=engine_config,
             backend_config=backend_config,
+            parameter_configs=config_model.parameters,
+            axes=AxisCollection.from_config(config_model.axes),
         )
+
+    def _sample_parameter(
+        self,
+        name: IdentifierString,
+        request: ParameterRequest,
+    ) -> ParameterValue:
+        """
+        Build and sample a requested parameter from configuration.
+
+        Returns:
+            The sampled parameter value and runtime shape metadata.
+
+        Raises:
+            KeyError: If the requested parameter is missing from configuration.
+            ValueError: If parameter configuration has not been attached.
+        """
+        if self.parameter_configs is None:
+            msg = "parameter_configs must be set before resolving parameters."
+            raise ValueError(msg)
+        if name not in self.parameter_configs:
+            msg = f"Required parameter '{name}' was requested but not configured."
+            raise KeyError(msg)
+        parameter = build_parameter(self.parameter_configs[name])
+        return parameter.sample(axes=self.axes, request=request)
+
+    def resolve_inputs(
+        self,
+    ) -> tuple[
+        dict[IdentifierString, ParameterValue],
+        dict[IdentifierString, ParameterValue],
+    ]:
+        """
+        Resolve configured parameters into an initial state and stepper inputs.
+
+        Returns:
+            Structured initial-state entries and structured stepper parameters.
+
+        Raises:
+            KeyError: If a required parameter is missing from configuration.
+            ValueError: If model state cannot be resolved for the system.
+        """
+        state_spec = self.system.model_state(self.axes)
+        if state_spec is None:
+            msg = "System did not declare model_state."
+            raise ValueError(msg)
+
+        state_samples = {
+            name: self._sample_parameter(name, request)
+            for name, request in state_spec.requests().items()
+        }
+        resolved_params: dict[IdentifierString, ParameterValue] = {}
+        for name, request in self.system.requested_parameters(self.axes).items():
+            if self.parameter_configs is None or name not in self.parameter_configs:
+                if request.optional:
+                    continue
+                msg = f"Required parameter '{name}' was requested but not configured."
+                raise KeyError(msg)
+            resolved_params[name] = self._sample_parameter(name, request)
+
+        return state_samples, resolved_params
 
     def run(
         self,
-        initial_state: Float64NDArray,
-        params: dict[str, float],
+        initial_state: dict[IdentifierString, ParameterValue] | None = None,
+        params: dict[IdentifierString, ParameterValue] | None = None,
         meta: RunMeta | None = None,
     ) -> Float64NDArray:
         """
         Run the simulation and persist results via the backend.
 
         Args:
-            initial_state: The initial state array for the simulation.
-            params: The parameter dict for the simulation.
+            initial_state: Structured initial-state entries for the simulation.
+            params: Structured stepper parameters for the simulation.
             meta: Metadata about the simulation run.
 
         Returns:
@@ -161,11 +239,24 @@ class Simulator:
         if self.simulate_config is None:
             msg = "simulate_config must be set before running the simulator."
             raise ValueError(msg)
+        model_state = self.system.model_state(self.axes)
+        if model_state is None:
+            msg = "System did not declare model_state."
+            raise ValueError(msg)
+        if initial_state is None and params is None:
+            initial_state, params = self.resolve_inputs()
+        elif initial_state is None or params is None:
+            msg = (
+                "initial_state and params must either both be "
+                "provided or both be omitted."
+            )
+            raise ValueError(msg)
         res = self.engine.run(
             self.system,
             self.simulate_config.t_eval,
             initial_state,
             params,
+            model_state=model_state,
         )
         meta = meta or RunMeta()
         self.backend.save(res, meta)

--- a/src/flepimop2/typing.py
+++ b/src/flepimop2/typing.py
@@ -29,7 +29,6 @@ Examples:
 """
 
 __all__ = [
-    "EngineProtocol",
     "ExitCode",
     "Float64NDArray",
     "IdentifierString",
@@ -222,19 +221,3 @@ def as_system_protocol(func: _SystemCallable[_P]) -> SystemProtocol:
         The function cast as SystemProtocol.
     """
     return cast("SystemProtocol", func)
-
-
-@runtime_checkable
-class EngineProtocol(Protocol):
-    """Type-definition (Protocol) for engine runner functions."""
-
-    def __call__(
-        self,
-        stepper: SystemProtocol,
-        times: Float64NDArray,
-        state: Float64NDArray,
-        params: dict[IdentifierString, Any],
-        **kwargs: Any,
-    ) -> Float64NDArray:
-        """Protocol for engine runner functions."""
-        ...

--- a/tests/engine/engine_wrapper_assets/dummy_engine.py
+++ b/tests/engine/engine_wrapper_assets/dummy_engine.py
@@ -15,21 +15,23 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """A dummy stepper function for testing `WrapperEngine`."""
 
-from typing import Any
+from collections.abc import Mapping
 
 import numpy as np
 
+from flepimop2.parameter.abc import ModelStateSpecification, ParameterValue
 from flepimop2.system.abc import SystemProtocol
 from flepimop2.typing import Float64NDArray, IdentifierString
 
 
-def runner(
+def runner(  # noqa: PLR0913
     f: SystemProtocol,
     times: Float64NDArray,
-    state: Float64NDArray,
-    params: dict[IdentifierString, Any],
+    initial_state: dict[IdentifierString, ParameterValue],
+    params: Mapping[IdentifierString, ParameterValue],
     *,
-    accumulate: bool,
+    model_state: ModelStateSpecification | None = None,
+    accumulate: bool = False,
 ) -> Float64NDArray:
     """
     A dummy runner function for testing purposes: only evaluates stepper at times.
@@ -37,19 +39,31 @@ def runner(
     Args:
         f: The stepper function.
         times: Array of time points.
-        state: The current state array.
+        initial_state: Structured initial-state entries.
         params: Additional parameters for the stepper.
+        model_state: Specification describing how to order the initial-state
+            entries into a numeric state array.
         accumulate: Whether to accumulate results over time.
 
     Returns:
         The state array evaluated at each time point.
+
+    Raises:
+        ValueError: If `model_state` is not provided.
     """
-    # numpy array to hold results - first column time, rest state
-    res = np.zeros((len(times), len(state) + 1), dtype=np.float64)
+    if model_state is None:
+        msg = "model_state must be provided to assemble the initial state."
+        raise ValueError(msg)
+    state = np.stack([
+        initial_state[name].value for name in model_state.parameter_names
+    ]).astype(np.float64)
+    flat_state = state.reshape(-1)
+    res = np.zeros((len(times), flat_state.size + 1), dtype=np.float64)
     res[:, 0] = times
-    res[0, 1:] = state
-    for i, t in enumerate(times[1:]):
-        if accumulate:
-            res[i + 1, 1:] = res[i, 1:]
-        res[i + 1, 1:] += f(t, res[i, 1:], **params)
+    res[0, 1:] = flat_state
+    current_state = state
+    for i, t in enumerate(times[1:], start=1):
+        next_state = f(t, current_state, **params)
+        current_state = current_state + next_state if accumulate else next_state
+        res[i, 1:] = current_state.reshape(-1)
     return res

--- a/tests/engine/test_engine_abc.py
+++ b/tests/engine/test_engine_abc.py
@@ -18,7 +18,9 @@
 import numpy as np
 import pytest
 
+from flepimop2.axis import ResolvedShape
 from flepimop2.engine.abc import EngineABC
+from flepimop2.parameter.abc import ModelStateSpecification, ParameterValue
 from flepimop2.system.abc import SystemABC
 from flepimop2.system.abc import wrap as system_wrap
 from flepimop2.typing import Float64NDArray, StateChangeEnum, as_system_protocol
@@ -28,7 +30,8 @@ from flepimop2.typing import Float64NDArray, StateChangeEnum, as_system_protocol
 def sample_step(
     time: np.float64,
     state: Float64NDArray,
-    offset: np.float64,
+    /,
+    **kwargs: ParameterValue,
 ) -> Float64NDArray:
     """
     A simple stepper function for testing purposes.
@@ -36,12 +39,12 @@ def sample_step(
     Args:
         time: The current time as a float64.
         state: The current state as a numpy array.
-        offset: The offset value.
+        **kwargs: Additional keyword arguments, including `offset`.
 
     Returns:
         The updated state after applying the stepper logic.
     """
-    return (state + offset) * time
+    return (state + kwargs["offset"].item()) * time
 
 
 DummySystem = system_wrap(sample_step, StateChangeEnum.STATE)
@@ -61,6 +64,11 @@ def test_abstraction_error(engine: EngineABC, system: SystemABC) -> None:
         engine.run(
             system,
             np.array([0.0], dtype=np.float64),
-            np.array([1.0, 2.0, 3.0], dtype=np.float64),
+            {
+                "s0": ParameterValue(np.array(1.0), ResolvedShape()),
+                "i0": ParameterValue(np.array(2.0), ResolvedShape()),
+                "r0": ParameterValue(np.array(3.0), ResolvedShape()),
+            },
             {},
+            model_state=ModelStateSpecification(parameter_names=("s0", "i0", "r0")),
         )

--- a/tests/engine/test_engine_wrapper.py
+++ b/tests/engine/test_engine_wrapper.py
@@ -24,7 +24,7 @@ import pytest
 from flepimop2.axis import ResolvedShape
 from flepimop2.engine.abc import build as engine_build
 from flepimop2.exceptions import ValidationIssue
-from flepimop2.parameter.abc import ParameterValue
+from flepimop2.parameter.abc import ModelStateSpecification, ParameterValue
 from flepimop2.system.abc import SystemABC
 from flepimop2.system.abc import build as system_build
 from flepimop2.typing import StateChangeEnum
@@ -66,8 +66,12 @@ def test_wrapper_system(
     result = engine.run(
         system,
         np.array([1.0, 2.0], dtype=np.float64),
-        np.array([1.0, 2.0], dtype=np.float64),
+        {
+            "x0": ParameterValue(np.array(1.0), ResolvedShape()),
+            "x1": ParameterValue(np.array(2.0), ResolvedShape()),
+        },
         params,
+        model_state=ModelStateSpecification(parameter_names=("x0", "x1")),
         accumulate=False,
     )
     expected = np.zeros((2, 3), dtype=np.float64)

--- a/tests/integration/external_provider/config.yaml
+++ b/tests/integration/external_provider/config.yaml
@@ -1,5 +1,10 @@
 ---
 name: 'example-provider'
+axes:
+  age:
+    kind: 'continuous'
+    domain: [0.0, 90.0]
+    size: 3
 system:
   - module: 'sir'
     state_change: 'flow'
@@ -14,10 +19,19 @@ simulate:
 parameters:
   s0:
     module: 'fixed'
-    value: 999
+    value: [999, 899, 799]
+    shape: ['age']
   i0:
     module: 'fixed'
-    value: 1
+    value: [1, 1, 1]
+    shape: ['age']
   r0:
     module: 'fixed'
-    value: 0
+    value: [0, 0, 0]
+    shape: ['age']
+  gamma:
+    module: 'fixed'
+    value: 0.1
+  beta:
+    module: 'linear'
+    slope: 0.001

--- a/tests/integration/external_provider/euler.py
+++ b/tests/integration/external_provider/euler.py
@@ -15,12 +15,14 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """Runner function for SIR model integration tests."""
 
+from collections.abc import Mapping
 from typing import Any
 
 import numpy as np
 
 from flepimop2.configuration import ModuleModel
 from flepimop2.engine.abc import EngineABC
+from flepimop2.parameter.abc import ModelStateSpecification, ParameterValue
 from flepimop2.system.abc import SystemProtocol
 from flepimop2.typing import Float64NDArray, IdentifierString
 
@@ -28,8 +30,9 @@ from flepimop2.typing import Float64NDArray, IdentifierString
 def runner(
     stepper: SystemProtocol,
     times: Float64NDArray,
-    state: Float64NDArray,
-    params: dict[IdentifierString, Any],
+    initial_state: dict[IdentifierString, ParameterValue],
+    params: Mapping[IdentifierString, ParameterValue],
+    model_state: ModelStateSpecification | None = None,
     **kwargs: Any,  # noqa: ARG001
 ) -> Float64NDArray:
     """
@@ -38,22 +41,35 @@ def runner(
     Args:
         stepper: The system stepper function.
         times: Array of time points.
-        state: The current state array.
+        initial_state: Structured initial-state entries.
         params: Additional parameters for the stepper.
+        model_state: Specification describing how to order the initial-state
+            entries into a numeric state array.
         **kwargs: Additional keyword arguments for the engine. Unused by this runner.
 
     Returns:
         The evolved time x state array.
+
+    Raises:
+        ValueError: If `model_state` is not provided.
     """
-    output = np.zeros((len(times), len(state)), dtype=float)
-    output[0] = state
-    for i, t in enumerate(times[1:]):
-        if i == 0:
-            continue
+    if model_state is None:
+        msg = "model_state must be provided to assemble the initial state."
+        raise ValueError(msg)
+    state = np.stack([
+        initial_state[name].value for name in model_state.parameter_names
+    ]).astype(np.float64)
+    flat_size = state.size
+    output = np.zeros((len(times), flat_size + 1), dtype=float)
+    output[:, 0] = times
+    output[0, 1:] = state.reshape(-1)
+    current_state = state
+    for i, t in enumerate(times[1:], start=1):
         dt = t - times[i - 1]
-        dydt = stepper(times[i - 1], output[i - 1], **params)
-        output[i] = output[i - 1] + (dydt * dt)
-    return np.hstack((times.reshape(-1, 1), output))
+        dydt = stepper(times[i - 1], current_state, **params)
+        current_state += dydt * dt
+        output[i, 1:] = current_state.reshape(-1)
+    return output
 
 
 class EulerEngine(EngineABC):

--- a/tests/integration/external_provider/linear.py
+++ b/tests/integration/external_provider/linear.py
@@ -1,0 +1,69 @@
+# flepimop2: The FLExible Pipeline for Interchangeable MOdel Processing
+# Copyright (C) 2026  Carl Pearson, Joshua Macdonald, Timothy Willard
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Linear parameter implementation for external-provider integration tests."""
+
+import numpy as np
+
+from flepimop2.axis import AxisCollection
+from flepimop2.configuration import ModuleModel
+from flepimop2.parameter.abc import ParameterABC, ParameterRequest, ParameterValue
+
+
+class LinearParameter(ModuleModel, ParameterABC, module="linear"):
+    """Parameter that scales one continuous axis by a configured slope."""
+
+    slope: float
+
+    def sample(
+        self,
+        *,
+        axes: AxisCollection | None = None,
+        request: ParameterRequest | None = None,
+    ) -> ParameterValue:
+        """
+        Sample values by multiplying one continuous axis's points by `slope`.
+
+        Args:
+            axes: Resolved runtime axes available for the current simulation.
+            request: System request describing the required parameter shape.
+
+        Returns:
+            A `ParameterValue` aligned with the requested axis.
+
+        Raises:
+            ValueError: If runtime axes are unavailable.
+            ValueError: If no request is provided.
+            ValueError: If the request does not name exactly one axis.
+        """
+        if axes is None:
+            msg = "LinearParameter requires runtime axes to sample values."
+            raise ValueError(msg)
+        if request is None:
+            msg = "LinearParameter requires a parameter request to determine shape."
+            raise ValueError(msg)
+        if len(request.axes) != 1:
+            msg = (
+                "LinearParameter currently supports exactly one requested axis; "
+                f"got {request.axes}."
+            )
+            raise ValueError(msg)
+
+        axis = axes[request.axes[0]]
+        values = self.slope * np.asarray(axis.points(), dtype=np.float64)
+        return ParameterValue(
+            value=values,
+            shape=axes.resolve_shape(request.axes),
+        )

--- a/tests/integration/external_provider/sir.py
+++ b/tests/integration/external_provider/sir.py
@@ -17,11 +17,17 @@
 
 import functools
 import sys
-from typing import Any, ParamSpec
+from typing import Any
 
 import numpy as np
 
+from flepimop2.axis import AxisCollection
 from flepimop2.configuration import ModuleModel
+from flepimop2.parameter.abc import (
+    ModelStateSpecification,
+    ParameterRequest,
+    ParameterValue,
+)
 from flepimop2.system.abc import SystemABC
 from flepimop2.typing import (
     Float64NDArray,
@@ -36,28 +42,33 @@ else:
     from typing_extensions import override
 
 
-def sir_stepper(
+def stepper(
     time: np.float64,  # noqa: ARG001
     state: Float64NDArray,
-    beta: float = 0.3,
-    gamma: float = 0.1,
+    *,
+    beta: ParameterValue,
+    gamma: ParameterValue | None = None,
+    **kwargs: Any,  # noqa: ARG001
 ) -> Float64NDArray:
     """
-    ODE for an SIR model.
+    ODE for an age-stratified SIR model with isolated age groups.
 
     Args:
         time: Current time (not used in this model).
-        state: Current state array [S, I, R].
-        beta: The infection rate.
-        gamma: The recovery rate.
+        state: Current state array shaped `(3, n_age)`.
+        beta: Age-specific transmission rates from the external provider.
+        gamma: The recovery-rate parameter.
+        **kwargs: Additional parameters.
 
     Returns:
-        Next state array after one step.
+        Next state array after one step with shape `(3, n_age)`.
     """
-    y_s, y_i, _ = np.asarray(state, dtype=float)
-    infection = beta * y_s * y_i / np.sum(state)
-    recovery = gamma * y_i
-    return np.array([-infection, infection - recovery, recovery], dtype=float)
+    y_s, y_i, y_r = np.asarray(state, dtype=float)
+    gamma_value = gamma.item() if gamma is not None else 0.1
+    totals = y_s + y_i + y_r
+    infection = beta.value * y_s * y_i / totals
+    recovery = gamma_value * y_i
+    return np.vstack((-infection, infection - recovery, recovery)).astype(np.float64)
 
 
 class SirSystem(SystemABC):
@@ -66,13 +77,42 @@ class SirSystem(SystemABC):
     module = "flepimop2.system.sir"
     state_change = StateChangeEnum.FLOW
 
-    P = ParamSpec("P")
-
     @override
     def _bind_impl(
         self, params: dict[IdentifierString, Any] | None = None
     ) -> SystemProtocol:
-        return functools.partial(sir_stepper, **(params or {}))
+        return functools.partial(stepper, **(params or {}))
+
+    def requested_parameters(
+        self,
+        axes: AxisCollection,  # noqa: ARG002
+    ) -> dict[str, ParameterRequest]:
+        """
+        Declare the non-state parameters consumed by the SIR stepper.
+
+        Returns:
+            Runtime parameter requests for the SIR stepper.
+        """
+        return {
+            "beta": ParameterRequest(name="beta", axes=("age",)),
+            "gamma": ParameterRequest(name="gamma", optional=True),
+        }
+
+    def model_state(
+        self,
+        axes: AxisCollection,  # noqa: ARG002
+    ) -> ModelStateSpecification:
+        """
+        Declare how parameter entries assemble the SIR state vector.
+
+        Returns:
+            The model-state specification for the SIR system.
+        """
+        return ModelStateSpecification(
+            parameter_names=("s0", "i0", "r0"),
+            axes=("age",),
+            labels=("S", "I", "R"),
+        )
 
 
 def build(config: dict[str, Any] | ModuleModel) -> SirSystem:  # noqa: ARG001

--- a/tests/integration/external_provider/test_external_provider.py
+++ b/tests/integration/external_provider/test_external_provider.py
@@ -18,6 +18,7 @@
 import re
 from pathlib import Path
 
+import numpy as np
 import pytest
 
 from flepimop2.testing import external_provider_package, flepimop2_run
@@ -54,6 +55,9 @@ def test_external_provider(
             repo_root / "tests/integration/external_provider/sir.py": Path(
                 "external_provider/src/flepimop2/system/sir.py"
             ),
+            repo_root / "tests/integration/external_provider/linear.py": Path(
+                "external_provider/src/flepimop2/parameter/linear.py"
+            ),
         },
     )
     monkeypatch.chdir(tmp_path)
@@ -72,3 +76,8 @@ def test_external_provider(
     csv = model_output[0]
     assert re.match(r"^simulate_\d{8}_\d{6}\.csv$", csv.name)
     assert csv.stat().st_size > 0
+    data = np.loadtxt(csv, delimiter=",")
+    assert data.shape == (101, 10)
+    np.testing.assert_allclose(data[0, 1:4], np.array([999.0, 899.0, 799.0]))
+    np.testing.assert_allclose(data[0, 4:7], np.array([1.0, 1.0, 1.0]))
+    np.testing.assert_allclose(data[0, 7:10], np.array([0.0, 0.0, 0.0]))

--- a/tests/simulator/test_simulator_class.py
+++ b/tests/simulator/test_simulator_class.py
@@ -1,0 +1,119 @@
+# flepimop2: The FLExible Pipeline for Interchangeable MOdel Processing
+# Copyright (C) 2026  Carl Pearson, Joshua Macdonald, Timothy Willard
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Tests for simulator input resolution from system contracts."""
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from flepimop2.configuration import ConfigurationModel
+from flepimop2.simulator import Simulator
+
+ENGINE_SCRIPT = (
+    Path(__file__).parent.parent
+    / "engine"
+    / "engine_wrapper_assets"
+    / "dummy_engine.py"
+)
+SYSTEM_SCRIPT = (
+    Path(__file__).parent.parent
+    / "system"
+    / "system_wrapper_assets"
+    / "wrapper_system_with_extras.py"
+)
+
+
+def test_simulator_resolves_inputs_and_runs(
+    tmp_path: Path,
+) -> None:
+    """Simulator should resolve structured inputs and execute the engine."""
+    output_root = tmp_path / "model_output"
+    output_root.mkdir()
+    config = ConfigurationModel.model_validate({
+        "axes": {
+            "age": {
+                "kind": "categorical",
+                "labels": ["0-17", "18-64", "65+"],
+            }
+        },
+        "systems": {
+            "demo": {
+                "module": "wrapper",
+                "script": SYSTEM_SCRIPT,
+                "state_change": "flow",
+                "requested_parameters": {
+                    "beta": None,
+                    "gamma": {
+                        "axes": ["age"],
+                        "broadcast": True,
+                    },
+                },
+                "model_state": {
+                    "parameter_names": ["s0", "i0", "r0"],
+                    "axes": ["age"],
+                    "broadcast": True,
+                    "labels": ["S", "I", "R"],
+                },
+            }
+        },
+        "engines": {
+            "demo": {
+                "module": "wrapper",
+                "script": ENGINE_SCRIPT,
+                "state_change": "flow",
+            }
+        },
+        "backends": {"demo": {"module": "csv", "root": output_root}},
+        "parameters": {
+            "s0": {"module": "fixed", "value": 100.0},
+            "i0": {"module": "fixed", "value": 1.0},
+            "r0": {"module": "fixed", "value": 0.0},
+            "beta": {"module": "fixed", "value": 0.3},
+            "gamma": {"module": "fixed", "value": 0.1},
+        },
+        "simulate": {
+            "demo": {
+                "system": "demo",
+                "engine": "demo",
+                "backend": "demo",
+                "times": [0.0, 1.0],
+            }
+        },
+    })
+
+    simulator = Simulator.from_configuration_model(config)
+    initial_state, params = simulator.resolve_inputs()
+
+    assert tuple(initial_state) == ("s0", "i0", "r0")
+    np.testing.assert_array_equal(initial_state["s0"].value, np.array([100.0] * 3))
+    np.testing.assert_array_equal(initial_state["i0"].value, np.array([1.0] * 3))
+    np.testing.assert_array_equal(initial_state["r0"].value, np.array([0.0] * 3))
+    assert params["beta"].item() == pytest.approx(0.3)
+    np.testing.assert_array_equal(params["gamma"].value, np.array([0.1, 0.1, 0.1]))
+
+    result = simulator.run(initial_state, params)
+
+    assert result.shape == (2, 10)
+    np.testing.assert_array_equal(result[:, 0], np.array([0.0, 1.0]))
+    np.testing.assert_array_equal(
+        result[0, 1:],
+        np.array([100.0, 100.0, 100.0, 1.0, 1.0, 1.0, 0.0, 0.0, 0.0]),
+    )
+    np.testing.assert_allclose(
+        result[1, 1:],
+        np.array([100.4, 100.4, 100.4, 1.4, 1.4, 1.4, 0.4, 0.4, 0.4]),
+    )


### PR DESCRIPTION
It pushes `ParameterValue` and model-state handling through the
simulator and engine interfaces so simulation, external providers, and
the docs example all execute against the same structured parameter
contract.

- Updated `EngineABC` and the engine protocol to run against structured
  `initial_state`, `params`, and optional `model_state`.
- Removed the engine protocol from `flepimop2.typing` and keep the
  engine specific contract alongside `engine.abc` and allow it to depend
  on `ParameterValue`.
- Adapted wrapper engine fixtures and tests to assemble numeric state
  from `ModelStateSpecification` and `ParameterValue` inputs.
- Wired the simulator and CLI flow through resolved structured inputs
  instead of hard-coded scalar state assembly.
- Added external-provider integration coverage for axis-aware state and
  a linear parameter source.