### PR TITLE
Add ability to upload to PyPI

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -52,7 +52,7 @@ jobs:
           path: 'dist/*'
           if-no-files-found: 'error'
   publish-pypi:
-    name: 'publish to PyPI'
+    name: 'publish package'
     needs:
       - 'validate'
     runs-on: 'ubuntu-latest'
@@ -65,9 +65,13 @@ jobs:
           name: 'dist'
           path: 'dist'
       - name: 'publish package to TestPyPI'
+        if: "${{ github.event.inputs.publish-target == 'testpypi' }}"
         uses: 'pypa/gh-action-pypi-publish@release/v1'
         with:
           repository-url: 'https://test.pypi.org/legacy/'
+      - name: 'publish package to PyPI'
+        if: "${{ github.event.inputs.publish-target == 'pypi' }}"
+        uses: 'pypa/gh-action-pypi-publish@release/v1'
   create-github-release:
     name: 'create GitHub release'
     needs:

--- a/docs/development/creating-a-release.md
+++ b/docs/development/creating-a-release.md
@@ -93,10 +93,14 @@ gh workflow run release.yaml \
 
 ## 4. Trusted Publishing Setup
 
-The TestPyPI publish job uses PyPI Trusted Publishing rather than a stored API token. To enable publishing to TestPyPI, configure the trusted publisher entry for:
+The publish job uses PyPI Trusted Publishing rather than a stored API token.
+
+For `publish-target=testpypi`, configure the TestPyPI trusted publisher entry for:
 
 - Owner: `ACCIDDA`.
 - Repository: `flepimop2`.
 - Workflow file: `release.yaml`.
 
-If that configuration is missing, the TestPyPI publish job will fail even if validation passes.
+For `publish-target=pypi`, configure the PyPI trusted publisher entry for the same repository and workflow file.
+
+If the matching trusted publisher configuration is missing on the selected package index, the publish job will fail even if validation passes.


### PR DESCRIPTION
## Description

Missing PyPI branch from the `publish-pypi` job.

## Related issues

n/a

## Checklist

- [x] I have read through and understand the [pull request process](https://github.com/ACCIDDA/flepimop2?tab=contributing-ov-file#pull-request-process).
- [x] I ran successfully ran CI local via `just ci`.
- [x] I have updated the `CHANGELOG.md` or noted "no major changes" in my commit if the PR is small.
