### PR TITLE
Support generic initial_state in simulate config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Generalized `SimulateCommand` to support an `initial_state` dict in simulate specs, allowing models with arbitrary state vectors (e.g., SIRHD, vaccination-structured). Falls back to the legacy `s0`/`i0`/`r0` convention when `initial_state` is absent. See [#220](https://github.com/ACCIDDA/flepimop2/pull/220).
 - Updated the documentation quick start integration test to use the same configuration file as the documentation homepage to ensure the two stay in sync. See [#185](https://github.com/ACCIDDA/flepimop2/issues/185).
 
 ### Deprecated

--- a/src/flepimop2/_cli/_simulate_command.py
+++ b/src/flepimop2/_cli/_simulate_command.py
@@ -55,21 +55,31 @@ class SimulateCommand(CliCommand):
         """
         config_model = ConfigurationModel.from_yaml(config)
 
-        s0 = build_parameter(config_model.parameters["s0"])
-        i0 = build_parameter(config_model.parameters["i0"])
-        r0 = build_parameter(config_model.parameters["r0"])
-        initial_state = np.array(
-            [
-                s0.sample().item(),
-                i0.sample().item(),
-                r0.sample().item(),
-            ],
-            dtype=np.float64,
-        )
+        target_name = target or next(iter(config_model.simulate))
+        sim_spec = config_model.simulate[target_name]
+        raw_initial: dict[str, float] | None = getattr(sim_spec, "initial_state", None)
+
+        if raw_initial is not None:
+            initial_state = np.array(list(raw_initial.values()), dtype=np.float64)
+            state_param_names = set(raw_initial.keys())
+        else:
+            s0 = build_parameter(config_model.parameters["s0"])
+            i0 = build_parameter(config_model.parameters["i0"])
+            r0 = build_parameter(config_model.parameters["r0"])
+            initial_state = np.array(
+                [
+                    s0.sample().item(),
+                    i0.sample().item(),
+                    r0.sample().item(),
+                ],
+                dtype=np.float64,
+            )
+            state_param_names = {"s0", "i0", "r0"}
+
         params = {
             k: build_parameter(v).sample().item()
             for k, v in config_model.parameters.items()
-            if k not in {"s0", "i0", "r0"}
+            if k not in state_param_names
         }
 
         simulator = Simulator.from_configuration_model(config_model, target=target)


### PR DESCRIPTION
## Summary

Generalize the `SimulateCommand` to support arbitrary-length initial state vectors instead of the hardcoded `s0`/`i0`/`r0` convention.

## Problem

The simulate CLI command hardcodes initial state extraction to exactly three SIR compartments (`s0`, `i0`, `r0`). This makes it impossible to use `flepimop2 simulate` with models that have more (or fewer) than 3 states — e.g., SIRHD (5 states) or vaccination-structured models (9+ states).

## Solution

When a simulate spec includes an `initial_state` dict, its values are used directly as the state vector and its keys are excluded from the params dict. The legacy `s0`/`i0`/`r0` fallback is preserved for backward compatibility.

**New config usage:**

```yaml
simulate:
  demo:
    times: 0.0:1.0:200.0
    initial_state:
      S: 9990
      I: 10
      H: 0
      R: 0
      D: 0
```

No schema changes were needed — `SimulateSpecificationModel` already has `ConfigDict(extra="allow")`, so the `initial_state` key is accepted and accessible via `getattr`.

## Note on inference compatibility

The new `initial_state` path currently takes raw floats, bypassing `ParameterABC`. This means initial conditions are fixed constants that cannot yet participate in sampling or optimization. However, this does **not** block future inference support — the dict-of-names structure is well-positioned for it. A future extension just needs to check whether each value is a bare number or a parameter module reference (e.g., `{module: distribution, ...}`) and route accordingly. The key names are the actual state names, which is a better foundation than the ad-hoc `s0`/`i0`/`r0` convention.

## Changes

- `src/flepimop2/_cli/_simulate_command.py`: Generalized initial state extraction (+22/-12 lines)
- `CHANGELOG.md`: Added entry under Changed

## Testing

- All 291 existing tests pass (289 unit + 2 integration)
- ruff and mypy clean