### PR TITLE
Add default configuration search for 'CONFIG' arg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Introduced the axis concept as a way to represent aligned shapes across parameters, systems, etc. Added two kinds of axes, categorical and continuous, to represent different kinds of dimensions. Also added an `axes` top level key to the `ConfigurationModel` so users can provide these axes via configuration and `flepimop2.axis` module for realizing & manipulating axes from configuration. See [#147](https://github.com/ACCIDDA/flepimop2/issues/147).
 - Added ways to specify shape for parameters based on `axes` by changing `ParameterABC.sample` to return a `ParameterValue` that contains both the underlying value as a numpy array as well as shape metadata, and is easily extensible to other metadata and underlying value types in the future. Also added `ModelStateSpecification`, `ParameterRequest` types for systems to advertise their underlying state and request parameters to comply with said state specification. See [#115](https://github.com/ACCIDDA/flepimop2/issues/115), [#133](https://github.com/ACCIDDA/flepimop2/issues/133).
+- Added help text for CLI arguments that are formatted similarly to click's default formatting for options.
 
 ### Changed
 
 - Updated CLI commands to return consistent exit codes based on the kind of failure. See [#17](https://github.com/ACCIDDA/flepimop2/issues/17).
+- Added a default search order for CLI commands with the `CONFIG` argument making providing a file manually not required for typical/small project usage. See [#245](https://github.com/ACCIDDA/flepimop2/issues/245).
 
 ### Deprecated
 

--- a/src/flepimop2/_cli/_cli_command.py
+++ b/src/flepimop2/_cli/_cli_command.py
@@ -165,9 +165,7 @@ class CliCommand(ABC):
         Returns:
             The help text for the command.
         """
-        if cls.__doc__:
-            return cls.__doc__.strip()
-        return "No description available."
+        return inspect.cleandoc(cls.__doc__ or "No description available.")
 
     def log(self, level: int, *args: Any, **kwargs: Any) -> None:
         """Log a message at the specified level."""

--- a/src/flepimop2/_cli/_options.py
+++ b/src/flepimop2/_cli/_options.py
@@ -17,49 +17,181 @@
 
 __all__ = []
 
-import pathlib
 from collections.abc import Callable
-from typing import Any, Final, TypeVar
+from pathlib import Path
+from typing import Any, Final, TypeVar, cast
 
 import click
 
 AnyCallable = Callable[..., Any]
 FC = TypeVar("FC", bound="AnyCallable | click.Command")
+CommonOptionDecorator = Callable[[AnyCallable], AnyCallable]
+CommonOptionEntry = tuple[CommonOptionDecorator, str | None]
+_DEFAULT_CONFIG_SEARCH_ORDER: Final[tuple[Path, ...]] = (
+    Path("config.yaml"),
+    Path("config.yml"),
+    Path("configuration.yaml"),
+    Path("configuration.yml"),
+    Path("configs/config.yaml"),
+    Path("configs/config.yml"),
+    Path("configs/configuration.yaml"),
+    Path("configs/configuration.yml"),
+)
+
+
+def _resolve_config_argument(
+    value: Path | None,
+    *,
+    cwd: Path | None = None,
+) -> Path:
+    r"""
+    Resolve a config argument, falling back to a default search order.
+
+    If `value` is provided, it is returned unchanged. Otherwise, the current
+    working directory is searched for the first matching default config file.
+
+    Args:
+        value: The explicit config path given on the command line, if any.
+        cwd: The directory to search when `value` is `None`.
+
+    Returns:
+        The explicit config path, or the first matching default config path.
+
+    Raises:
+        FileNotFoundError: If `value` is `None` and no default config file exists.
+
+    Examples:
+        >>> from pathlib import Path
+        >>> _resolve_config_argument(Path("example.yaml"))
+        PosixPath('example.yaml')
+        >>> _ = Path("configuration.yml").write_text("x: 1\\n")
+        >>> _resolve_config_argument(None).name
+        'configuration.yml'
+        >>> _ = Path("configuration.yml").unlink()
+    """
+    if value is not None:
+        return value
+    search_root = Path.cwd() if cwd is None else cwd
+    for relative_path in _DEFAULT_CONFIG_SEARCH_ORDER:
+        candidate = search_root / relative_path
+        if candidate.is_file():
+            return candidate
+    searched = ", ".join(
+        str(search_root / path) for path in _DEFAULT_CONFIG_SEARCH_ORDER
+    )
+    msg = (
+        "No configuration file was provided and none was found in the default "
+        f"search locations: {searched}"
+    )
+    raise FileNotFoundError(msg)
+
+
+def _config_argument_callback(
+    ctx: click.Context,
+    param: click.Parameter,
+    value: Path | None,
+) -> Path:
+    """
+    Resolve the shared config argument for Click commands.
+
+    Args:
+        ctx: The active Click context.
+        param: The Click parameter being processed.
+        value: The explicit config path, if provided.
+
+    Returns:
+        The resolved config path.
+
+    Raises:
+        click.BadParameter: If no explicit or default config path can be found.
+    """
+    del ctx
+    try:
+        return _resolve_config_argument(value)
+    except FileNotFoundError as exc:
+        raise click.BadParameter(str(exc), param=param) from exc
+
+
+def _argument_help_records(
+    params: list[click.Parameter],
+) -> list[tuple[str, str]]:
+    """
+    Build shared help records for common positional arguments.
+
+    Args:
+        params: The Click parameters used by a command.
+
+    Returns:
+        Help records suitable for `click.HelpFormatter.write_dl`.
+    """
+    return [
+        (param.human_readable_name, option_entry[1])
+        for param in params
+        if param.name is not None
+        and (option_entry := COMMON_OPTIONS.get(param.name)) is not None
+        and option_entry[1] is not None
+    ]
+
 
 # Dictionary of common Click options and arguments
 # These can be requested by command classes to maintain consistency
-COMMON_OPTIONS: Final = {
-    "config": click.argument(
-        "config",
-        type=click.Path(
-            exists=True, dir_okay=False, readable=True, path_type=pathlib.Path
+COMMON_OPTIONS: Final[dict[str, CommonOptionEntry]] = {
+    "config": (
+        click.argument(
+            "config",
+            callback=_config_argument_callback,
+            default=None,
+            required=False,
+            type=click.Path(exists=True, dir_okay=False, readable=True, path_type=Path),
+        ),
+        (
+            "Configuration file. If omitted, flepimop2 searches, in order, for "
+            "`config.yaml`, `config.yml`, `configuration.yaml`, "
+            "`configuration.yml`, `configs/config.yaml`, "
+            "`configs/config.yml`, `configs/configuration.yaml`, and "
+            "`configs/configuration.yml`."
         ),
     ),
-    "dry_run": click.option(
-        "--dry-run",
-        is_flag=True,
-        default=False,
-        help="Should this command be run using dry run?",
-    ),
-    "path": click.argument(
-        "path",
-        type=click.Path(
-            exists=False, file_okay=False, writable=True, path_type=pathlib.Path
+    "dry_run": (
+        click.option(
+            "--dry-run",
+            is_flag=True,
+            default=False,
+            help="Should this command be run using dry run?",
         ),
-        default=None,
+        None,
     ),
-    "target": click.option(
-        "-t",
-        "--target",
-        default=None,
-        help="The target to use for this command.",
+    "path": (
+        click.argument(
+            "path",
+            type=click.Path(
+                exists=False,
+                file_okay=False,
+                writable=True,
+                path_type=Path,
+            ),
+            default=None,
+        ),
+        "Filesystem path used by the command.",
     ),
-    "verbosity": click.option(
-        "-v",
-        "--verbosity",
-        count=True,
-        default=0,
-        help="The verbosity level to use for this command.",
+    "target": (
+        click.option(
+            "-t",
+            "--target",
+            default=None,
+            help="The target to use for this command.",
+        ),
+        None,
+    ),
+    "verbosity": (
+        click.option(
+            "-v",
+            "--verbosity",
+            count=True,
+            default=0,
+            help="The verbosity level to use for this command.",
+        ),
+        None,
     ),
 }
 
@@ -77,10 +209,10 @@ def get_option(name: str) -> Callable[[FC], FC]:
     Raises:
         KeyError: If the option name is not found.
     """
-    if (opt := COMMON_OPTIONS.get(name)) is None:
+    if (entry := COMMON_OPTIONS.get(name)) is None:
         msg = (
             f"Unknown option '{name}'. "
             f"Available options: {', '.join(COMMON_OPTIONS.keys())}"
         )
         raise KeyError(msg)
-    return opt
+    return cast("Callable[[FC], FC]", entry[0])

--- a/src/flepimop2/_cli/_register_command.py
+++ b/src/flepimop2/_cli/_register_command.py
@@ -15,10 +15,27 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 from typing import Any
 
+import click
 from click import Group
 
 from flepimop2._cli._cli_command import CliCommand
-from flepimop2._cli._options import get_option
+from flepimop2._cli._options import _argument_help_records, get_option
+
+
+class _ArgumentHelpCommand(click.Command):
+    """Click command that renders shared positional argument help."""
+
+    def format_options(
+        self,
+        ctx: click.Context,
+        formatter: click.HelpFormatter,
+    ) -> None:
+        """Write shared argument help before the normal options section."""
+        argument_help = _argument_help_records(self.get_params(ctx))
+        if argument_help:
+            with formatter.section("Arguments"):
+                formatter.write_dl(argument_help)
+        super().format_options(ctx, formatter)
 
 
 def register_command(command_cls: type[CliCommand], group: Group) -> None:
@@ -52,4 +69,4 @@ def register_command(command_cls: type[CliCommand], group: Group) -> None:
         command_wrapper = option_decorator(command_wrapper)
 
     # Register the command with the CLI group
-    group.command(name=command_name)(command_wrapper)
+    group.command(name=command_name, cls=_ArgumentHelpCommand)(command_wrapper)

--- a/tests/_cli/_options/test_common_options_constant.py
+++ b/tests/_cli/_options/test_common_options_constant.py
@@ -16,8 +16,32 @@
 """Tests for the `COMMON_OPTIONS` constant in `flepimop2._cli._options`."""
 
 from collections import Counter
+from collections.abc import Callable
+
+import click
 
 from flepimop2._cli._options import COMMON_OPTIONS
+
+
+def _click_param_from_decorator(
+    decorator: Callable[[Callable[[], None]], Callable[[], None]],
+) -> click.Parameter:
+    """
+    Materialize a Click parameter from a common option decorator.
+
+    Returns:
+        The single Click parameter attached by the decorator.
+    """
+
+    def callback() -> None:
+        return None
+
+    decorated = decorator(callback)
+    click_params = getattr(decorated, "__click_params__", None)
+    assert click_params is not None
+    assert len(click_params) == 1
+    assert isinstance(click_params[0], click.Parameter)
+    return click_params[0]
 
 
 def test_common_options_keys_are_sorted() -> None:
@@ -34,7 +58,7 @@ def test_no_duplicate_option_names() -> None:
     # Collect all option names from the decorators
     # Click decorators store the option names in their closure (3rd element)
     all_opts: list[str] = []
-    for decorator in COMMON_OPTIONS.values():
+    for decorator, _help_text in COMMON_OPTIONS.values():
         if hasattr(decorator, "__closure__") and decorator.__closure__:
             # The option names are typically in the 3rd closure cell (index 2)
             # This contains a tuple like ('-v', '--verbosity') or ('config',)
@@ -54,3 +78,15 @@ def test_no_duplicate_option_names() -> None:
         f"Found duplicate option names in COMMON_OPTIONS: "
         f"{', '.join(f'{opt} ({count})' for opt, count in duplicates.items())}"
     )
+
+
+def test_argument_help_is_only_defined_for_arguments() -> None:
+    """Only positional arguments should define additional argument help text."""
+    for name, (decorator, help_text) in COMMON_OPTIONS.items():
+        if help_text is None:
+            continue
+        click_param = _click_param_from_decorator(decorator)
+        assert isinstance(click_param, click.Argument), (
+            f"{name} defines shared argument help but is not backed by "
+            "click.argument; use click.option(..., help=...) directly for options."
+        )

--- a/tests/_cli/_options/test_config_argument.py
+++ b/tests/_cli/_options/test_config_argument.py
@@ -1,0 +1,110 @@
+# flepimop2: The FLExible Pipeline for Interchangeable MOdel Processing
+# Copyright (C) 2026  Carl Pearson, Joshua Macdonald, Timothy Willard
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Tests for shared config argument resolution in `flepimop2._cli._options`."""
+
+from pathlib import Path
+
+import click
+import pytest
+from click.testing import CliRunner
+
+from flepimop2._cli._options import (
+    _resolve_config_argument,
+    get_option,
+)
+
+
+def test_resolve_config_argument_returns_explicit_value(tmp_path: Path) -> None:
+    """An explicit config path should bypass default search resolution."""
+    config_path = tmp_path / "custom.yaml"
+    config_path.write_text("name: explicit\n")
+
+    assert _resolve_config_argument(config_path) == config_path
+
+
+def test_resolve_config_argument_uses_first_match_in_search_order(
+    tmp_path: Path,
+) -> None:
+    """The first matching default config path should win."""
+    first_match = tmp_path / "configuration.yml"
+    first_match.write_text("name: first\n")
+    later_match = tmp_path / "configs" / "config.yaml"
+    later_match.parent.mkdir()
+    later_match.write_text("name: later\n")
+
+    assert _resolve_config_argument(None, cwd=tmp_path) == first_match
+
+
+def test_resolve_config_argument_prefers_yaml_before_yml(tmp_path: Path) -> None:
+    """`.yaml` should win over `.yml` when both names exist for a pattern."""
+    yaml_path = tmp_path / "config.yaml"
+    yaml_path.write_text("name: yaml\n")
+    yml_path = tmp_path / "config.yml"
+    yml_path.write_text("name: yml\n")
+
+    assert _resolve_config_argument(None, cwd=tmp_path) == yaml_path
+
+
+def test_resolve_config_argument_raises_when_no_default_found(tmp_path: Path) -> None:
+    """Missing default configs should produce a useful error."""
+    msg = "No configuration file was provided and none was found"
+
+    with pytest.raises(FileNotFoundError, match=msg) as exc_info:
+        _resolve_config_argument(None, cwd=tmp_path)
+
+    assert str(tmp_path / "config.yaml") in str(exc_info.value)
+
+
+def test_common_config_argument_uses_default_search(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The shared Click argument should resolve a default config when omitted."""
+    config_path = tmp_path / "configs" / "configuration.yaml"
+    config_path.parent.mkdir()
+    config_path.write_text("name: resolved\n")
+    monkeypatch.chdir(tmp_path)
+
+    @click.command()
+    @get_option("config")
+    def command(config: Path) -> None:
+        click.echo(str(config))
+
+    runner = CliRunner()
+    result = runner.invoke(command, [], catch_exceptions=False)
+
+    assert result.exit_code == 0
+    assert result.output.strip() == str(config_path)
+
+
+def test_common_config_argument_reports_missing_default(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The shared Click argument should fail clearly when no config is found."""
+    monkeypatch.chdir(tmp_path)
+
+    @click.command()
+    @get_option("config")
+    def command(config: Path) -> None:
+        click.echo(str(config))
+
+    runner = CliRunner()
+    result = runner.invoke(command, [], catch_exceptions=False)
+
+    assert result.exit_code != 0
+    assert "Invalid value for '[CONFIG]'" in result.output
+    assert "No configuration file was provided and none was found" in result.output

--- a/tests/_cli/_register_command/test_register_command.py
+++ b/tests/_cli/_register_command/test_register_command.py
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """Tests for the `register_command` function in `flepimop2._cli._cli`."""
 
+import inspect
 from unittest.mock import MagicMock
 
 import click
@@ -108,6 +109,16 @@ class MockCommandNoAutoVerbosity(CliCommand):
         click.echo(f"Command ran with config: {config}")
 
 
+class MockCommandWithCommonArguments(CliCommand):
+    """Mock command with shared positional arguments."""
+
+    auto_append_verbosity = False
+
+    def run(self, *, config: str, path: str) -> None:  # type: ignore[override]
+        """Mock run method."""
+        click.echo(f"Command ran with config: {config} and path: {path}")
+
+
 class MockCommandWithNonExistentOption(CliCommand):
     """Mock command that requests a non-existent option."""
 
@@ -172,7 +183,10 @@ def test_register_command_sets_help_text() -> None:
     command = test_cli.commands["mock"]
 
     # Help text should come from the class docstring
-    assert command.help == (MockCommand.__doc__ or "No description available.").strip()
+    assert command.help == inspect.cleandoc(
+        MockCommand.__doc__ or "No description available."
+    )
+    assert "Arguments:" not in command.help
 
 
 def test_register_command_uses_custom_help_text() -> None:
@@ -184,6 +198,22 @@ def test_register_command_uses_custom_help_text() -> None:
 
     # Should use the custom help text
     assert command.help == "Custom help text for this command."
+
+
+def test_register_command_appends_shared_argument_help() -> None:
+    """Shared common argument help should render as its own help section."""
+    test_cli = click.Group()
+    register_command(MockCommandWithCommonArguments, test_cli)
+
+    command = test_cli.commands["mock-command-with-common-arguments"]
+    runner = CliRunner()
+    result = runner.invoke(command, ["--help"])
+
+    assert result.exit_code == 0
+    assert "\nArguments:\n" in result.output
+    assert "CONFIG" in result.output
+    assert "PATH" in result.output
+    assert "`config.yaml`" in result.output
 
 
 def test_register_command_wrapper_instantiates_and_runs() -> None:


### PR DESCRIPTION
## Description

Added a default configuration search order for the 'CONFIG' CLI argument. This particular search order is documented in the newly added argument documentation feature.

## Related issues

Closes #245.

## Checklist

- [x] I have read through and understand the [pull request process](https://github.com/ACCIDDA/flepimop2?tab=contributing-ov-file#pull-request-process).
- [x] I ran successfully ran CI local via `just ci`.
- [x] I have updated the `CHANGELOG.md` or noted "no major changes" in my commit if the PR is small.
