### PR TITLE
Update install documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added repository citation metadata via `CITATION.cff` and generated documentation for citing `flepimop2`. See [#136](https://github.com/ACCIDDA/flepimop2/issues/136).
+- Added a dedicated installation guide that documents `pip install flepimop2`, `uv add flepimop2`, and how to declare `flepimop2` as a dependency in another project. See [#89](https://github.com/ACCIDDA/flepimop2/issues/89), [#144](https://github.com/ACCIDDA/flepimop2/issues/144).
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,16 @@
 
 The next generation of the flexible epidemic modeling pipeline.
 
+## Installation
+
+`flepimop2` is published on [PyPI](https://pypi.org/project/flepimop2/) and can be installed with:
+
+```bash
+pip install flepimop2
+```
+
+If you are adding `flepimop2` as a dependency in another project, see the [installation guide](docs/guides/install.md).
+
 ## Local Development
 
 1. Clone the repository

--- a/docs/development/creating-an-external-provider-package.md
+++ b/docs/development/creating-an-external-provider-package.md
@@ -54,10 +54,12 @@ uv init --package --build-backend hatchling
 
 # Add dependencies
 uv add numpy
-uv add "git+https://github.com/ACCIDDA/flepimop2"
+uv add "flepimop2~=0.0"
 ```
 
 This creates a basic package structure with a `pyproject.toml` file configured to use the Hatch build backend.
+
+`flepimop2` is still in its pre-1.0 release line, so provider packages should pin to the current major version series. That means a constraint like `flepimop2~=0.0` today, and `flepimop2~=1.0` once the project reaches v1.
 
 ### Step 2: Configure `pyproject.toml`
 
@@ -71,7 +73,7 @@ description = "An external provider for flepimop2 for saving and reading npz fil
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    "flepimop2",
+    "flepimop2~=0.0",
     "numpy>=2.3.5",
 ]
 
@@ -81,9 +83,6 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/flepimop2"]
-
-[tool.uv.sources]
-flepimop2 = { git = "https://github.com/ACCIDDA/flepimop2" }
 ```
 
 The critical configuration here is `[tool.hatch.build.targets.wheel]`, which tells Hatch to package everything under `src/flepimop2` as part of the `flepimop2` namespace.

--- a/docs/guides/install.md
+++ b/docs/guides/install.md
@@ -1,0 +1,54 @@
+# Installation
+
+`flepimop2` is published on [PyPI](https://pypi.org/project/flepimop2/) and can be installed with `pip`:
+
+```bash
+pip install flepimop2
+```
+
+If you use `uv`, you can install it into the current environment with:
+
+```bash
+uv pip install flepimop2
+```
+
+## Add It To A Project
+
+If you want `flepimop2` to be a dependency of another Python project, add it to that project’s dependency list.
+
+With `uv`, the simplest option is:
+
+```bash
+uv add flepimop2
+```
+
+If you manage dependencies manually in `pyproject.toml`, add the package name to `project.dependencies`:
+
+```toml
+[project]
+dependencies = [
+    "flepimop2",
+]
+```
+
+After installation, the `flepimop2` CLI should be available in your environment:
+
+```bash
+flepimop2 --help
+```
+
+## Installing From GitHub
+
+`flepimop2` is still in the alpha/beta development stage and you may find that newer features are available with the development version. In this case you can install `flepimop2` directly from GitHub via:
+
+```bash
+pip install git+https://github.com/ACCIDDA/flepimop2.git@main
+```
+
+If you use `uv`, you can install it into the current environment with:
+
+```bash
+uv pip install git+https://github.com/ACCIDDA/flepimop2.git@main
+```
+
+The `@main` indicates to install from the main branch, but you can also change this to install from a specific branch or tag.

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,15 +6,13 @@ The next generation of the flexible epidemic modeling pipeline.
 
 ### Installation
 
-You'll need [git](https://git-scm.com/install/) and [pipx](https://pipx.pypa.io/latest/installation/) on your system.
+`flepimop2` is published on [PyPI](https://pypi.org/project/flepimop2/) and can be installed with `pip`:
 
 ```bash
-git clone git@github.com:ACCIDDA/flepimop2.git
-cd flepimop2
-pipx install .
+pip install flepimop2
 ```
 
-This clones the source of the library, then uses it to install the application.
+If you want to work from a local clone instead, see the [installation guide](guides/install.md) for a source install and dependency setup.
 
 ### Create a Project
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -71,6 +71,7 @@ extra_css:
 nav:
   - Home: index.md
   - Guides:
+      - Installation: guides/install.md
       - Getting Started: guides/getting-started.md
   - Development:
       - Contributing: development/contributing.md


### PR DESCRIPTION
## Description

Updated installation documentation for `flepimop2` since it is now
available on PyPI. Also clarified the version pinning strategy for
provider packages. Closes #89, closes #144.

## Related issues

Closes #89, closes #144.

## Checklist

- [x] I have read through and understand the [pull request process](https://github.com/ACCIDDA/flepimop2?tab=contributing-ov-file#pull-request-process).
- [x] I ran successfully ran CI local via `just ci`.
- [x] I have updated the `CHANGELOG.md` or noted "no major changes" in my commit if the PR is small.
