### PR TITLE
Simplify module API with class-level `module=`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Introduced the axis concept as a way to represent aligned shapes across parameters, systems, etc. Added two kinds of axes, categorical and continuous, to represent different kinds of dimensions. Also added an `axes` top level key to the `ConfigurationModel` so users can provide these axes via configuration, but setting this currently results in a warning since it has no effect. See [#147](https://github.com/ACCIDDA/flepimop2/issues/147).
 - Refactor `SystemABC` type approach to binding (and fix knock on mypy typing issues, circular dependency issues). Briefly, a `SystemABC` implementation now only needs to provide `_bind_impl` which fixes (or not) parameters in the system. This update adds another internal implementation (`AdapterSystem`) for directly creating a system from locally `def`d function (vs `WrapperSystem` which reads from a file).
 - Added infrastructure for submitting package to PyPI. See [#123](https://github.com/ACCIDDA/flepimop2/issues/123), [#142](https://github.com/ACCIDDA/flepimop2/issues/142), [#195](https://github.com/ACCIDDA/flepimop2/issues/195), [#196](https://github.com/ACCIDDA/flepimop2/issues/196).
+- Modules can now declare their name via the `module` keyword argument to class declaration to simplify naming for developers. See [#88](https://github.com/ACCIDDA/flepimop2/issues/88).
 
 ### Changed
 

--- a/docs/development/creating-an-external-provider-package.md
+++ b/docs/development/creating-an-external-provider-package.md
@@ -127,7 +127,6 @@ When you inherit from [`ModuleModel`][flepimop2.configuration.ModuleModel], your
 
 import os
 from pathlib import Path
-from typing import Literal
 
 import numpy as np
 from flepimop2.typing import Float64NDArray
@@ -138,10 +137,9 @@ from flepimop2.configuration import ModuleModel
 from flepimop2.meta import RunMeta
 
 
-class NpzBackend(ModuleModel, BackendABC):
+class NpzBackend(ModuleModel, BackendABC, module="npz"):
     """NPZ backend for saving numpy arrays to .npz files."""
 
-    module: Literal["flepimop2.backend.npz"] = "flepimop2.backend.npz"
     root: Path = Field(default_factory=lambda: Path.cwd() / "model_output")
     compressed: bool = Field(default=True, description="Use compression when saving")
 
@@ -211,10 +209,21 @@ class NpzBackend(ModuleModel, BackendABC):
             return npz_file["data"]
 ```
 
+The `module="npz"` class argument is the preferred API. It resolves to the fully qualified module path `"flepimop2.backend.npz"` and also configures the matching Pydantic field for the model. The explicit form is still supported if you prefer to spell it out:
+
+```python
+from typing import Literal
+
+
+class NpzBackend(ModuleModel, BackendABC):
+    module: Literal["flepimop2.backend.npz"] = "flepimop2.backend.npz"
+    ...
+```
+
 The key points of this approach are:
 
 - The class inherits from both [`ModuleModel`][flepimop2.configuration.ModuleModel] and [`BackendABC`][flepimop2.abcs.BackendABC].
-- The `module` field uses a `Literal` type hint to specify the exact module path.
+- The preferred `module="npz"` class argument resolves the exact module path while keeping the corresponding Pydantic field constrained to that value.
 - Pydantic's `Field` is used to define configuration options with defaults and descriptions.
 - Field validators can be used for custom validation logic.
 - No separate `build` function is needed, `flepimop2` is able to inspect that this class inherits [`ModuleModel`][flepimop2.configuration.ModuleModel] and creates a default `build` function.

--- a/docs/development/implementing-custom-engines-and-systems.md
+++ b/docs/development/implementing-custom-engines-and-systems.md
@@ -27,7 +27,7 @@ For now, however, we'll stick with a module that only contains this single world
 ```python
 """Stepper function for SIR model integration tests."""
 
-from typing import Any, Literal
+from typing import Any
 
 import numpy as np
 
@@ -59,10 +59,9 @@ def global_sir(
         gamma * state[1]
     ])
 
-class SirSystem(ModuleModel, SystemABC):
+class SirSystem(ModuleModel, SystemABC, module="sir"):
     """SIR model system."""
 
-    module : Literal["flepimop2.system.sir"] = "flepimop2.system.sir"
     state_change : StateChangeEnum = StateChangeEnum.FLOW
     _stepper : SystemProtocol = global_sir
 
@@ -114,10 +113,8 @@ def runner(
     pass
 
 
-class EulerEngine(EngineABC):
+class EulerEngine(EngineABC, module="euler"):
     """SIR model runner."""
-
-    module = "flepimop2.engine.euler"
 
     def __init__(self) -> None:
         """Initialize the SIR runner with the SIR runner function."""

--- a/src/flepimop2/backend/abc/__init__.py
+++ b/src/flepimop2/backend/abc/__init__.py
@@ -27,7 +27,7 @@ from flepimop2.module import ModuleABC
 from flepimop2.typing import Float64NDArray
 
 
-class BackendABC(ModuleABC):
+class BackendABC(ModuleABC, module_namespace="backend"):
     """Abstract base class for flepimop2 file IO backends."""
 
     def save(self, data: Float64NDArray, run_meta: RunMeta) -> None:

--- a/src/flepimop2/backend/csv/__init__.py
+++ b/src/flepimop2/backend/csv/__init__.py
@@ -19,7 +19,6 @@ __all__ = ["CsvBackend"]
 
 import os
 from pathlib import Path
-from typing import Literal
 
 import numpy as np
 from pydantic import Field, field_validator
@@ -30,10 +29,9 @@ from flepimop2.meta import RunMeta
 from flepimop2.typing import Float64NDArray
 
 
-class CsvBackend(ModuleModel, BackendABC):
+class CsvBackend(ModuleModel, BackendABC, module="csv"):
     """CSV backend for saving numpy arrays to CSV files."""
 
-    module: Literal["flepimop2.backend.csv"] = "flepimop2.backend.csv"
     root: Path = Field(default_factory=lambda: Path.cwd() / "model_output")
 
     @field_validator("root", mode="after")

--- a/src/flepimop2/configuration/_module.py
+++ b/src/flepimop2/configuration/_module.py
@@ -13,11 +13,12 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
-from typing import Annotated
+from typing import Annotated, Any, Literal, cast
 
 from pydantic import BaseModel, BeforeValidator, ConfigDict, Field
 
 from flepimop2._utils._pydantic import _to_default_dict
+from flepimop2.module import ModuleABC
 from flepimop2.typing import IdentifierString
 
 
@@ -26,12 +27,37 @@ class ModuleModel(BaseModel):
     Module configuration model for flepimop2.
 
     Attributes:
-        module: The type of the module.
+        module: The module identifier for the configuration. Concrete subclasses
+            may leave this as a general string field or specialize it to a fixed
+            `Literal[...]` module path.
     """
 
     model_config = ConfigDict(extra="allow")
 
     module: str = Field(min_length=1)
+
+    @classmethod
+    def __pydantic_init_subclass__(cls, **kwargs: Any) -> None:  # noqa: PLW3201
+        """
+        Finalize the `module` field for `ModuleABC` subclasses after model creation.
+
+        This keeps the explicit declaration API working while also allowing the
+        shared `module="..."` class-definition shortcut implemented in `ModuleABC`.
+
+        Args:
+            **kwargs: Additional keyword arguments passed to parent classes.
+
+        """
+        super().__pydantic_init_subclass__(**kwargs)
+        if not issubclass(cls, ModuleABC):
+            return
+        module = getattr(cls, "module", None)
+        field = cls.model_fields.get("module")
+        if not isinstance(module, str) or field is None:
+            return
+        field.annotation = cast("Any", Literal[module])
+        field.default = module
+        cls.model_rebuild(force=True)
 
 
 ModuleGroupModel = Annotated[

--- a/src/flepimop2/engine/abc/__init__.py
+++ b/src/flepimop2/engine/abc/__init__.py
@@ -43,7 +43,7 @@ def _no_run_func(
     raise NotImplementedError(msg)
 
 
-class EngineABC(ModuleABC):
+class EngineABC(ModuleABC, module_namespace="engine"):
     """Abstract class for Engines to evolve Dynamic Systems."""
 
     _runner: EngineProtocol

--- a/src/flepimop2/engine/wrapper/__init__.py
+++ b/src/flepimop2/engine/wrapper/__init__.py
@@ -18,7 +18,7 @@
 __all__ = ["WrapperEngine"]
 
 from pathlib import Path
-from typing import Literal, Self
+from typing import Self
 
 from pydantic import model_validator
 
@@ -30,10 +30,9 @@ from flepimop2.system.abc import SystemABC
 from flepimop2.typing import StateChangeEnum
 
 
-class WrapperEngine(ModuleModel, EngineABC):
+class WrapperEngine(ModuleModel, EngineABC, module="wrapper"):
     """A `EngineABC` which wraps a user-defined script file."""
 
-    module: Literal["flepimop2.engine.wrapper"] = "flepimop2.engine.wrapper"
     state_change: StateChangeEnum
     script: Path
 

--- a/src/flepimop2/module.py
+++ b/src/flepimop2/module.py
@@ -13,28 +13,33 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
-"""Base class for defining modules in the system, engine, or backend."""
+"""Base class for defining flepimop2 modules."""
 
 __all__ = ["ModuleABC"]
 
 import inspect
 from abc import ABC
-from typing import Any
+from typing import Any, ClassVar, Literal
 
 from flepimop2.typing import RaiseOnMissing, RaiseOnMissingType
 
 
 class ModuleABC(ABC):
     """
-    Abstract base class for modules in the system, engine, or backend.
+    Abstract base class for flepimop2 modules.
 
     Attributes:
-        module: The name of the module.
+        module: The fully-qualified module name. Concrete subclasses may define
+            this explicitly or provide a namespaced class keyword argument such as
+            `module="csv"`.
+        module_namespace: The flepimop2 namespace used to resolve short module
+            names such as `"csv"` into fully-qualified paths.
         options: Optional dictionary of additional options the module exposes for
             `flepimop2` to take advantage of.
 
     """
 
+    module_namespace: ClassVar[str | None] = None
     module: str
     options: dict[str, Any] | None = None
 
@@ -43,17 +48,121 @@ class ModuleABC(ABC):
         Ensure concrete subclasses define a valid module name.
 
         This validation works for both plain Python and Pydantic-based subclasses.
+        If `module_namespace="..."` or `module="..."` are supplied in the class
+        definition, they are normalized before validation.
 
         Args:
             **kwargs: Additional keyword arguments passed to parent classes.
 
-        Raises:
-            TypeError: If a concrete subclass does not define a valid `module` string.
-
         """
+        module_namespace = kwargs.pop("module_namespace", None)
+        module = kwargs.pop("module", None)
         super().__init_subclass__(**kwargs)
+        if module_namespace is not None:
+            cls._apply_module_namespace(module_namespace)
+        if module is not None:
+            cls._apply_module_shortcut(module)
         if inspect.isabstract(cls) or cls.__name__.endswith("ABC"):
             return
+        cls._validate_module_definition()
+
+    @classmethod
+    def _apply_module_namespace(cls, module_namespace: str) -> None:
+        """
+        Normalize the class-definition `module_namespace=` keyword argument.
+
+        Args:
+            module_namespace: A bare flepimop2 module namespace such as
+                `"backend"` or `"system"`.
+
+        Raises:
+            TypeError: If the namespace is invalid or conflicts with an explicit
+                `module_namespace` attribute defined in the class body.
+
+        """
+        if "module_namespace" in cls.__dict__:
+            msg = (
+                f"Class '{cls.__name__}' cannot define both class attribute "
+                "'module_namespace' and class keyword argument `module_namespace=`."
+            )
+            raise TypeError(msg)
+        if not isinstance(module_namespace, str) or not module_namespace:
+            msg = (
+                f"Class '{cls.__name__}' must define class attribute "
+                "'module_namespace' as a non-empty string."
+            )
+            raise TypeError(msg)
+        cls.module_namespace = module_namespace
+
+    @classmethod
+    def _apply_module_shortcut(cls, module: str) -> None:
+        """
+        Normalize the class-definition `module=` shortcut into a full module path.
+
+        Args:
+            module: A short module name such as "csv" or a fully-qualified path.
+
+        Raises:
+            TypeError: If the shortcut is invalid or conflicts with an explicit
+                `module` attribute defined in the class body.
+
+        """
+        if "module" in cls.__dict__:
+            msg = (
+                f"Concrete class '{cls.__name__}' cannot define both class attribute "
+                "'module' and class keyword argument `module=`."
+            )
+            raise TypeError(msg)
+        module_full_name = cls._resolve_module_name(module)
+        cls.module = module_full_name
+        cls.__annotations__ = {
+            **getattr(cls, "__annotations__", {}),
+            "module": Literal[module_full_name],
+        }
+
+    @classmethod
+    def _resolve_module_name(cls, module: str) -> str:
+        """
+        Resolve a module shortcut into a fully-qualified flepimop2 module path.
+
+        Args:
+            module: A short module name or a fully-qualified module path.
+
+        Returns:
+            The fully-qualified module path.
+
+        Raises:
+            TypeError: If the module name is invalid or the namespace cannot be
+                inferred from the subclass hierarchy.
+
+        """
+        if not isinstance(module, str) or not module:
+            msg = (
+                f"Concrete class '{cls.__name__}' must define class attribute "
+                "'module' as a non-empty string."
+            )
+            raise TypeError(msg)
+        if "." in module:
+            return module
+        if cls.module_namespace is None:
+            msg = (
+                f"Concrete class '{cls.__name__}' must define `module_namespace` to "
+                "use the class keyword argument `module=` with a short module name. "
+                "Use a fully-qualified module string or inherit from a namespaced "
+                "ModuleABC subclass."
+            )
+            raise TypeError(msg)
+        return f"flepimop2.{cls.module_namespace}.{module}"
+
+    @classmethod
+    def _validate_module_definition(cls) -> None:
+        """
+        Ensure a concrete subclass defines a valid module name.
+
+        Raises:
+            TypeError: If the subclass does not define `module` as a non-empty string.
+
+        """
         module = cls.__dict__.get("module")
         if not isinstance(module, str) or not module:
             msg = (

--- a/src/flepimop2/parameter/abc/__init__.py
+++ b/src/flepimop2/parameter/abc/__init__.py
@@ -26,7 +26,7 @@ from flepimop2.module import ModuleABC
 from flepimop2.typing import Float64NDArray
 
 
-class ParameterABC(ModuleABC):
+class ParameterABC(ModuleABC, module_namespace="parameter"):
     """Abstract base class for parameters."""
 
     @abstractmethod

--- a/src/flepimop2/parameter/fixed/__init__.py
+++ b/src/flepimop2/parameter/fixed/__init__.py
@@ -17,8 +17,6 @@
 
 __all__ = ["FixedParameter"]
 
-from typing import Literal
-
 import numpy as np
 
 from flepimop2.configuration import ModuleModel
@@ -26,7 +24,7 @@ from flepimop2.parameter.abc import ParameterABC
 from flepimop2.typing import Float64NDArray
 
 
-class FixedParameter(ModuleModel, ParameterABC):
+class FixedParameter(ModuleModel, ParameterABC, module="fixed"):
     """
     Parameter with a fixed value.
 
@@ -38,7 +36,6 @@ class FixedParameter(ModuleModel, ParameterABC):
 
     """
 
-    module: Literal["flepimop2.parameter.fixed"] = "flepimop2.parameter.fixed"
     value: float
 
     def sample(self) -> Float64NDArray:

--- a/src/flepimop2/process/abc/__init__.py
+++ b/src/flepimop2/process/abc/__init__.py
@@ -26,7 +26,7 @@ from flepimop2.exceptions import Flepimop2ValidationError, ValidationIssue
 from flepimop2.module import ModuleABC
 
 
-class ProcessABC(ModuleABC):
+class ProcessABC(ModuleABC, module_namespace="process"):
     """Abstract base class for flepimop2 processing steps."""
 
     def execute(self, *, dry_run: bool = False) -> None:

--- a/src/flepimop2/process/shell/__init__.py
+++ b/src/flepimop2/process/shell/__init__.py
@@ -18,7 +18,6 @@
 __all__ = ["ShellProcess"]
 
 from subprocess import run  # noqa: S404
-from typing import Literal
 
 from pydantic import Field
 
@@ -26,18 +25,18 @@ from flepimop2.configuration import ModuleModel
 from flepimop2.process.abc import ProcessABC
 
 
-class ShellProcess(ModuleModel, ProcessABC):
+class ShellProcess(ModuleModel, ProcessABC, module="shell"):
     """
     Shell process for executing commands.
 
     Attributes:
-        module: The module type, fixed to "flepimop2.process.shell".
+        module: The fully-qualified module name, resolved from `module="shell"` to
+            `"flepimop2.process.shell"`.
         command: The shell command to execute.
         args: Arguments to pass to the shell command.
 
     """
 
-    module: Literal["flepimop2.process.shell"] = "flepimop2.process.shell"
     command: str = Field(min_length=1)
     args: list[str] = Field(default_factory=list)
 

--- a/src/flepimop2/system/abc/__init__.py
+++ b/src/flepimop2/system/abc/__init__.py
@@ -26,7 +26,7 @@ __all__ = [
 import inspect
 import sys
 from abc import abstractmethod
-from typing import Any, Literal
+from typing import Any
 
 import numpy as np
 
@@ -48,12 +48,12 @@ else:
     from typing_extensions import override
 
 
-class SystemABC(ModuleABC):
+class SystemABC(ModuleABC, module_namespace="system"):
     """
     Abstract class for Dynamic Systems.
 
     Attributes:
-        module: The module name for the system.
+        module: The fully-qualified module name for the system.
         state_change: The type of state change.
         options: Optional dictionary of additional options the system exposes for
             `flepimop2` to take advantage of.
@@ -163,10 +163,9 @@ class SystemABC(ModuleABC):
         return self.bind()(time, state, **params)
 
 
-class _AdapterSystem(SystemABC):
+class _AdapterSystem(SystemABC, module="wrapper"):
     """A `SystemABC` which wraps a user-defined function."""
 
-    module: Literal["flepimop2.system.wrapper"] = "flepimop2.system.wrapper"
     state_change: StateChangeEnum
     stepper: SystemProtocol
     options: dict[IdentifierString, Any]

--- a/tests/module/test_module_abc_class.py
+++ b/tests/module/test_module_abc_class.py
@@ -16,12 +16,17 @@
 """Tests for `ModuleABC` class behavior."""
 
 from abc import ABC, abstractmethod
-from typing import Any, Literal
+from typing import Any, Literal, get_args
 
+import numpy as np
 import pytest
+from pydantic import ValidationError
 
+from flepimop2.backend.abc import BackendABC
 from flepimop2.configuration import ModuleModel
 from flepimop2.module import ModuleABC
+from flepimop2.process.abc import ProcessABC
+from flepimop2.typing import Float64NDArray
 
 
 def test_missing_module_attribute_raises() -> None:
@@ -100,6 +105,82 @@ def test_option_uses_default_when_missing_for_plain_subclass() -> None:
     assert mod.option("missing", default="fallback") == "fallback"
 
 
+def test_module_shortcut_sets_fully_qualified_module_for_plain_subclass() -> None:
+    """The class-definition shortcut should resolve namespaced plain modules."""
+
+    class PlainProcess(ProcessABC, module="test_process"):
+        def _process(self, *, dry_run: bool) -> None: ...
+
+    mod = PlainProcess()
+    assert mod.module == "flepimop2.process.test_process"
+
+
+def test_module_namespace_keyword_sets_public_classvar() -> None:
+    """The class-definition namespace shortcut should set `module_namespace`."""
+
+    class PluginModule(ModuleABC, module_namespace="plugin", module="demo"):
+        pass
+
+    assert PluginModule.module_namespace == "plugin"
+    assert PluginModule.module == "flepimop2.plugin.demo"
+
+
+def test_short_module_name_requires_module_namespace() -> None:
+    """Short module names should fail without a declared namespace."""
+    with pytest.raises(
+        TypeError,
+        match="must define `module_namespace` to use the class keyword argument",
+    ):
+
+        class MissingNamespaceModule(ModuleABC, module="demo"):
+            pass
+
+
+def test_module_namespace_keyword_and_explicit_attribute_conflict_raises() -> None:
+    """The namespace shortcut cannot be combined with an explicit attribute."""
+    with pytest.raises(
+        TypeError,
+        match="cannot define both class attribute 'module_namespace'",
+    ):
+
+        class ConflictingNamespaceModule(ModuleABC, module_namespace="plugin"):
+            module_namespace = "other"
+            module = "flepimop2.plugin.demo"
+
+
+def test_module_shortcut_sets_literal_module_field_for_pydantic_subclass() -> None:
+    """The shortcut should also specialize the Pydantic `module` field."""
+
+    class PydanticBackend(ModuleModel, BackendABC, module="test_backend"):
+        root: str = "."
+
+        def _save(self, data: object, run_meta: object) -> None: ...
+
+        def _read(self, _run_meta: object) -> Float64NDArray:
+            return np.array([], dtype=np.float64)
+
+    expected = "flepimop2.backend.test_backend"
+
+    assert get_args(PydanticBackend.model_fields["module"].annotation) == (expected,)
+    assert PydanticBackend.model_fields["module"].default == expected
+    assert PydanticBackend.model_validate({"root": "."}).module == expected
+    with pytest.raises(ValidationError, match="Input should be"):
+        PydanticBackend.model_validate({"module": "wrong", "root": "."})
+
+
+def test_module_shortcut_and_explicit_attribute_conflict_raises() -> None:
+    """The shortcut cannot be combined with an explicit class `module` attribute."""
+    with pytest.raises(
+        TypeError,
+        match="cannot define both class attribute 'module' and class keyword argument",
+    ):
+
+        class ConflictingProcess(ProcessABC, module="test_process"):
+            module = "flepimop2.process.test_process"
+
+            def _process(self, *, dry_run: bool) -> None: ...
+
+
 def test_option_reports_module_for_pydantic_subclass() -> None:
     """Option lookup should include module name for pydantic subclasses."""
 
@@ -134,3 +215,29 @@ def test_option_uses_default_when_missing_for_pydantic_subclass() -> None:
     mod = PydanticModule()
     assert mod.options is None
     assert mod.option("missing", default=0) == 0
+
+
+def test_explicit_module_definition_still_works_for_plain_subclass() -> None:
+    """Plain subclasses may still define `module` directly."""
+
+    class PlainProcess(ProcessABC):
+        module = "flepimop2.process.explicit"
+
+        def _process(self, *, dry_run: bool) -> None: ...
+
+    assert PlainProcess().module == "flepimop2.process.explicit"
+
+
+def test_explicit_module_definition_still_works_for_pydantic_subclass() -> None:
+    """Pydantic subclasses may still define `module` directly."""
+
+    class PydanticProcess(ModuleModel, ProcessABC):
+        module: Literal["flepimop2.process.explicit"] = "flepimop2.process.explicit"
+        command: str = "echo"
+
+        def _process(self, *, dry_run: bool) -> None: ...
+
+    expected = "flepimop2.process.explicit"
+
+    assert PydanticProcess().module == expected
+    assert get_args(PydanticProcess.model_fields["module"].annotation) == (expected,)


### PR DESCRIPTION
## Description

Add a shared class-definition shortcut for module types so concrete
modules can declare `module="csv"` instead of repeating a fully
qualified `Literal[...]` field in every implementation. This moves the
normalization logic into the shared `ModuleABC` path, keeps explicit
module declarations supported, and preserves the correct constrained
field behavior for Pydantic-based modules with a minor update to
`ModuleModel`. Updated documentation to clarify this is the preferred
way for modules to declare their name and updated modules provided
directly by `flepimop2` to use this simplified API. Also added the
ability for module ABCs, like `SystemABC`, to similarly declare their
module namespace via the `module_namespace="system"` class keyword
argument largely leveraging the same infra.

## Related issues

Closes #88.

## Checklist

- [x] I have read through and understand the [pull request process](https://github.com/ACCIDDA/flepimop2?tab=contributing-ov-file#pull-request-process).
- [x] I ran successfully ran CI local via `just ci`.
- [x] I have updated the `CHANGELOG.md` or noted "no major changes" in my commit if the PR is small.
