### PR TITLE
Add default `module` to `ModuleModel`, fix #216

### DIFF
--- a/src/flepimop2/configuration/_module.py
+++ b/src/flepimop2/configuration/_module.py
@@ -34,7 +34,7 @@ class ModuleModel(BaseModel):
 
     model_config = ConfigDict(extra="allow")
 
-    module: str = Field(min_length=1)
+    module: str = Field(default="", min_length=1)
 
     @classmethod
     def __pydantic_init_subclass__(cls, **kwargs: Any) -> None:  # noqa: PLW3201

--- a/tests/module/test_module_abc_class.py
+++ b/tests/module/test_module_abc_class.py
@@ -115,6 +115,21 @@ def test_module_shortcut_sets_fully_qualified_module_for_plain_subclass() -> Non
     assert mod.module == "flepimop2.process.test_process"
 
 
+def test_module_shortcut_sets_fully_qualified_module_for_plain_backend_subclass() -> (
+    None
+):
+    """The class-definition shortcut should resolve namespaced plain backends."""
+
+    class PlainBackend(BackendABC, module="test_backend"):
+        def _save(self, data: Float64NDArray, run_meta: object) -> None: ...
+
+        def _read(self, _run_meta: object) -> Float64NDArray:
+            return np.array([], dtype=np.float64)
+
+    mod = PlainBackend()
+    assert mod.module == "flepimop2.backend.test_backend"
+
+
 def test_module_namespace_keyword_sets_public_classvar() -> None:
     """The class-definition namespace shortcut should set `module_namespace`."""
 
@@ -166,6 +181,22 @@ def test_module_shortcut_sets_literal_module_field_for_pydantic_subclass() -> No
     assert PydanticBackend.model_validate({"root": "."}).module == expected
     with pytest.raises(ValidationError, match="Input should be"):
         PydanticBackend.model_validate({"module": "wrong", "root": "."})
+
+
+def test_module_shortcut_allows_pydantic_instantiation_without_module_argument() -> (
+    None
+):
+    """Shortcut-backed Pydantic subclasses should not require `module` at init time."""
+
+    class PydanticBackend(ModuleModel, BackendABC, module="test_backend"):
+        root: str = "."
+
+        def _save(self, data: object, run_meta: object) -> None: ...
+
+        def _read(self, _run_meta: object) -> Float64NDArray:
+            return np.array([], dtype=np.float64)
+
+    assert PydanticBackend(root=".").module == "flepimop2.backend.test_backend"
 
 
 def test_module_shortcut_and_explicit_attribute_conflict_raises() -> None:


### PR DESCRIPTION
## Description

Added a default value to the `module` attribute of the `ModuleModel` class as a follow up to fix #216. Without this default `mypy` falsely identifies an issue where `module` is not being provided to pydantic modules that use the `module=` class keyword argument, such as `FixedParameter`. No major changes.

## Related issues

Follow up to #216.

## Checklist

- [x] I have read through and understand the [pull request process](https://github.com/ACCIDDA/flepimop2?tab=contributing-ov-file#pull-request-process).
- [x] I ran successfully ran CI local via `just ci`.
- [x] I have updated the `CHANGELOG.md` or noted "no major changes" in my commit if the PR is small.
