### PR TITLE
Fix `flepimop2 --version` bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Restored `parameter: value` syntax (i.e. `pi: 3.14`) for specifying scalar parameters directly as floats/ints in the configuration file. See [#100](https://github.com/ACCIDDA/flepimop2/issues/100).
+- Fixed bug where `flepimop2 --version` would show 0.1.0, now corrected to show the version from `flepimop2` installed. See [#266](https://github.com/ACCIDDA/flepimop2/issues/266).
 
 ### Security
 

--- a/src/flepimop2/_cli/_cli.py
+++ b/src/flepimop2/_cli/_cli.py
@@ -16,6 +16,9 @@
 __all__ = []
 
 
+from importlib.metadata import version
+from typing import Final
+
 import click
 
 from flepimop2._cli._build_command import BuildCommand
@@ -24,10 +27,12 @@ from flepimop2._cli._register_command import register_command
 from flepimop2._cli._simulate_command import SimulateCommand
 from flepimop2._cli._skeleton_command import SkeletonCommand
 
+_FLEPIMOP2_VERSION: Final[str] = version("flepimop2")
+
 
 @click.group()
 @click.version_option(
-    version="0.1.0",
+    version=_FLEPIMOP2_VERSION,
     message="%(prog)s %(version)s\nLicense: GNU GPL v3 <https://www.gnu.org/licenses/>",
 )
 def cli() -> None:


### PR DESCRIPTION
## Description

Fix `flepimop2 --version` bug

## Related issues

Closes #266.

## Checklist

- [x] I have read through and understand the [pull request process](https://github.com/ACCIDDA/flepimop2?tab=contributing-ov-file#pull-request-process).
- [x] I ran successfully ran CI local via `just ci`.
- [x] I have updated the `CHANGELOG.md` or noted "no major changes" in my commit if the PR is small.
