### PR TITLE
Remove PyPI restriction from `release.yaml`

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,13 +32,6 @@ jobs:
     name: 'validate release'
     runs-on: 'ubuntu-latest'
     steps:
-      - name: 'fail if PyPI publish is requested'
-        if: "${{ github.event.inputs.publish-target == 'pypi' }}"
-        run: |
-          # `flepimop2` is not ready for submission to PyPI yet.
-          echo "Publishing to PyPI is intentionally disabled for this"
-          echo "repository."
-          exit 1
       - name: 'checkout repository'
         uses: 'actions/checkout@v6'
         with:

--- a/docs/development/creating-a-release.md
+++ b/docs/development/creating-a-release.md
@@ -81,7 +81,15 @@ When testing from a branch, keep `create-github-release=false` and `deploy-docs=
 
 ### PyPI
 
-If `publish-target=pypi` is selected, the workflow intentionally fails early. That option is present to preserve the future workflow shape, but real PyPI publication is not enabled for `flepimop2` yet.
+Use this to publish `flepimop2` to PyPI, create a GitHub release, and deploy the documentation:
+
+```shell
+gh workflow run release.yaml \
+  --repo ACCIDDA/flepimop2 \
+  --field publish-target=pypi \
+  --field create-github-release=false \
+  --field deploy-docs=false
+```
 
 ## 4. Trusted Publishing Setup
 


### PR DESCRIPTION
## Description

Removed restriction from the `release.yaml` workflow that prevents `flepimop2` from being released on PyPI. No major changes.

## Related issues

n/a

## Checklist

- [x] I have read through and understand the [pull request process](https://github.com/ACCIDDA/flepimop2?tab=contributing-ov-file#pull-request-process).
- [x] I ran successfully ran CI local via `just ci`.
- [x] I have updated the `CHANGELOG.md` or noted "no major changes" in my commit if the PR is small.
