### PR TITLE
Correct GitHub pages documentation aliases

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -80,7 +80,7 @@ jobs:
       - name: 'deploy to github pages'
         run: |
           uv run mike set-default latest
-          if [ "${DEPLOY_MODE}" = "release" ] || [[ $VERSION == 0* ]]; then
+          if [ "${DEPLOY_MODE}" = "release" ]; then
             ALIAS=latest
           else
             ALIAS=dev

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -74,6 +74,7 @@ nav:
       - Installation: guides/install.md
       - Getting Started: guides/getting-started.md
       - Vaccination Campaign Scenario Grid: guides/vaccination-campaign-scenario-grid-example.md
+      - Generating Scenario Results: guides/scenarios.md
   - Development:
       - Contributing: development/contributing.md
       - Creating An External Provider Package: development/creating-an-external-provider-package.md


### PR DESCRIPTION
## Description

Updated the `gh-pages.yaml` workflow to point the version of `flepimop2` in the repository to the "dev" alias and to point the latest released version on PyPI to the "latest" alias. No major changes.

## Related issues

n/a

## Checklist

- [x] I have read through and understand the [pull request process](https://github.com/ACCIDDA/flepimop2?tab=contributing-ov-file#pull-request-process).
- [x] I ran successfully ran CI local via `just ci`.
- [x] I have updated the `CHANGELOG.md` or noted "no major changes" in my commit if the PR is small.
