### PR TITLE
Add `ConfigurationModel/ModuleBase.patch`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added ways to specify shape for parameters based on `axes` by changing `ParameterABC.sample` to return a `ParameterValue` that contains both the underlying value as a numpy array as well as shape metadata, and is easily extensible to other metadata and underlying value types in the future. Also added `ModelStateSpecification`, `ParameterRequest` types for systems to advertise their underlying state and request parameters to comply with said state specification. See [#115](https://github.com/ACCIDDA/flepimop2/issues/115), [#133](https://github.com/ACCIDDA/flepimop2/issues/133).
 - Added help text for CLI arguments that are formatted similarly to click's default formatting for options.
 - Added optional shorthand module configuration support across all module namespaces, allowing config values such as `fixed(0.3)` for modules that implement `from_shorthand`. See [#14](https://github.com/ACCIDDA/flepimop2/issues/14).
+- Added `ConfigurationModel/ModuleBase.patch` method to merge configurations together. See [#51](https://github.com/ACCIDDA/flepimop2/issues/51).
 
 ### Changed
 

--- a/src/flepimop2/_utils/_dict.py
+++ b/src/flepimop2/_utils/_dict.py
@@ -1,0 +1,63 @@
+# flepimop2: The FLExible Pipeline for Interchangeable MOdel Processing
+# Copyright (C) 2026  Carl Pearson, Joshua Macdonald, Timothy Willard
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Private dictionary helpers."""
+
+from copy import deepcopy
+from typing import Any
+
+
+def _deep_merge_dicts(current: dict[str, Any], patch: dict[str, Any]) -> dict[str, Any]:
+    """
+    Deep-merge two dictionaries, preferring values from `patch`.
+
+    Only nested dictionaries are merged recursively. Lists and scalars are
+    replaced wholesale by the incoming patch value.
+
+    Args:
+        current: The current dictionary.
+        patch: The incoming patch dictionary.
+
+    Returns:
+        A merged dictionary.
+
+    Examples:
+        >>> _deep_merge_dicts({"alpha": 1}, {"beta": 2})
+        {'alpha': 1, 'beta': 2}
+        >>> _deep_merge_dicts(
+        ...     {"outer": {"left": 1, "shared": {"x": 1, "z": True}}},
+        ...     {"outer": {"right": 2, "shared": {"y": 2, "z": False}}},
+        ... )
+        {'outer': {'left': 1, 'shared': {'x': 1, 'z': False, 'y': 2}, 'right': 2}}
+        >>> _deep_merge_dicts({"values": [1, 2, 3]}, {"values": [4, 5]})
+        {'values': [4, 5]}
+        >>> current = {"outer": {"left": 1}}
+        >>> merged = _deep_merge_dicts(current, {"outer": {"right": 2}})
+        >>> current
+        {'outer': {'left': 1}}
+        >>> merged
+        {'outer': {'left': 1, 'right': 2}}
+    """
+    merged = deepcopy(current)
+    for key, patch_value in patch.items():
+        if (
+            key in merged
+            and isinstance(merged[key], dict)
+            and isinstance(patch_value, dict)
+        ):
+            merged[key] = _deep_merge_dicts(merged[key], patch_value)
+        else:
+            merged[key] = deepcopy(patch_value)
+    return merged

--- a/src/flepimop2/configuration/_configuration.py
+++ b/src/flepimop2/configuration/_configuration.py
@@ -13,15 +13,19 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+from collections.abc import Mapping
+from copy import deepcopy
 from typing import Literal, Self
 
-from pydantic import Field, model_validator
+from pydantic import BaseModel, Field, model_validator
 
+from flepimop2._utils._dict import _deep_merge_dicts
 from flepimop2.configuration._axes import AxesGroupModel
 from flepimop2.configuration._module import ModuleGroupModel, ParameterGroupModel
 from flepimop2.configuration._simulate import SimulateSpecificationModel
 from flepimop2.configuration._yaml import YamlSerializableBaseModel
-from flepimop2.typing import IdentifierString
+from flepimop2.module import ModuleBase
+from flepimop2.typing import IdentifierString, PatchConflictMode
 
 
 class ConfigurationModel(
@@ -55,6 +59,216 @@ class ConfigurationModel(
     simulate: dict[IdentifierString, SimulateSpecificationModel] = Field(
         default_factory=dict
     )
+
+    @staticmethod
+    def _copy_patch_value(value: object) -> object:
+        """
+        Create a deep copy suitable for a patched configuration value.
+
+        Args:
+            value: The value to copy.
+
+        Returns:
+            A deep copy of `value`.
+        """
+        if isinstance(value, BaseModel):
+            return value.model_copy(deep=True)
+        return deepcopy(value)
+
+    @staticmethod
+    def _collect_patch_conflicts(
+        current: Mapping[IdentifierString, object],
+        patch: Mapping[IdentifierString, object],
+    ) -> list[IdentifierString]:
+        """
+        Collect duplicate keys shared by two configuration sections.
+
+        Args:
+            current: The current section contents.
+            patch: The incoming section patch.
+
+        Returns:
+            The sorted list of conflicting keys.
+        """
+        return sorted(set(current) & set(patch))
+
+    @staticmethod
+    def _patch_section(
+        current: Mapping[IdentifierString, object],
+        patch: Mapping[IdentifierString, object],
+        *,
+        conflict: PatchConflictMode,
+    ) -> dict[IdentifierString, object]:
+        """
+        Patch one top-level dictionary section of the configuration.
+
+        Args:
+            current: The current section contents.
+            patch: The incoming section patch.
+            conflict: How to handle duplicate entry names.
+
+        Returns:
+            The patched section contents.
+
+        Raises:
+            AssertionError: If overlapping entries reach this method under
+                `conflict="error"`.
+        """
+        patched = {
+            key: ConfigurationModel._copy_patch_value(value)
+            for key, value in current.items()
+        }
+        for key, patch_value in patch.items():
+            if key not in patched:
+                patched[key] = ConfigurationModel._copy_patch_value(patch_value)
+                continue
+            if conflict is PatchConflictMode.REPLACE:
+                if isinstance(current_value := patched[key], ModuleBase) and isinstance(
+                    patch_value, ModuleBase
+                ):
+                    patched[key] = current_value.patch(
+                        patch_value,
+                        conflict=conflict,
+                    )
+                else:
+                    patched[key] = ConfigurationModel._copy_patch_value(patch_value)
+                continue
+            if conflict is PatchConflictMode.ERROR:
+                msg = (
+                    "ConfigurationModel.patch should reject duplicate keys before "
+                    "_patch_section processes overlapping entries."
+                )
+                raise AssertionError(msg)
+            current_value = patched[key]
+            if isinstance(current_value, ModuleBase) and isinstance(
+                patch_value, ModuleBase
+            ):
+                patched[key] = current_value.patch(
+                    patch_value,
+                    conflict=PatchConflictMode.MERGE,
+                )
+            elif isinstance(current_value, BaseModel) and isinstance(
+                patch_value, BaseModel
+            ):
+                if type(current_value) is not type(patch_value):
+                    patched[key] = ConfigurationModel._copy_patch_value(patch_value)
+                else:
+                    patched[key] = type(current_value).model_validate(
+                        _deep_merge_dicts(
+                            current_value.model_dump(),
+                            patch_value.model_dump(),
+                        )
+                    )
+            else:
+                patched[key] = ConfigurationModel._copy_patch_value(patch_value)
+        return patched
+
+    def patch(
+        self,
+        other: Self,
+        *,
+        conflict: PatchConflictMode = PatchConflictMode.ERROR,
+    ) -> Self:
+        """
+        Patch this configuration with another configuration.
+
+        This method treats `other` as the incoming patch. Top-level sections are
+        merged entry-by-entry; when both entries are `ModuleBase` instances their
+        `patch()` implementations are used.
+
+        Args:
+            other: The patch to apply to this configuration.
+            conflict: How to handle duplicate top-level entry names.
+
+        Returns:
+            The patched configuration.
+
+        Raises:
+            ValueError: If there are sub-top level key conflicts and `conflict` is
+                `PatchConflictMode.ERROR`.
+        """
+        section_conflicts = {
+            section_name: self._collect_patch_conflicts(
+                getattr(self, section_name),
+                getattr(other, section_name),
+            )
+            for section_name in (
+                "axes",
+                "engines",
+                "systems",
+                "backends",
+                "process",
+                "parameters",
+                "scenarios",
+                "simulate",
+            )
+        }
+        section_conflicts = {
+            section_name: conflicts
+            for section_name, conflicts in section_conflicts.items()
+            if conflicts
+        }
+        if conflict is PatchConflictMode.ERROR and section_conflicts:
+            details = "; ".join(
+                f"{section_name}={conflicts!r}"
+                for section_name, conflicts in section_conflicts.items()
+            )
+            msg = (
+                "Cannot patch configuration under conflict='error'; duplicate "
+                f"section keys: {details}."
+            )
+            raise ValueError(msg)
+
+        sections = {
+            "axes": self._patch_section(
+                self.axes,
+                other.axes,
+                conflict=conflict,
+            ),
+            "engines": self._patch_section(
+                self.engines,
+                other.engines,
+                conflict=conflict,
+            ),
+            "systems": self._patch_section(
+                self.systems,
+                other.systems,
+                conflict=conflict,
+            ),
+            "backends": self._patch_section(
+                self.backends,
+                other.backends,
+                conflict=conflict,
+            ),
+            "process": self._patch_section(
+                self.process,
+                other.process,
+                conflict=conflict,
+            ),
+            "parameters": self._patch_section(
+                self.parameters,
+                other.parameters,
+                conflict=conflict,
+            ),
+            "scenarios": self._patch_section(
+                self.scenarios,
+                other.scenarios,
+                conflict=conflict,
+            ),
+            "simulate": self._patch_section(
+                self.simulate,
+                other.simulate,
+                conflict=conflict,
+            ),
+        }
+
+        name_payload: dict[str, str | None] = {}
+        if "name" in other.model_fields_set:
+            name_payload["name"] = other.name
+        elif "name" in self.model_fields_set:
+            name_payload["name"] = self.name
+
+        return type(self).model_validate({**name_payload, **sections})
 
     def _check_simulate_engines_or_systems(
         self, kind: Literal["engine", "system", "backend"]

--- a/src/flepimop2/module.py
+++ b/src/flepimop2/module.py
@@ -22,7 +22,8 @@ from typing import Any, ClassVar, Literal, Self, cast
 
 from pydantic import BaseModel, ConfigDict, Field
 
-from flepimop2.typing import RaiseOnMissing, RaiseOnMissingType
+from flepimop2._utils._dict import _deep_merge_dicts
+from flepimop2.typing import PatchConflictMode, RaiseOnMissing, RaiseOnMissingType
 
 
 class ModuleBase(BaseModel):
@@ -282,3 +283,43 @@ class ModuleBase(BaseModel):
             msg = f"Option '{name}' not found in module '{self.module}'."
             raise KeyError(msg)
         return opts.get(name, default)
+
+    def patch(
+        self,
+        other: Self,
+        *,
+        conflict: Literal[PatchConflictMode.MERGE, PatchConflictMode.REPLACE],
+    ) -> Self:
+        """
+        Patch this module configuration with another module configuration.
+
+        This method treats `other` as the incoming patch. The default
+        implementation is intentionally simple: replace wholesale for `replace`,
+        and deep-merge dumped model dictionaries for `merge`.
+
+        Module developers can override this method to implement more complex patching
+        logic if needed (e.g. merging certain subsections or sets of fields while
+        replacing others). However, they should still try to respect the semantics of
+        the `conflict` argument as much as possible to avoid surprising users.
+
+        Args:
+            other: The patch to apply to this module.
+            conflict: How to handle overlapping fields.
+
+        Returns:
+            The patched module configuration.
+
+        Raises:
+            TypeError: If `self` and `other` are different concrete model types.
+        """
+        if type(self) is not type(other):
+            msg = (
+                f"Cannot patch {type(self).__name__} with {type(other).__name__}; "
+                "module patching requires matching concrete types."
+            )
+            raise TypeError(msg)
+        if conflict is PatchConflictMode.REPLACE:
+            return other.model_copy(deep=True)
+        return type(self).model_validate(
+            _deep_merge_dicts(self.model_dump(), other.model_dump())
+        )

--- a/src/flepimop2/typing.py
+++ b/src/flepimop2/typing.py
@@ -33,6 +33,7 @@ __all__ = [
     "ExitCode",
     "Float64NDArray",
     "IdentifierString",
+    "PatchConflictMode",
     "RaiseOnMissing",
     "RaiseOnMissingType",
     "StateChangeEnum",
@@ -50,6 +51,7 @@ from typing import (
     Literal,
     ParamSpec,
     Protocol,
+    Self,
     cast,
     runtime_checkable,
 )
@@ -195,6 +197,48 @@ class RaiseOnMissingType:
 
 RaiseOnMissing: Final[RaiseOnMissingType] = RaiseOnMissingType()
 """Sentinel value indicating an error should be raised if a value is missing."""
+
+
+class PatchConflictMode(StrEnum):
+    """
+    Strategies for handling overlapping configuration keys during patching.
+
+    Examples:
+        >>> from flepimop2.typing import PatchConflictMode
+        >>> PatchConflictMode.from_string("merge")
+        <PatchConflictMode.MERGE: 'merge'>
+        >>> PatchConflictMode.from_string("replace")
+        <PatchConflictMode.REPLACE: 'replace'>
+        >>> PatchConflictMode.from_string("override")
+        Traceback (most recent call last):
+            ...
+        ValueError: Unknown patch conflict mode 'override'; expected one of: error, merge, replace.
+    """  # noqa: E501
+
+    ERROR = "error"
+    MERGE = "merge"
+    REPLACE = "replace"
+
+    @classmethod
+    def from_string(cls, value: str) -> Self:
+        """
+        Parse a patch conflict mode from its string form.
+
+        Args:
+            value: The conflict mode string.
+
+        Returns:
+            The parsed `PatchConflictMode`.
+
+        Raises:
+            ValueError: If `value` is not a valid patch conflict mode.
+        """
+        try:
+            return cls(value)
+        except ValueError as exc:
+            modes = ", ".join(sorted(mode.value for mode in cls))
+            msg = f"Unknown patch conflict mode {value!r}; expected one of: {modes}."
+            raise ValueError(msg) from exc
 
 
 class StateChangeEnum(StrEnum):

--- a/tests/configuration/configuration_model_class/test_parameter_configuration.py
+++ b/tests/configuration/configuration_model_class/test_parameter_configuration.py
@@ -13,7 +13,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
-"""Tests for the `ConfigurationModel` class."""
+"""Tests for parameter-oriented `ConfigurationModel` behavior."""
 
 from pathlib import Path
 

--- a/tests/configuration/configuration_model_class/test_patch.py
+++ b/tests/configuration/configuration_model_class/test_patch.py
@@ -1,0 +1,180 @@
+# flepimop2: The FLExible Pipeline for Interchangeable MOdel Processing
+# Copyright (C) 2026  Carl Pearson, Joshua Macdonald, Timothy Willard
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Tests for `ConfigurationModel.patch`."""
+
+import math
+
+import pytest
+
+from flepimop2.configuration import ConfigurationModel
+from flepimop2.typing import PatchConflictMode
+
+
+def test_configuration_model_patch_merge_delegates_to_module_patch() -> None:
+    """Merging configurations should patch overlapping module entries."""
+    configuration = ConfigurationModel.model_validate({
+        "parameters": {
+            "foo": {
+                "module": "fixed",
+                "value": [1, 2, 3],
+                "shape": "age",
+            },
+            "bar": {
+                "module": "fixed",
+                "value": 0.5,
+            },
+        }
+    })
+    patch = ConfigurationModel.model_validate({
+        "parameters": {
+            "foo": {
+                "module": "fixed",
+                "value": [4, 5, 6],
+            },
+            "baz": {
+                "module": "fixed",
+                "value": 0.7,
+            },
+        }
+    })
+
+    patched = configuration.patch(patch, conflict=PatchConflictMode.MERGE)
+    assert patched.model_dump(exclude_none=True).get("parameters", {}) == {
+        "foo": {
+            "module": "fixed",
+            "value": [4, 5, 6],
+            "shape": "age",
+        },
+        "bar": {
+            "module": "fixed",
+            "value": 0.5,
+        },
+        "baz": {
+            "module": "fixed",
+            "value": 0.7,
+        },
+    }
+
+
+def test_configuration_model_patch_replace_replaces_duplicate_entries() -> None:
+    """Replace mode should overwrite duplicate section keys with patch values."""
+    configuration = ConfigurationModel.model_validate({
+        "parameters": {"pi": math.pi, "r0": 0.1}
+    })
+    patch = ConfigurationModel.model_validate({"parameters": {"gamma": 0.2, "r0": 0.3}})
+
+    patched = configuration.patch(patch, conflict=PatchConflictMode.REPLACE)
+
+    assert patched.parameters == {
+        "pi": f"fixed({math.pi!r})",
+        "gamma": "fixed(0.2)",
+        "r0": "fixed(0.3)",
+    }
+
+
+def test_configuration_model_patch_merge_merges_simulate_models() -> None:
+    """Non-module top-level models should use the default base-model merge."""
+    configuration = ConfigurationModel.model_validate({
+        "engines": {"default": {"module": "demo.engine"}},
+        "systems": {"default": {"module": "demo.system"}},
+        "backends": {"default": {"module": "demo.backend"}},
+        "simulate": {
+            "main": {
+                "times": [0.0, 1.0],
+                "params": {"alpha": 1.0},
+            }
+        },
+    })
+    patch = ConfigurationModel.model_validate({
+        "engines": {"default": {"module": "demo.engine"}},
+        "systems": {"default": {"module": "demo.system"}},
+        "backends": {"default": {"module": "demo.backend"}},
+        "simulate": {
+            "main": {
+                "times": [0.0, 2.0],
+                "params": {"beta": 2.0},
+            }
+        },
+    })
+
+    patched = configuration.patch(patch, conflict=PatchConflictMode.MERGE)
+
+    simulate = patched.simulate["main"]
+    assert simulate.engine == "default"
+    assert simulate.params == {"alpha": 1.0, "beta": 2.0}
+
+
+def test_configuration_model_patch_error_collects_all_duplicate_entries() -> None:
+    """Error mode should report all duplicate section keys in one failure."""
+    configuration = ConfigurationModel.model_validate({
+        "process": {"main": {"module": "flepimop2.process.shell"}},
+        "parameters": {"pi": math.pi, "r0": 0.1},
+    })
+    patch = ConfigurationModel.model_validate({
+        "process": {"main": {"module": "flepimop2.process.shell"}},
+        "parameters": {"gamma": 0.2, "pi": 3.0, "r0": 0.3},
+    })
+
+    with pytest.raises(
+        ValueError,
+        match="Cannot patch configuration under conflict='error'",
+    ) as excinfo:
+        configuration.patch(patch, conflict=PatchConflictMode.ERROR)
+
+    message = str(excinfo.value)
+    assert "process=['main']" in message
+    assert "parameters=['pi', 'r0']" in message
+
+
+def test_configuration_model_patch_name_prefers_other_when_both_are_set() -> None:
+    """When both names are set, the patch name should win."""
+    configuration = ConfigurationModel.model_validate({"name": "base"})
+    patch = ConfigurationModel.model_validate({"name": "override"})
+
+    patched = configuration.patch(patch, conflict=PatchConflictMode.MERGE)
+
+    assert patched.name == "override"
+
+
+def test_configuration_model_patch_name_uses_only_set_name() -> None:
+    """When only one name is set, the patched config should keep that name."""
+    configuration = ConfigurationModel.model_validate({"name": "base"})
+    patch = ConfigurationModel.model_validate({})
+
+    patched = configuration.patch(patch, conflict=PatchConflictMode.MERGE)
+
+    assert patched.name == "base"
+
+
+def test_configuration_model_patch_name_uses_patch_name_when_only_it_is_set() -> None:
+    """When only the patch sets a name, the patched config should use it."""
+    configuration = ConfigurationModel.model_validate({})
+    patch = ConfigurationModel.model_validate({"name": "override"})
+
+    patched = configuration.patch(patch, conflict=PatchConflictMode.MERGE)
+
+    assert patched.name == "override"
+
+
+def test_configuration_model_patch_omits_name_when_neither_is_set() -> None:
+    """When neither config sets a name, the patched config should omit it too."""
+    configuration = ConfigurationModel.model_validate({})
+    patch = ConfigurationModel.model_validate({})
+
+    patched = configuration.patch(patch, conflict=PatchConflictMode.MERGE)
+
+    assert patched.name is None
+    assert "name" not in patched.model_fields_set

--- a/tests/module/test_module_abc_class.py
+++ b/tests/module/test_module_abc_class.py
@@ -24,7 +24,7 @@ from pydantic import ValidationError
 from flepimop2.backend.abc import BackendABC
 from flepimop2.module import ModuleBase
 from flepimop2.process.abc import ProcessABC
-from flepimop2.typing import Float64NDArray
+from flepimop2.typing import Float64NDArray, PatchConflictMode
 
 
 def test_missing_module_attribute_raises() -> None:
@@ -185,6 +185,58 @@ def test_option_uses_default_when_missing() -> None:
     mod = MyModule()
     assert mod.options is None
     assert mod.option("missing", default=0) == 0
+
+
+def test_module_patch_replace_returns_other() -> None:
+    """Replace mode should return the incoming patch model."""
+    mod = ModuleBase.model_validate({
+        "module": "fixed",
+        "value": [1, 2, 3],
+        "shape": "age",
+    })
+    patch = ModuleBase.model_validate({"module": "fixed", "value": [4, 5, 6]})
+
+    replaced = mod.patch(patch, conflict=PatchConflictMode.REPLACE)
+
+    assert replaced is not patch
+    assert replaced.model_dump(exclude_none=True) == {
+        "module": "fixed",
+        "value": [4, 5, 6],
+    }
+
+
+def test_module_patch_merge_deep_merges_model_dumps() -> None:
+    """Merge mode should deep-merge the dumped model dictionaries."""
+    mod = ModuleBase.model_validate({
+        "module": "fixed",
+        "value": [1, 2, 3],
+        "shape": "age",
+    })
+    patch = ModuleBase.model_validate({"module": "fixed", "value": [4, 5, 6]})
+
+    merged = mod.patch(patch, conflict=PatchConflictMode.MERGE)
+
+    assert merged.model_dump(exclude_none=True) == {
+        "module": "fixed",
+        "value": [4, 5, 6],
+        "shape": "age",
+    }
+
+
+def test_module_patch_raises_type_error_for_mismatched_model_types() -> None:
+    """Default module patching should reject different concrete model types."""
+
+    class FirstModule(ModuleBase, module="flepimop2.test.first"):
+        pass
+
+    class SecondModule(ModuleBase, module="flepimop2.test.second"):
+        pass
+
+    mod: ModuleBase = FirstModule()
+    patch = SecondModule()
+
+    with pytest.raises(TypeError, match="requires matching concrete types"):
+        mod.patch(patch, conflict=PatchConflictMode.MERGE)
 
 
 def test_explicit_module_definition_still_works() -> None:


### PR DESCRIPTION
## Description

Added methods for merging configurations together. `ConfigurationModel.patch` orchestrates the merging and delegates to `ModuleBase.patch` for specific modules. The model specific implementation is intentionally thin with a note for module developers about overriding the module for their specific implementation.

## Related issues

Closes #51.

## Checklist

- [x] I have read through and understand the [pull request process](https://github.com/ACCIDDA/flepimop2?tab=contributing-ov-file#pull-request-process).
- [x] I ran successfully ran CI local via `just ci`.
- [x] I have updated the `CHANGELOG.md` or noted "no major changes" in my commit if the PR is small.
