### PR TITLE
Add shorthand syntax to simplify user configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Introduced the axis concept as a way to represent aligned shapes across parameters, systems, etc. Added two kinds of axes, categorical and continuous, to represent different kinds of dimensions. Also added an `axes` top level key to the `ConfigurationModel` so users can provide these axes via configuration and `flepimop2.axis` module for realizing & manipulating axes from configuration. See [#147](https://github.com/ACCIDDA/flepimop2/issues/147).
 - Added ways to specify shape for parameters based on `axes` by changing `ParameterABC.sample` to return a `ParameterValue` that contains both the underlying value as a numpy array as well as shape metadata, and is easily extensible to other metadata and underlying value types in the future. Also added `ModelStateSpecification`, `ParameterRequest` types for systems to advertise their underlying state and request parameters to comply with said state specification. See [#115](https://github.com/ACCIDDA/flepimop2/issues/115), [#133](https://github.com/ACCIDDA/flepimop2/issues/133).
 - Added help text for CLI arguments that are formatted similarly to click's default formatting for options.
+- Added optional shorthand module configuration support across all module namespaces, allowing config values such as `fixed(0.3)` for modules that implement `from_shorthand`. See [#14](https://github.com/ACCIDDA/flepimop2/issues/14).
 
 ### Changed
 
 - Updated CLI commands to return consistent exit codes based on the kind of failure. See [#17](https://github.com/ACCIDDA/flepimop2/issues/17).
 - Added a default search order for CLI commands with the `CONFIG` argument making providing a file manually not required for typical/small project usage. See [#245](https://github.com/ACCIDDA/flepimop2/issues/245).
+- Removed implicit default module selection from module builders. Backend, engine, parameter, process, scenario, and system configs must now declare their module explicitly or use shorthand syntax.
+- Simplified `ScenarioABC` to use `module_namespace="scenario"` so scenario modules can use the same module-name shortcut mechanism as the other ABCs. Follow up to [#216](https://github.com/ACCIDDA/flepimop2/pull/216).
 
 ### Deprecated
 

--- a/docs/assets/full_feature_workflow/SIR_plot_op_engine.py
+++ b/docs/assets/full_feature_workflow/SIR_plot_op_engine.py
@@ -39,6 +39,7 @@ def _resolve_results_dir(config_model: ConfigurationModel) -> Path:
     Raises:
         ValueError: If the simulate block is empty.
         KeyError: If the backend name is not found in the backends block.
+        TypeError: If the backend config uses shorthand syntax.
     """
     simulate_block = config_model.simulate
     if not simulate_block:
@@ -58,6 +59,12 @@ def _resolve_results_dir(config_model: ConfigurationModel) -> Path:
     if backend_model is None:
         msg = f"simulate backend {backend_name!r} not found in config.backends"
         raise KeyError(msg)
+    if isinstance(backend_model, str):
+        msg = (
+            f"config.backends[{backend_name!r}] uses shorthand syntax, but this "
+            "workflow requires an expanded module mapping."
+        )
+        raise TypeError(msg)
 
     backend_cfg = backend_model.model_dump()
 
@@ -85,13 +92,20 @@ def _resolve_state_names(config_model: ConfigurationModel) -> list[str]:
 
     Raises:
         ValueError: If no systems are defined or the spec does not declare a state list.
+        TypeError: If the system config uses shorthand syntax.
 
     """
     if not config_model.systems:
         msg = "config.system must define at least one system"
         raise ValueError(msg)
 
-    first_system = next(iter(config_model.systems.values()))
+    system_name, first_system = next(iter(config_model.systems.items()))
+    if isinstance(first_system, str):
+        msg = (
+            f"config.systems[{system_name!r}] uses shorthand syntax, but this "
+            "workflow requires an expanded module mapping."
+        )
+        raise TypeError(msg)
     state_names = first_system.model_dump().get("spec", {}).get("state", [])
 
     if not state_names:

--- a/src/flepimop2/_utils/_module.py
+++ b/src/flepimop2/_utils/_module.py
@@ -16,15 +16,25 @@
 """Private utilities for dynamic module loading and validation."""
 
 import inspect
+import re
 from abc import ABCMeta
 from importlib import import_module
 from importlib.util import module_from_spec, spec_from_file_location
 from os import PathLike
 from pathlib import Path
 from types import ModuleType
-from typing import Any, Literal, Protocol, TypeVar, cast, runtime_checkable
+from typing import (
+    Any,
+    Literal,
+    NamedTuple,
+    Protocol,
+    Self,
+    TypeVar,
+    cast,
+    runtime_checkable,
+)
 
-from pydantic import BaseModel
+from pydantic import BaseModel, TypeAdapter, ValidationError
 
 from flepimop2.configuration import ModuleModel
 from flepimop2.module import ModuleABC
@@ -33,6 +43,87 @@ from flepimop2.typing import IdentifierString
 Namespace = Literal["backend", "engine", "parameter", "process", "scenario", "system"]
 
 T_co = TypeVar("T_co", bound=ModuleABC, covariant=True)
+SHORTHAND_PATTERN = re.compile(
+    r"^\s*(?P<module>[A-Za-z_][A-Za-z0-9_\.]*)\((?P<args>.*)\)\s*$",
+    re.DOTALL,
+)
+IDENTIFIER_STRING_ADAPTER = TypeAdapter(IdentifierString)
+
+
+class ParsedShorthand(NamedTuple):
+    """
+    Parsed representation of shorthand module configuration text.
+
+    This class represents the result of parsing a shorthand configuration string, i.e.
+    `from: ...`. It contains the extracted module token and the argument payload as
+    separate attributes. For example, parsing the string `fixed(0.3)` would yield a
+    `ParsedShorthand` with `module='fixed'` and `args='0.3'`.
+
+    Attributes:
+        module: The module token extracted from the shorthand text.
+        args: The argument payload extracted from the shorthand text.
+    """
+
+    module: IdentifierString
+    args: str
+
+    @classmethod
+    def from_string(cls, value: str) -> Self:
+        r"""
+        Parse shorthand config text into a module token and argument payload.
+
+        Args:
+            value: Shorthand configuration text such as `fixed(0.3)`.
+
+        Returns:
+            A parsed shorthand object containing the module token and argument
+            payload.
+
+        Raises:
+            ValueError: If the text does not match shorthand syntax.
+
+        Examples:
+            >>> from flepimop2._utils._module import ParsedShorthand
+            >>> ParsedShorthand.from_string("fixed(0.3)")
+            ParsedShorthand(module='fixed', args='0.3')
+            >>> ParsedShorthand.from_string(" normal(-1, 2.5) ")
+            ParsedShorthand(module='normal', args='-1, 2.5')
+            >>> parsed = ParsedShorthand.from_string('''fixed(
+            ...   3.1415
+            ... )''')
+            >>> parsed.module
+            'fixed'
+            >>> parsed.args == '''
+            ...   3.1415
+            ... '''
+            True
+            >>> try:
+            ...     ParsedShorthand.from_string("Normal(1)")
+            ... except ValueError as exc:
+            ...     print(exc)
+            Shorthand module name 'Normal' must satisfy IdentifierString.
+            >>> try:
+            ...     ParsedShorthand.from_string("fixed")
+            ... except ValueError as exc:
+            ...     print(exc)
+            Shorthand module configuration must match the form 'module_name(...)'.
+        """
+        match = SHORTHAND_PATTERN.fullmatch(value)
+        if match is None:
+            msg = (
+                "Shorthand module configuration must match the form 'module_name(...)'."
+            )
+            raise ValueError(msg)
+        raw_module = match.group("module")
+        try:
+            module = IDENTIFIER_STRING_ADAPTER.validate_python(raw_module)
+        except ValidationError as exc:
+            msg = f"Shorthand module name {raw_module!r} must satisfy IdentifierString."
+            raise ValueError(msg) from exc
+        return cls(
+            module=module,
+            args=match.group("args"),
+        )
 
 
 @runtime_checkable
@@ -253,9 +344,8 @@ def _resolve_module_name(module: str, namespace: Namespace) -> str:
 
 
 def _build(
-    config: dict[str, Any] | ModuleModel,
+    config: dict[str, Any] | ModuleModel | str,
     namespace: Namespace,
-    default_module: str,
     enforced_type: type[T_co] | ABCMeta,
 ) -> T_co:
     """
@@ -265,9 +355,8 @@ def _build(
     system ABC build functions to reduce code duplication.
 
     Args:
-        config: Configuration dictionary or `ModuleModel` instance.
+        config: Configuration dictionary, `ModuleModel` instance, or shorthand text.
         namespace: The namespace for module resolution.
-        default_module: The default module to use if not specified in config.
         enforced_type: The expected type of the built instance. Can be an abstract
             class since it's only used for isinstance checks, not instantiation.
 
@@ -275,19 +364,39 @@ def _build(
         The constructed instance.
 
     Raises:
+        ValueError: If the configuration does not define a module.
         TypeError: If the built instance does not match the enforced type.
 
     """
-    config_dict = _as_dict(config)
-    if "module" not in config_dict:
-        config_dict["module"] = default_module
-    module_path = _resolve_module_name(config_dict["module"], namespace)
-    config_dict["module"] = module_path
+    if isinstance(config, str):
+        parsed = ParsedShorthand.from_string(config)
+        module_path = _resolve_module_name(parsed.module, namespace)
+        mod = import_module(module_path)
+        target_class = cast(
+            "type[T_co]",
+            _find_target_class(mod, module_path, enforced_type),
+        )
+        try:
+            instance = target_class.from_shorthand(parsed.args)
+        except NotImplementedError as exc:
+            msg = f"Module '{module_path}' does not support shorthand configuration."
+            raise ValueError(msg) from exc
+    else:
+        config_dict = _as_dict(config)
+        configured_module = config_dict.get("module")
+        if not isinstance(configured_module, str) or not configured_module:
+            msg = (
+                f"Configuration for namespace '{namespace}' must define a non-empty "
+                "'module' string."
+            )
+            raise ValueError(msg)
+        module_path = _resolve_module_name(configured_module, namespace)
+        config_dict["module"] = module_path
 
-    # Anchor T_co by passing enforced_type
-    builder: Buildable[T_co] = _load_builder(module_path, enforced_type)
+        # Anchor T_co by passing enforced_type
+        builder: Buildable[T_co] = _load_builder(module_path, enforced_type)
 
-    instance = builder.build(config_dict)
+        instance = builder.build(config_dict)
 
     # Final runtime safety check since we've done a lot of casting
     if not isinstance(instance, enforced_type):

--- a/src/flepimop2/backend/abc/__init__.py
+++ b/src/flepimop2/backend/abc/__init__.py
@@ -63,16 +63,16 @@ class BackendABC(ModuleABC, module_namespace="backend"):
         ...
 
 
-def build(config: dict[str, Any] | ModuleModel) -> BackendABC:
+def build(config: dict[str, Any] | ModuleModel | str) -> BackendABC:
     """Build a `BackendABC` from a configuration dictionary.
 
     Args:
-        config: Configuration dictionary. The dict must contains a 'module' key, which
-            will be used to lookup the Backend module path. The module will have
+        config: Configuration dictionary. The dict must contain a 'module' key, which
+            will be used to lookup the backend module path. The module will have
             "flepimop2.backend." prepended.
 
     Returns:
         The constructed backend instance.
 
     """
-    return _build(config, "backend", "flepimop2.backend.csv", BackendABC)
+    return _build(config, "backend", BackendABC)

--- a/src/flepimop2/configuration/__init__.py
+++ b/src/flepimop2/configuration/__init__.py
@@ -21,6 +21,7 @@ __all__ = [
     "CategoricalAxisModel",
     "ConfigurationModel",
     "ContinuousAxisModel",
+    "ModuleConfigurationValue",
     "ModuleGroupModel",
     "ModuleModel",
     "SimulateSpecificationModel",
@@ -33,5 +34,9 @@ from flepimop2.configuration._axes import (
     ContinuousAxisModel,
 )
 from flepimop2.configuration._configuration import ConfigurationModel
-from flepimop2.configuration._module import ModuleGroupModel, ModuleModel
+from flepimop2.configuration._module import (
+    ModuleConfigurationValue,
+    ModuleGroupModel,
+    ModuleModel,
+)
 from flepimop2.configuration._simulate import SimulateSpecificationModel

--- a/src/flepimop2/configuration/_module.py
+++ b/src/flepimop2/configuration/_module.py
@@ -13,7 +13,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
-from typing import Annotated, Any, Literal, cast
+from typing import Annotated, Any, Literal, TypeAlias, cast
 
 from pydantic import BaseModel, BeforeValidator, ConfigDict, Field
 
@@ -60,7 +60,11 @@ class ModuleModel(BaseModel):
         cls.model_rebuild(force=True)
 
 
+ModuleConfigurationValue: TypeAlias = ModuleModel | str
+"""A module configuration value, either expanded config or shorthand text."""
+
+
 ModuleGroupModel = Annotated[
-    dict[IdentifierString, ModuleModel], BeforeValidator(_to_default_dict)
+    dict[IdentifierString, ModuleConfigurationValue], BeforeValidator(_to_default_dict)
 ]
 """Module group configuration model for flepimop2."""

--- a/src/flepimop2/engine/abc/__init__.py
+++ b/src/flepimop2/engine/abc/__init__.py
@@ -130,15 +130,15 @@ class EngineABC(ModuleABC, module_namespace="engine"):
         return None
 
 
-def build(config: dict[str, Any] | ModuleModel) -> EngineABC:
+def build(config: dict[str, Any] | ModuleModel | str) -> EngineABC:
     """Build a `EngineABC` from a configuration dictionary.
 
     Args:
         config: Configuration dictionary or a `ModuleModel` instance to construct the
-            engine from.
+            engine from. The configuration must define a `module`.
 
     Returns:
         The constructed engine instance.
 
     """
-    return _build(config, "engine", "flepimop2.engine.wrapper", EngineABC)
+    return _build(config, "engine", EngineABC)

--- a/src/flepimop2/module.py
+++ b/src/flepimop2/module.py
@@ -19,7 +19,7 @@ __all__ = ["ModuleABC"]
 
 import inspect
 from abc import ABC
-from typing import Any, ClassVar, Literal
+from typing import Any, ClassVar, Literal, Self
 
 from flepimop2.typing import RaiseOnMissing, RaiseOnMissingType
 
@@ -170,6 +170,41 @@ class ModuleABC(ABC):
                 "'module' as a non-empty string."
             )
             raise TypeError(msg)
+
+    @classmethod
+    def from_shorthand(cls, shorthand: str) -> Self:
+        """
+        Build an instance from shorthand configuration text.
+
+        Concrete modules may override this optional hook to support configuration
+        values shaped like `module_name(...)`. The provided `shorthand` is the text
+        inside the parentheses.
+
+        Args:
+            shorthand: The text contained within the shorthand parentheses.
+
+        Notes:
+            This hook is primarily intended for external module providers that want
+            to offer a concise string syntax for simple configurations.
+
+            Before implementing shorthand, consider whether the module actually
+            benefits from it. Modules that require many settings, nested structure,
+            or richer validation are often better served by full YAML mappings than
+            by a single string.
+
+            Implementations should parse `shorthand` robustly. In particular,
+            callers may supply multiline values from YAML block scalars, so parsing
+            should tolerate embedded newlines and surrounding whitespace where that
+            makes sense for the module's syntax.
+
+            Implementations should raise `ValueError` for invalid shorthand input so
+            users receive a clear configuration error rather than a generic failure.
+
+        Raises:
+            NotImplementedError: If the module does not support shorthand syntax.
+        """
+        msg = "Shorthand syntax is not supported by this module."
+        raise NotImplementedError(msg)
 
     def option(self, name: str, default: Any = RaiseOnMissing) -> Any:  # noqa: ANN401
         """

--- a/src/flepimop2/parameter/abc/__init__.py
+++ b/src/flepimop2/parameter/abc/__init__.py
@@ -289,14 +289,14 @@ class ParameterABC(ModuleABC, module_namespace="parameter"):
         raise NotImplementedError
 
 
-def build(config: dict[str, Any] | ModuleModel) -> ParameterABC:
+def build(config: dict[str, Any] | ModuleModel | str) -> ParameterABC:
     """Build a `ParameterABC` from a configuration dictionary.
 
     Args:
         config: Configuration dictionary or a `ModuleModel` instance to construct the
-            parameter from.
+            parameter from. The configuration must define a `module`.
 
     Returns:
         The constructed parameter instance.
     """
-    return _build(config, "parameter", "flepimop2.parameter.wrapper", ParameterABC)
+    return _build(config, "parameter", ParameterABC)

--- a/src/flepimop2/parameter/fixed/__init__.py
+++ b/src/flepimop2/parameter/fixed/__init__.py
@@ -18,7 +18,7 @@
 __all__ = ["FixedParameter"]
 
 
-from typing import Any
+from typing import Any, Self
 
 import numpy as np
 
@@ -41,6 +41,47 @@ class FixedParameter(ModuleModel, ParameterABC, module="fixed"):
 
     value: float | int | list[Any]
     shape: tuple[IdentifierString, ...] = ()
+
+    @classmethod
+    def from_shorthand(cls, shorthand: str) -> Self:
+        r"""
+        Build a fixed parameter from shorthand argument text.
+
+        Args:
+            shorthand: The text inside the shorthand parentheses.
+
+        Returns:
+            A fixed parameter with the parsed numeric value.
+
+        Raises:
+            ValueError: If the shorthand cannot be parsed as a float.
+
+        Examples:
+            >>> from flepimop2.parameter.fixed import FixedParameter
+            >>> FixedParameter.from_shorthand("3").value
+            3.0
+            >>> FixedParameter.from_shorthand("0.25").value
+            0.25
+            >>> FixedParameter.from_shorthand("-7").value
+            -7.0
+            >>> FixedParameter.from_shorthand('''
+            ...   3.1415
+            ... ''').value
+            3.1415
+            >>> try:
+            ...     FixedParameter.from_shorthand("'x'")
+            ... except ValueError as exc:
+            ...     print(exc)
+            FixedParameter shorthand must contain exactly one numeric value, got "'x'".
+        """
+        try:
+            return cls(value=float(shorthand.strip()))
+        except ValueError as exc:
+            msg = (
+                "FixedParameter shorthand must contain exactly one numeric value, "
+                f"got {shorthand!r}."
+            )
+            raise ValueError(msg) from exc
 
     def sample(
         self,

--- a/src/flepimop2/process/abc/__init__.py
+++ b/src/flepimop2/process/abc/__init__.py
@@ -62,7 +62,7 @@ class ProcessABC(ModuleABC, module_namespace="process"):
         return None
 
 
-def build(config: dict[str, Any] | ModuleModel) -> ProcessABC:
+def build(config: dict[str, Any] | ModuleModel | str) -> ProcessABC:
     """Build a `ProcessABC` from a configuration dictionary.
 
     Args:
@@ -74,4 +74,4 @@ def build(config: dict[str, Any] | ModuleModel) -> ProcessABC:
         ProcessABC: The constructed process object.
 
     """
-    return _build(config, "process", "flepimop2.process.shell", ProcessABC)
+    return _build(config, "process", ProcessABC)

--- a/src/flepimop2/scenario/abc/__init__.py
+++ b/src/flepimop2/scenario/abc/__init__.py
@@ -27,7 +27,7 @@ from flepimop2.module import ModuleABC
 from flepimop2.typing import Float64NDArray, IdentifierString
 
 
-class ScenarioABC(ModuleABC):
+class ScenarioABC(ModuleABC, module_namespace="scenario"):
     """Abstract base class for scenarios."""
 
     @property
@@ -50,15 +50,15 @@ class ScenarioABC(ModuleABC):
         raise NotImplementedError
 
 
-def build(config: dict[IdentifierString, Any] | ModuleModel) -> ScenarioABC:
+def build(config: dict[IdentifierString, Any] | ModuleModel | str) -> ScenarioABC:
     """Build a `ScenarioABC` from a configuration dictionary.
 
     Args:
         config: Configuration dictionary or a `ModuleModel` instance to construct the
-            scenarios from.
+            scenarios from. The configuration must define a `module`.
 
     Returns:
         The constructed scenario instance.
 
     """
-    return _build(config, "scenario", "flepimop2.scenario.grid", ScenarioABC)
+    return _build(config, "scenario", ScenarioABC)

--- a/src/flepimop2/scenario/grid/__init__.py
+++ b/src/flepimop2/scenario/grid/__init__.py
@@ -19,14 +19,14 @@ __all__ = ["Float64NDArray", "GridScenario"]
 
 import itertools
 from collections.abc import Iterable
-from typing import Any, Literal, NamedTuple, cast
+from typing import Any, NamedTuple, cast
 
 from flepimop2.configuration import ModuleModel
 from flepimop2.scenario.abc import ScenarioABC
 from flepimop2.typing import Float64NDArray, IdentifierString
 
 
-class GridScenario(ModuleModel, ScenarioABC):
+class GridScenario(ModuleModel, ScenarioABC, module="grid"):
     """
     Grid scenario implementation.
 
@@ -39,7 +39,6 @@ class GridScenario(ModuleModel, ScenarioABC):
             parameter values to be combined into scenarios.
     """
 
-    module: Literal["flepimop2.scenario.grid"] = "flepimop2.scenario.grid"
     parameters: dict[IdentifierString, list[Any]]
 
     @property

--- a/src/flepimop2/simulator.py
+++ b/src/flepimop2/simulator.py
@@ -23,7 +23,7 @@ from flepimop2.backend.abc import BackendABC
 from flepimop2.backend.abc import build as build_backend
 from flepimop2.configuration import (
     ConfigurationModel,
-    ModuleModel,
+    ModuleConfigurationValue,
     SimulateSpecificationModel,
 )
 from flepimop2.engine.abc import EngineABC
@@ -61,10 +61,10 @@ class Simulator:
     backend: BackendABC
     target: str | None = None
     simulate_config: SimulateSpecificationModel | None = None
-    system_config: ModuleModel | None = None
-    engine_config: ModuleModel | None = None
-    backend_config: ModuleModel | None = None
-    parameter_configs: dict[IdentifierString, ModuleModel] | None = None
+    system_config: ModuleConfigurationValue | None = None
+    engine_config: ModuleConfigurationValue | None = None
+    backend_config: ModuleConfigurationValue | None = None
+    parameter_configs: dict[IdentifierString, ModuleConfigurationValue] | None = None
     axes: AxisCollection
 
     def __init__(  # noqa: PLR0913
@@ -75,10 +75,11 @@ class Simulator:
         *,
         target: str | None = None,
         simulate_config: SimulateSpecificationModel | None = None,
-        system_config: ModuleModel | None = None,
-        engine_config: ModuleModel | None = None,
-        backend_config: ModuleModel | None = None,
-        parameter_configs: dict[IdentifierString, ModuleModel] | None = None,
+        system_config: ModuleConfigurationValue | None = None,
+        engine_config: ModuleConfigurationValue | None = None,
+        backend_config: ModuleConfigurationValue | None = None,
+        parameter_configs: dict[IdentifierString, ModuleConfigurationValue]
+        | None = None,
         axes: AxisCollection | None = None,
     ) -> None:
         """
@@ -93,7 +94,7 @@ class Simulator:
             system_config: The resolved system configuration model, if available.
             engine_config: The resolved engine configuration model, if available.
             backend_config: The resolved backend configuration model, if available.
-            parameter_configs: The resolved parameter configuration models, if
+            parameter_configs: The resolved parameter configuration values, if
                 available.
             axes: The resolved runtime axis collection for the simulation.
 

--- a/src/flepimop2/system/abc/__init__.py
+++ b/src/flepimop2/system/abc/__init__.py
@@ -297,23 +297,19 @@ class _AdapterSystem(SystemABC, module="wrapper"):
         return super().model_state(axes)
 
 
-def build(config: dict[IdentifierString, Any] | ModuleModel) -> SystemABC:
+def build(config: dict[IdentifierString, Any] | ModuleModel | str) -> SystemABC:
     """
     Build a `SystemABC` from a configuration dictionary.
 
     Args:
-        config: Configuration dictionary or a `ModuleModel` instance.
+        config: Configuration dictionary or a `ModuleModel` instance. The
+            configuration must define a `module`.
 
     Returns:
         The constructed system instance.
 
     """
-    return _build(
-        config,
-        "system",
-        "flepimop2.system.wrapper",
-        SystemABC,
-    )
+    return _build(config, "system", SystemABC)
 
 
 def wrap(

--- a/tests/_utils/_module/test__build.py
+++ b/tests/_utils/_module/test__build.py
@@ -1,0 +1,56 @@
+# flepimop2: The FLExible Pipeline for Interchangeable MOdel Processing
+# Copyright (C) 2026  Carl Pearson, Joshua Macdonald, Timothy Willard
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Tests for `_build` via the public module builders."""
+
+from collections.abc import Callable
+from typing import Any
+
+import pytest
+
+from flepimop2.backend.abc import build as build_backend
+from flepimop2.configuration import ModuleModel
+from flepimop2.engine.abc import build as build_engine
+from flepimop2.module import ModuleABC
+from flepimop2.parameter.abc import build as build_parameter
+from flepimop2.process.abc import build as build_process
+from flepimop2.scenario.abc import build as build_scenario
+from flepimop2.system.abc import build as build_system
+
+
+@pytest.mark.parametrize(
+    ("builder", "namespace"),
+    [
+        (build_backend, "backend"),
+        (build_engine, "engine"),
+        (build_parameter, "parameter"),
+        (build_process, "process"),
+        (build_scenario, "scenario"),
+        (build_system, "system"),
+    ],
+)
+def test_build_requires_explicit_module(
+    builder: Callable[[dict[str, Any] | ModuleModel], ModuleABC],
+    namespace: str,
+) -> None:
+    """Each public builder should require an explicit `module`."""
+    with pytest.raises(
+        ValueError,
+        match=(
+            rf"Configuration for namespace '{namespace}' must define a non-empty "
+            r"'module' string\."
+        ),
+    ):
+        builder({})

--- a/tests/engine/test_engine_wrapper.py
+++ b/tests/engine/test_engine_wrapper.py
@@ -41,7 +41,8 @@ TEST_SYSTEM_SCRIPT: Final = (
 
 
 @pytest.mark.parametrize(
-    "config", [{"script": TEST_ENGINE_SCRIPT, "state_change": "flow"}]
+    "config",
+    [{"module": "wrapper", "script": TEST_ENGINE_SCRIPT, "state_change": "flow"}],
 )
 @pytest.mark.parametrize(
     "system",
@@ -82,19 +83,22 @@ def test_wrapper_system(
 
 
 @pytest.mark.parametrize(
-    "config", [{"script": TEST_ENGINE_SCRIPT, "state_change": "flow"}]
+    "config",
+    [{"module": "wrapper", "script": TEST_ENGINE_SCRIPT, "state_change": "flow"}],
 )
 def test_wrapper_engine_validate_system_properties(config: dict[str, Any]) -> None:
     """Test `WrapperEngine` validates system properties compatibility."""
     engine = engine_build(config)
 
     compatible_system = system_build({
+        "module": "wrapper",
         "script": TEST_SYSTEM_SCRIPT,
         "state_change": StateChangeEnum.FLOW,
     })
     assert engine.validate_system(compatible_system) is None
 
     incompatible_system = system_build({
+        "module": "wrapper",
         "script": TEST_SYSTEM_SCRIPT,
         "state_change": StateChangeEnum.DELTA,
     })

--- a/tests/process/test_process_shell.py
+++ b/tests/process/test_process_shell.py
@@ -22,8 +22,23 @@ import pytest
 from flepimop2.process.abc import build as build_process
 
 
-@pytest.mark.parametrize("config", [{"command": "echo", "args": ["Hello, World!"]}])
+@pytest.mark.parametrize(
+    "config",
+    [{"module": "shell", "command": "echo", "args": ["Hello, World!"]}],
+)
 def test_shell_system(config: dict[str, Any]) -> None:
     """Test `ShellProcess` makes a command and executes it."""
     process = build_process(config)
     process.execute()
+
+
+def test_shell_process_shorthand_not_supported() -> None:
+    """Shell process should reject shorthand until it opts in."""
+    with pytest.raises(
+        ValueError,
+        match=(
+            r"Module 'flepimop2\.process\.shell' does not support shorthand "
+            r"configuration\."
+        ),
+    ):
+        build_process("shell(echo, hello)")

--- a/tests/scenario/test_scenario_grid.py
+++ b/tests/scenario/test_scenario_grid.py
@@ -30,6 +30,6 @@ from flepimop2.typing import IdentifierString
 )
 def test_set_valid_static_parameters(params: dict[IdentifierString, Any]) -> None:
     """Confirm generation of all combinations of parameters."""
-    scenario = scenario_build({"parameters": params})
+    scenario = scenario_build({"module": "grid", "parameters": params})
     expected_scenarios = list(itertools.product(*params.values()))
     assert list(scenario.scenarios()) == expected_scenarios

--- a/tests/system/test_system_bind.py
+++ b/tests/system/test_system_bind.py
@@ -26,7 +26,11 @@ from flepimop2.system.abc import SystemABC, build
 from flepimop2.typing import StateChangeEnum
 
 TEST_SCRIPT = Path(__file__).parent / "system_wrapper_assets" / "dummy_system.py"
-system = build({"script": TEST_SCRIPT, "state_change": StateChangeEnum.DELTA})
+system = build({
+    "module": "wrapper",
+    "script": TEST_SCRIPT,
+    "state_change": StateChangeEnum.DELTA,
+})
 
 par = pytest.mark.parametrize("test_system", [system])
 

--- a/tests/system/test_system_wrapper.py
+++ b/tests/system/test_system_wrapper.py
@@ -35,7 +35,10 @@ WRAPPER_SCRIPT_WITH_EXTRAS: Final = (
 )
 
 
-@pytest.mark.parametrize("config", [{"script": TEST_SCRIPT, "state_change": "flow"}])
+@pytest.mark.parametrize(
+    "config",
+    [{"module": "wrapper", "script": TEST_SCRIPT, "state_change": "flow"}],
+)
 def test_wrapper_system(config: dict[str, Any]) -> None:
     """Test `WrapperSystem` loads a script and uses its `stepper` function."""
     system = build(config)
@@ -55,6 +58,7 @@ def test_wrapper_system(config: dict[str, Any]) -> None:
 def test_wrapper_system_options_available_via_option_method() -> None:
     """Test `WrapperSystem` exposes configured options through `ModuleABC.option`."""
     system = build({
+        "module": "wrapper",
         "script": TEST_SCRIPT,
         "state_change": "flow",
         "options": {"offset": 1.5},
@@ -67,6 +71,7 @@ def test_wrapper_system_loads_requested_parameters_and_model_state_from_config()
 ):
     """Wrapper systems should expose parameter and state metadata from config."""
     system = build({
+        "module": "wrapper",
         "script": WRAPPER_SCRIPT_WITH_EXTRAS,
         "state_change": "flow",
         "requested_parameters": {


### PR DESCRIPTION
## Description

Added the ability for `flepimop2` to parse shorthand syntax from modules
that easy to specify in a single line with few arguments. In a
configuration file this looks like the user specifying the module model
as a string. For example:

```yaml
parameter:
  beta: fixed(0.3)
```

The initial portion of the string, 'fixed', identifies the module to
load and the contents between the parens are passed to `from_shorthand`
class method (if implemented) to parse into a well formed module.

- Updated build functions to accept strings, by default
  `flepimop2._utils._module._build` handles this by deferring to the
  `from_shorthand` classmethod of the requested module.
- Added shorthand syntax for `FixedParameter` for user convenience.
- Removed the default module from the `flepimop2.*.abc.build` helpers,
  instead requiring that users either use shorthand syntax or specify a
  'module' explicitly.

## Related issues

Closes #14.

## Checklist

- [x] I have read through and understand the [pull request process](https://github.com/ACCIDDA/flepimop2?tab=contributing-ov-file#pull-request-process).
- [x] I ran successfully ran CI local via `just ci`.
- [x] I have updated the `CHANGELOG.md` or noted "no major changes" in my commit if the PR is small.
