### PR TITLE
Restore `parameter: value` syntax for fixed params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- ...
+- Restored `parameter: value` syntax (i.e. `pi: 3.14`) for specifying scalar parameters directly as floats/ints in the configuration file. See [#100](https://github.com/ACCIDDA/flepimop2/issues/100).
 
 ### Security
 

--- a/docs/assets/full_feature_workflow/config.yml
+++ b/docs/assets/full_feature_workflow/config.yml
@@ -55,18 +55,8 @@ process:
     output: model_output/SirPlot.html
 
 parameter:
-  beta:
-    module: fixed
-    value: 0.3
-  gamma:
-    module: fixed
-    value: 0.1
-  s0:
-    module: fixed
-    value: 999
-  i0:
-    module: fixed
-    value: 1
-  r0:
-    module: fixed
-    value: 0
+  beta: 0.3
+  gamma: 0.1
+  s0: 999
+  i0: 1
+  r0: 0

--- a/docs/assets/postprocessing_workflow/config.yaml
+++ b/docs/assets/postprocessing_workflow/config.yaml
@@ -29,18 +29,8 @@ process:
       - configs/config.yaml
       - model_output/SIR_plot_hires.png
 parameter:
-  beta:
-    module: fixed
-    value: 0.3
-  gamma:
-    module: fixed
-    value: 0.1
-  s0:
-    module: fixed
-    value: 999
-  i0:
-    module: fixed
-    value: 1
-  r0:
-    module: fixed
-    value: 0
+  beta: 0.3
+  gamma: 0.1
+  s0: 999
+  i0: 1
+  r0: 0

--- a/docs/assets/quickstart_workflow/config.yaml
+++ b/docs/assets/quickstart_workflow/config.yaml
@@ -8,31 +8,25 @@ system:
     model_state:
       parameter_names: [s0, i0, r0]
       labels: [S, I, R]
+
 engine:
   - module: wrapper
     state_change: flow
     script: model_input/plugins/solve_ivp.py
+
 backend:
   - module: csv
+
 simulate:
   quick_start:
     system: default
     engine: default
     backend: default
     times: "0.0:0.1:10"
+
 parameter:
-  beta:
-    module: fixed
-    value: 0.3
-  gamma:
-    module: fixed
-    value: 0.1
-  s0:
-    module: fixed
-    value: 999
-  i0:
-    module: fixed
-    value: 1
-  r0:
-    module: fixed
-    value: 0
+  beta: 0.3
+  gamma: 0.1
+  s0: 999
+  i0: 1
+  r0: 0

--- a/src/flepimop2/configuration/_configuration.py
+++ b/src/flepimop2/configuration/_configuration.py
@@ -18,7 +18,7 @@ from typing import Literal, Self
 from pydantic import Field, model_validator
 
 from flepimop2.configuration._axes import AxesGroupModel
-from flepimop2.configuration._module import ModuleGroupModel
+from flepimop2.configuration._module import ModuleGroupModel, ParameterGroupModel
 from flepimop2.configuration._simulate import SimulateSpecificationModel
 from flepimop2.configuration._yaml import YamlSerializableBaseModel
 from flepimop2.typing import IdentifierString
@@ -50,7 +50,7 @@ class ConfigurationModel(
     systems: ModuleGroupModel = Field(default_factory=dict)
     backends: ModuleGroupModel = Field(default_factory=dict)
     process: ModuleGroupModel = Field(default_factory=dict)
-    parameters: ModuleGroupModel = Field(default_factory=dict)
+    parameters: ParameterGroupModel = Field(default_factory=dict)
     scenarios: ModuleGroupModel = Field(default_factory=dict)
     simulate: dict[IdentifierString, SimulateSpecificationModel] = Field(
         default_factory=dict

--- a/src/flepimop2/configuration/_module.py
+++ b/src/flepimop2/configuration/_module.py
@@ -68,3 +68,46 @@ ModuleGroupModel = Annotated[
     dict[IdentifierString, ModuleConfigurationValue], BeforeValidator(_to_default_dict)
 ]
 """Module group configuration model for flepimop2."""
+
+
+def _coerce_parameter_configuration_value(value: Any) -> Any:  # noqa: ANN401
+    """
+    Rewrite bare numeric parameter config values to fixed-parameter shorthand.
+
+    Args:
+        value: The raw parameter configuration value.
+
+    Returns:
+        The original value, or a `fixed(...)` shorthand string for numeric inputs.
+
+    Examples:
+        >>> _coerce_parameter_configuration_value(0.3)
+        'fixed(0.3)'
+        >>> _coerce_parameter_configuration_value(2)
+        'fixed(2)'
+        >>> _coerce_parameter_configuration_value("fixed(0.3)")
+        'fixed(0.3)'
+        >>> _coerce_parameter_configuration_value("some-other-string")
+        'some-other-string'
+        >>> _coerce_parameter_configuration_value(True)
+        True
+        >>> _coerce_parameter_configuration_value(None) is None
+        True
+    """
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return f"fixed({value!r})"
+    return value
+
+
+ParameterConfigurationValue: TypeAlias = Annotated[
+    ModuleConfigurationValue,
+    BeforeValidator(_coerce_parameter_configuration_value),
+]
+"""A parameter value, including bare numeric shorthand for fixed parameters."""
+
+
+ParameterGroupModel = Annotated[
+    dict[IdentifierString, ParameterConfigurationValue],
+    BeforeValidator(_to_default_dict),
+]
+"""Parameter group configuration model for flepimop2."""

--- a/tests/configuration/test_configuration_model_class.py
+++ b/tests/configuration/test_configuration_model_class.py
@@ -1,0 +1,51 @@
+# flepimop2: The FLExible Pipeline for Interchangeable MOdel Processing
+# Copyright (C) 2026  Carl Pearson, Joshua Macdonald, Timothy Willard
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Tests for the `ConfigurationModel` class."""
+
+from pathlib import Path
+
+import pytest
+
+from flepimop2.configuration import ConfigurationModel
+from flepimop2.parameter.abc import build as build_parameter
+
+
+@pytest.mark.parametrize(
+    ("key", "value", "expected"),
+    [("parameter", 0.3, "fixed(0.3)"), ("parameters", 2, "fixed(2)")],
+)
+def test_configuration_model_rewrites_numeric_parameter_values(
+    key: str, value: float, expected: str
+) -> None:
+    """Bare numeric parameter values should become fixed-parameter shorthand."""
+    configuration = ConfigurationModel.model_validate({key: {"beta": value}})
+
+    assert configuration.parameters["beta"] == expected
+    assert build_parameter(
+        configuration.parameters["beta"]
+    ).sample().item() == pytest.approx(value)
+
+
+def test_configuration_model_from_yaml_accepts_numeric_parameter_values(
+    tmp_path: Path,
+) -> None:
+    """YAML config files should accept singular `parameter` with bare numerics."""
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("parameter:\n  beta: 0.3\n", encoding="utf-8")
+
+    configuration = ConfigurationModel.from_yaml(config_path)
+
+    assert configuration.parameters["beta"] == "fixed(0.3)"


### PR DESCRIPTION
## Description

Restored the direct specification of scalars for fixed parameters that
was removed in #93. This is accomplished by rewriting int/float values
in the parameter section of the configuration to the string shorthand,
'fixed(...)'. Also updated the documentation configuration files to use
this syntax for conciseness.

## Related issues

Closes #100.

This PR is stacked on #253, to review it might be more helpful to just look at the second commit. As a result of being stacked, it is blocked by #253.

## Checklist

- [x] I have read through and understand the [pull request process](https://github.com/ACCIDDA/flepimop2?tab=contributing-ov-file#pull-request-process).
- [x] I ran successfully ran CI local via `just ci`.
- [x] I have updated the `CHANGELOG.md` or noted "no major changes" in my commit if the PR is small.
