### PR TITLE
Omit `src/flepimop2/testing.py` from coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -164,5 +164,10 @@ include = [
 ]
 
 [tool.coverage.report]
-fail_under = 75
+fail_under = 80
 precision = 1
+
+[tool.coverage.run]
+omit = [
+    "src/flepimop2/testing.py",
+]


### PR DESCRIPTION
## Description

Omit `src/flepimop2/testing.py` from coverage.

## Related issues

Closes #215.

## Checklist

- [x] I have read through and understand the [pull request process](https://github.com/ACCIDDA/flepimop2?tab=contributing-ov-file#pull-request-process).
- [x] I ran successfully ran CI local via `just ci`.
- [x] I have updated the `CHANGELOG.md` or noted "no major changes" in my commit if the PR is small.
