### PR TITLE
Resolve initial_state from system spec in simulate command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- The simulate command now resolves initial conditions from the system's `initial_state` option (a symbolic state→parameter mapping) when available, falling back to the legacy `s0`/`i0`/`r0` convention. See [#225](https://github.com/ACCIDDA/flepimop2/issues/225).
 - Updated the documentation quick start integration test to use the same configuration file as the documentation homepage to ensure the two stay in sync. See [#185](https://github.com/ACCIDDA/flepimop2/issues/185).
 
 ### Deprecated

--- a/src/flepimop2/_cli/_simulate_command.py
+++ b/src/flepimop2/_cli/_simulate_command.py
@@ -55,28 +55,48 @@ class SimulateCommand(CliCommand):
         """
         config_model = ConfigurationModel.from_yaml(config)
 
-        s0 = build_parameter(config_model.parameters["s0"])
-        i0 = build_parameter(config_model.parameters["i0"])
-        r0 = build_parameter(config_model.parameters["r0"])
-        initial_state = np.array(
-            [
-                s0.sample().item(),
-                i0.sample().item(),
-                r0.sample().item(),
-            ],
-            dtype=np.float64,
-        )
-        params = {
-            k: build_parameter(v).sample().item()
-            for k, v in config_model.parameters.items()
-            if k not in {"s0", "i0", "r0"}
-        }
-
         simulator = Simulator.from_configuration_model(config_model, target=target)
 
         if simulator.simulate_config is None:
             msg = "simulate_config must be set before running the simulator."
             raise ValueError(msg)
+
+        ic_map: dict[str, str] | None = simulator.system.option(
+            "initial_state",
+            default=None,
+        )
+        if ic_map is not None:
+            state_names: tuple[str, ...] = simulator.system.option("state_names")
+            ic_param_names = set(ic_map.values())
+            initial_state = np.array(
+                [
+                    build_parameter(config_model.parameters[ic_map[s]]).sample().item()
+                    for s in state_names
+                ],
+                dtype=np.float64,
+            )
+            params = {
+                k: build_parameter(v).sample().item()
+                for k, v in config_model.parameters.items()
+                if k not in ic_param_names
+            }
+        else:
+            s0 = build_parameter(config_model.parameters["s0"])
+            i0 = build_parameter(config_model.parameters["i0"])
+            r0 = build_parameter(config_model.parameters["r0"])
+            initial_state = np.array(
+                [
+                    s0.sample().item(),
+                    i0.sample().item(),
+                    r0.sample().item(),
+                ],
+                dtype=np.float64,
+            )
+            params = {
+                k: build_parameter(v).sample().item()
+                for k, v in config_model.parameters.items()
+                if k not in {"s0", "i0", "r0"}
+            }
 
         for component in ["system", "engine", "backend"]:
             name = getattr(simulator.simulate_config, component)


### PR DESCRIPTION
Closes #225

## Summary

The simulate command now queries the system for a symbolic `initial_state` mapping (state name → parameter name) and resolves numeric values through the `parameter:` block. Falls back to the legacy `s0`/`i0`/`r0` convention when the system does not declare `initial_state`.

## Changes

**`src/flepimop2/_cli/_simulate_command.py`**
- Build the `Simulator` (and its system) before resolving initial conditions, so `system.option()` is available.
- When `system.option("initial_state")` is present, use `system.option("state_names")` to build `initial_state` in the correct order, resolving each symbolic param name through `config_model.parameters`.
- IC parameter names are excluded from the `params` dict passed to the engine.
- When the option is absent, the existing `s0`/`i0`/`r0` logic is preserved unchanged.

**`CHANGELOG.md`**
- Added entry under **Changed**.

## Depends on

- ACCIDDA/op_system#65 — template expansion for `initial_state` in `specs.py` and exposing `state_names` + `initial_state` via the flepimop2-op_system adapter options.