### PR TITLE
Fix CI issues with #212

### DIFF
--- a/docs/assets/scenarios_config.yaml
+++ b/docs/assets/scenarios_config.yaml
@@ -40,4 +40,7 @@ scenarios:
 process:
   - module: shell
     command: Rscript scripts/plot_scenarios.R
-    args: ["configs/scenarios_config.yaml", "model_output", "figures/scenarios_plot.png"]
+    args:
+      - configs/scenarios_config.yaml
+      - model_output
+      - figures/scenarios_plot.png

--- a/docs/guides/scenarios.md
+++ b/docs/guides/scenarios.md
@@ -16,7 +16,6 @@ flepimop2 process scenarios_config.yaml
 The processing step uses the outputs to create a plot.
 
 ??? example "Processing Script - `model_input/plot_scenarios.R`"
-    ```python
+    ```r
     --8<-- "assets/plot_scenarios.R"
     ```
-

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -90,6 +90,7 @@ nav:
           - Module: reference/api/module.md
           - Parameter: reference/api/parameter.md
           - Process: reference/api/process.md
+          - Scenario: reference/api/scenario.md
           - Simulator: reference/api/simulator.md
           - System: reference/api/system.md
           - Testing: reference/api/testing.md

--- a/src/flepimop2/scenario/abc/__init__.py
+++ b/src/flepimop2/scenario/abc/__init__.py
@@ -1,3 +1,18 @@
+# flepimop2: The FLExible Pipeline for Interchangeable MOdel Processing
+# Copyright (C) 2026  Carl Pearson, Joshua Macdonald, Timothy Willard
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """Abstract base class for scenarios."""
 
 __all__ = ["Float64NDArray", "ScenarioABC", "build"]

--- a/src/flepimop2/scenario/grid/__init__.py
+++ b/src/flepimop2/scenario/grid/__init__.py
@@ -1,3 +1,18 @@
+# flepimop2: The FLExible Pipeline for Interchangeable MOdel Processing
+# Copyright (C) 2026  Carl Pearson, Joshua Macdonald, Timothy Willard
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """Grid scenario implementation."""
 
 __all__ = ["Float64NDArray", "GridScenario"]

--- a/tests/integration/documentation_scenarios/test_scenarios.py
+++ b/tests/integration/documentation_scenarios/test_scenarios.py
@@ -1,3 +1,18 @@
+# flepimop2: The FLExible Pipeline for Interchangeable MOdel Processing
+# Copyright (C) 2026  Carl Pearson, Joshua Macdonald, Timothy Willard
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """Integration test for the documentation quick start flow."""
 
 from pathlib import Path

--- a/tests/scenario/test_scenario_grid.py
+++ b/tests/scenario/test_scenario_grid.py
@@ -1,3 +1,18 @@
+# flepimop2: The FLExible Pipeline for Interchangeable MOdel Processing
+# Copyright (C) 2026  Carl Pearson, Joshua Macdonald, Timothy Willard
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """Tests `ScenarioABC` grid implementation."""
 
 import itertools


### PR DESCRIPTION
## Description

- Added missing copyright notices.
- Correct `docs/assets/scenarios_config.yaml` formatting.
- Correct code block hint from `python` to `r` in `docs/guides/scenarios.md`.
- Add `flepimop2.scenarios` to API reference navigation.

## Related issues

Address CI issues with #212.

## Checklist

- [x] I have read through and understand the [pull request process](https://github.com/ACCIDDA/flepimop2?tab=contributing-ov-file#pull-request-process).
- [x] I ran successfully ran CI local via `just ci`.
- [x] I have updated the `CHANGELOG.md` or noted "no major changes" in my commit if the PR is small.
