### PR TITLE
Bind CLI arguments to `CliCommand` instance

### DIFF
--- a/src/flepimop2/_cli/_cli_command.py
+++ b/src/flepimop2/_cli/_cli_command.py
@@ -26,6 +26,8 @@ from pathlib import Path
 from typing import Any
 
 from flepimop2._cli._logging import get_script_logger
+from flepimop2._cli._options import COMMON_OPTIONS
+from flepimop2._utils._click import _click_param_for_option, _render_param
 from flepimop2.typing import ExitCode
 
 _COMMAND_NAME_REGEX = re.compile(r"(?<!^)(?=[A-Z])")
@@ -42,22 +44,28 @@ class CliCommand(ABC):
 
     auto_append_verbosity: bool = True
     logger: logging.Logger | None = None
+    bound_kwargs: dict[str, Any]
 
-    def __call__(self, **kwargs: Any) -> None:
+    def __init__(self, **kwargs: Any) -> None:
         """
-        Make the command instance callable.
-
-        This method allows instances of `CliCommand` subclasses to be called
-        directly, forwarding all keyword arguments to the `run` method.
-
-        The 'verbosity' option is consumed here for logger setup. If 'verbosity'
-        was auto-appended (not in _literal_options), it's removed from kwargs
-        before passing to run(). The return value from run() is passed to
-        `sys.exit()`.
+        Bind CLI kwargs to this command instance.
 
         Args:
-            **kwargs: Command-specific arguments passed from Click options/arguments.
+            **kwargs: Keyword arguments corresponding to the options declared
+                by this command's `options()` classmethod.
         """
+        self.bound_kwargs = dict(kwargs)
+
+    def __call__(self) -> None:
+        """
+        Execute this command using the kwargs bound at construction time.
+
+        Consumes 'verbosity' for logger setup. If 'verbosity' was
+        auto-appended (not in `_literal_options`), it is removed from the
+        kwargs passed to `run()`. The return value from `run()` is forwarded
+        to `sys.exit()`.
+        """
+        kwargs = dict(self.bound_kwargs)
         verbosity = kwargs.pop("verbosity", 0)
         self.logger = get_script_logger(__name__, verbosity)
         longest_key = max((len(str(k)) for k in kwargs), default=0)
@@ -150,6 +158,36 @@ class CliCommand(ABC):
         return _COMMAND_NAME_REGEX.sub(
             "-", cls.__name__.removesuffix("Command")
         ).lower()
+
+    def to_argv(self) -> list[str]:
+        """Render this instance's bound kwargs back into argv tokens.
+
+        Walks `cls.options()` in declaration order and converts each bound
+        value to its CLI representation:
+
+        - `click.Argument`: bare positional string (skipped if `None`).
+        - `click.Option` with `is_flag=True`: long flag name when truthy, omitted when
+            falsy.
+        - `click.Option` with `count=True`: repeated short flag
+            (e.g. `-vvv` for `verbosity=3`).
+        - `click.Option` otherwise: `--name value` pair.
+
+        `Path` values are rendered as their absolute string form so the
+        resulting argv replays correctly on a remote with a shared filesystem.
+
+        Returns:
+            A list of string tokens suitable for passing to `subprocess`.
+        """
+        tokens: list[str] = []
+        for name in type(self).options():
+            entry = COMMON_OPTIONS.get(name)
+            if entry is None:
+                continue
+            param = _click_param_for_option(entry[0])
+            if param is None:
+                continue
+            tokens.extend(_render_param(param, self.bound_kwargs.get(name)))
+        return tokens
 
     @classmethod
     def help_text(cls) -> str:

--- a/src/flepimop2/_cli/_register_command.py
+++ b/src/flepimop2/_cli/_register_command.py
@@ -54,8 +54,8 @@ def register_command(command_cls: type[CliCommand], group: Group) -> None:
 
     # Create a wrapper function that instantiates and runs the command
     def command_wrapper(**kwargs: Any) -> None:
-        command_instance = command_cls()
-        command_instance(**kwargs)
+        command_instance = command_cls(**kwargs)
+        command_instance()
 
     # Set the function name and docstring for Click
     command_name = command_cls.command_name()

--- a/src/flepimop2/_utils/_click.py
+++ b/src/flepimop2/_utils/_click.py
@@ -13,9 +13,16 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
-from typing import TypeVar
+from pathlib import Path
+from typing import TYPE_CHECKING, TypeVar
 
+from click import Argument as ClickArgument
 from click import BadOptionUsage, UsageError
+from click import Option as ClickOption
+from click import Parameter as ClickParameter
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 T = TypeVar("T")
 U = TypeVar("U")
@@ -62,3 +69,136 @@ def _get_config_target(group: dict[str, T], name: str | None, group_name: str) -
         msg = f"Target '{name}' not available from {group.keys()} for '{group_name}'."
         raise BadOptionUsage(option_name="target", message=msg)
     return res
+
+
+def _click_param_for_option(
+    decorator: "Callable[..., object]",
+) -> ClickParameter | None:
+    """Extract the Click parameter object produced by a `COMMON_OPTIONS` decorator.
+
+    Applies the decorator to a dummy function and returns the last parameter
+    it attached.  This is the mechanism `to_argv` uses to inspect whether a
+    COMMON_OPTIONS entry is an argument, a flag, a count option, etc.
+
+    Args:
+        decorator: A Click decorator (e.g. `click.option(...)` or
+            `click.argument(...)`).
+
+    Returns:
+        The `ClickParameter` instance attached by the decorator, or `None`
+        if the decorator produced none.
+
+    Examples:
+        >>> import click
+        >>> from flepimop2._utils._click import _click_param_for_option
+        >>> opt_decorator = click.option("--dry-run", is_flag=True, default=False)
+        >>> param = _click_param_for_option(opt_decorator)
+        >>> isinstance(param, click.Option)
+        True
+        >>> param.name
+        'dry_run'
+        >>> _click_param_for_option(lambda f: f) is None
+        True
+    """
+    dummy: object = lambda: None  # noqa: E731
+    decorated = decorator(dummy)
+    params: list[ClickParameter] = getattr(decorated, "__click_params__", [])
+    return params[-1] if params else None
+
+
+def _str_value(value: object) -> str:
+    """Render a single option value as a string, resolving `Path` objects.
+
+    `Path` values are resolved to their absolute form so that the resulting
+    token replays correctly when the argv is re-executed on a remote with a
+    shared filesystem.
+
+    Args:
+        value: Any bound option value.
+
+    Returns:
+        The string representation of the value, with `Path` objects rendered
+        as their absolute path.
+
+    Examples:
+        >>> from pathlib import Path
+        >>> from flepimop2._utils._click import _str_value
+        >>> _str_value("hello")
+        'hello'
+        >>> _str_value(42)
+        '42'
+        >>> _str_value(Path("/abs/path"))
+        '/abs/path'
+        >>> result = _str_value(Path("relative"))
+        >>> result == str(Path("relative").absolute())
+        True
+    """
+    if isinstance(value, Path):
+        return str(value.absolute())
+    return str(value)
+
+
+def _render_param(param: ClickParameter, value: object) -> list[str]:
+    """Render a single Click parameter and its bound value into argv tokens.
+
+    Converts a `(ClickParameter, value)` pair to the list of string tokens
+    that represent it on the command line:
+
+    - `click.Argument`: bare positional string, or `[]` if `value` is
+      `None`.
+    - `click.Option(is_flag=True)`: the first option string when truthy,
+      `[]` when falsy.
+    - `click.Option(count=True)`: repeated short flag, e.g. `["-vvv"]` for
+      `value=3`, `[]` for `value=0`.
+    - `click.Option` (regular): `["--name", str(value)]`, or `[]` if
+      `value` is `None`.
+
+    Args:
+        param: The Click parameter descriptor.
+        value: The bound value for that parameter.
+
+    Returns:
+        A (possibly empty) list of string tokens.
+
+    Examples:
+        >>> import click
+        >>> from flepimop2._utils._click import _render_param
+        >>> arg = click.Argument(["config"])
+        >>> _render_param(arg, "config.yaml")
+        ['config.yaml']
+        >>> _render_param(arg, None)
+        []
+        >>> flag = click.Option(["--dry-run"], is_flag=True, default=False)
+        >>> _render_param(flag, True)
+        ['--dry-run']
+        >>> _render_param(flag, False)
+        []
+        >>> verbosity = click.Option(["-v", "--verbosity"], count=True, default=0)
+        >>> _render_param(verbosity, 3)
+        ['-vvv']
+        >>> _render_param(verbosity, 0)
+        []
+        >>> target = click.Option(["-t", "--target"], default=None)
+        >>> _render_param(target, "sim1")
+        ['--target', 'sim1']
+        >>> _render_param(target, None)
+        []
+    """
+    if isinstance(param, ClickArgument):
+        return [_str_value(value)] if value is not None else []
+    if not isinstance(param, ClickOption):
+        return []
+    if getattr(param, "is_flag", False):
+        return [param.opts[0]] if value else []
+    if getattr(param, "count", False):
+        count = int(value) if isinstance(value, (int, str)) and value else 0
+        short = next(
+            (o for o in param.opts if o.startswith("-") and not o.startswith("--")),
+            param.opts[0],
+        )
+        return ["-" + short.lstrip("-") * count] if count else []
+    long_opt = next(
+        (o for o in param.opts if o.startswith("--")),
+        param.opts[0],
+    )
+    return [long_opt, _str_value(value)] if value is not None else []

--- a/tests/_cli/cli_command_class/test_call.py
+++ b/tests/_cli/cli_command_class/test_call.py
@@ -13,7 +13,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
-"""Tests for `flepimop2._cli._cli_command`."""
+"""Tests for `CliCommand.__call__`."""
 
 from unittest.mock import Mock
 
@@ -23,30 +23,50 @@ from flepimop2._cli._cli_command import CliCommand
 from flepimop2.typing import ExitCode
 
 
+class _FlagCommand(CliCommand):
+    """Command with a flag option (dry_run) and auto-appended verbosity."""
+
+    def run(self, *, dry_run: bool, verbosity: int) -> ExitCode:  # type: ignore[override]
+        """Execute the command.
+
+        Returns:
+            Exit code.
+        """
+        del dry_run, verbosity
+        return ExitCode.OKAY
+
+
 @pytest.mark.parametrize(
-    "return_exit_code",
+    "exit_code",
     [ExitCode.OKAY, ExitCode.GENERAL, ExitCode.CONFIGURATION],
 )
-def test_run_returns_exit_code(
+def test_exits_with_run_return_value(
     monkeypatch: pytest.MonkeyPatch,
-    return_exit_code: ExitCode,
+    exit_code: ExitCode,
 ) -> None:
-    """Test that run return values are passed through to process exit codes."""
+    """__call__ should forward run()'s return value to sys.exit()."""
 
-    class MockExitCodeCommand(CliCommand):
-        """Mock command that returns a configurable exit code."""
+    class _FixedExitCommand(CliCommand):
+        """Command that returns a configured exit code."""
 
-        def run(self) -> ExitCode:  # type: ignore[override]
+        def run(self, *, verbosity: int) -> ExitCode:  # type: ignore[override]
             """Execute the command.
 
             Returns:
                 The configured exit code.
             """
-            return return_exit_code
+            del verbosity
+            return exit_code
 
     exit_mock = Mock()
     monkeypatch.setattr("flepimop2._cli._cli_command.sys.exit", exit_mock)
+    _FixedExitCommand()()
+    exit_mock.assert_called_once_with(exit_code)
 
-    MockExitCodeCommand()()
 
-    exit_mock.assert_called_once_with(return_exit_code)
+def test_uses_bound_kwargs(monkeypatch: pytest.MonkeyPatch) -> None:
+    """__call__ should run the command using the kwargs bound at construction."""
+    exit_mock = Mock()
+    monkeypatch.setattr("flepimop2._cli._cli_command.sys.exit", exit_mock)
+    _FlagCommand(dry_run=False, verbosity=0)()
+    exit_mock.assert_called_once_with(ExitCode.OKAY)

--- a/tests/_cli/cli_command_class/test_init.py
+++ b/tests/_cli/cli_command_class/test_init.py
@@ -1,0 +1,69 @@
+# flepimop2: The FLExible Pipeline for Interchangeable MOdel Processing
+# Copyright (C) 2026  Carl Pearson, Joshua Macdonald, Timothy Willard
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Tests for `CliCommand.__init__` and `bound_kwargs`."""
+
+from pathlib import Path
+
+from flepimop2._cli._cli_command import CliCommand
+from flepimop2.typing import ExitCode
+
+
+class _FlagCommand(CliCommand):
+    """Command with a flag option (dry_run) and auto-appended verbosity."""
+
+    def run(self, *, dry_run: bool, verbosity: int) -> ExitCode:  # type: ignore[override]
+        """Execute the command.
+
+        Returns:
+            Exit code.
+        """
+        del dry_run, verbosity
+        return ExitCode.OKAY
+
+
+class _ConfigCommand(CliCommand):
+    """Command whose sole option is the config positional argument."""
+
+    auto_append_verbosity = False
+
+    def run(self, *, config: Path) -> ExitCode:  # type: ignore[override]
+        """Execute the command.
+
+        Returns:
+            Exit code.
+        """
+        del config
+        return ExitCode.OKAY
+
+
+def test_stores_bound_kwargs() -> None:
+    """Constructor kwargs must be stored verbatim in bound_kwargs."""
+    cmd = _FlagCommand(dry_run=True, verbosity=2)
+    assert cmd.bound_kwargs == {"dry_run": True, "verbosity": 2}
+
+
+def test_empty_kwargs_stores_empty_dict() -> None:
+    """No kwargs should produce an empty bound_kwargs dict."""
+    cmd = _FlagCommand()
+    assert cmd.bound_kwargs == {}
+
+
+def test_preserves_path_objects() -> None:
+    """Path values must be stored as Path, not converted to strings."""
+    p = Path("/some/config.yaml")
+    cmd = _ConfigCommand(config=p)
+    assert isinstance(cmd.bound_kwargs["config"], Path)
+    assert cmd.bound_kwargs["config"] == p

--- a/tests/_cli/cli_command_class/test_to_argv.py
+++ b/tests/_cli/cli_command_class/test_to_argv.py
@@ -1,0 +1,129 @@
+# flepimop2: The FLExible Pipeline for Interchangeable MOdel Processing
+# Copyright (C) 2026  Carl Pearson, Joshua Macdonald, Timothy Willard
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Tests for `CliCommand.to_argv`."""
+
+from pathlib import Path
+
+from flepimop2._cli._cli_command import CliCommand
+from flepimop2.typing import ExitCode
+
+
+class _FlagCommand(CliCommand):
+    """Command with a flag option (dry_run) and auto-appended verbosity."""
+
+    def run(self, *, dry_run: bool, verbosity: int) -> ExitCode:  # type: ignore[override]
+        """Execute the command.
+
+        Returns:
+            Exit code.
+        """
+        del dry_run, verbosity
+        return ExitCode.OKAY
+
+
+class _ConfigCommand(CliCommand):
+    """Command whose sole option is the config positional argument."""
+
+    auto_append_verbosity = False
+
+    def run(self, *, config: Path) -> ExitCode:  # type: ignore[override]
+        """Execute the command.
+
+        Returns:
+            Exit code.
+        """
+        del config
+        return ExitCode.OKAY
+
+
+class _TargetCommand(CliCommand):
+    """Command with a --target string option."""
+
+    auto_append_verbosity = False
+
+    def run(self, *, target: str | None) -> ExitCode:  # type: ignore[override]
+        """Execute the command.
+
+        Returns:
+            Exit code.
+        """
+        del target
+        return ExitCode.OKAY
+
+
+def test_config_absolute_path(tmp_path: Path) -> None:
+    """Config argument should be rendered as an absolute path string."""
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text("x: 1\n")
+    cmd = _ConfigCommand(config=cfg)
+    assert cmd.to_argv() == [str(cfg.absolute())]
+
+
+def test_config_none_omitted() -> None:
+    """If config is None, it should be omitted from argv."""
+    cmd = _ConfigCommand(config=None)
+    assert cmd.to_argv() == []
+
+
+def test_flag_true() -> None:
+    """A truthy is_flag option should appear as its flag token."""
+    cmd = _FlagCommand(dry_run=True, verbosity=0)
+    assert "--dry-run" in cmd.to_argv()
+
+
+def test_flag_false_omitted() -> None:
+    """A falsy is_flag option should be omitted entirely."""
+    cmd = _FlagCommand(dry_run=False, verbosity=0)
+    assert "--dry-run" not in cmd.to_argv()
+
+
+def test_verbosity_zero_omitted() -> None:
+    """Verbosity of 0 should produce no token."""
+    cmd = _FlagCommand(dry_run=False, verbosity=0)
+    assert not any(t.startswith("-v") for t in cmd.to_argv())
+
+
+def test_verbosity_one() -> None:
+    """-v should appear once for verbosity=1."""
+    cmd = _FlagCommand(dry_run=False, verbosity=1)
+    assert "-v" in cmd.to_argv()
+
+
+def test_verbosity_three() -> None:
+    """-vvv should appear for verbosity=3."""
+    cmd = _FlagCommand(dry_run=False, verbosity=3)
+    assert "-vvv" in cmd.to_argv()
+
+
+def test_target_present() -> None:
+    """A set --target value should produce ['--target', value]."""
+    cmd = _TargetCommand(target="sim1")
+    argv = cmd.to_argv()
+    assert "--target" in argv
+    assert argv[argv.index("--target") + 1] == "sim1"
+
+
+def test_target_none_omitted() -> None:
+    """A None --target should be omitted from argv."""
+    cmd = _TargetCommand(target=None)
+    assert "--target" not in cmd.to_argv()
+
+
+def test_order_matches_options() -> None:
+    """Tokens should appear in the same order as cls.options()."""
+    cmd = _FlagCommand(dry_run=True, verbosity=2)
+    argv = cmd.to_argv()
+    assert argv.index("--dry-run") < argv.index("-vv")

--- a/tests/_utils/_click/test__click_param_for_option.py
+++ b/tests/_utils/_click/test__click_param_for_option.py
@@ -1,0 +1,42 @@
+# flepimop2: The FLExible Pipeline for Interchangeable MOdel Processing
+# Copyright (C) 2026  Carl Pearson, Joshua Macdonald, Timothy Willard
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Tests for `flepimop2._utils._click._click_param_for_option`."""
+
+import click
+
+from flepimop2._utils._click import _click_param_for_option
+
+
+def test_returns_option_for_option_decorator() -> None:
+    """A click.option decorator should yield a ClickOption instance."""
+    decorator = click.option("--dry-run", is_flag=True, default=False)
+    param = _click_param_for_option(decorator)
+    assert isinstance(param, click.Option)
+    assert param.name == "dry_run"
+
+
+def test_returns_argument_for_argument_decorator() -> None:
+    """A click.argument decorator should yield a ClickArgument instance."""
+    decorator = click.argument("config")
+    param = _click_param_for_option(decorator)
+    assert isinstance(param, click.Argument)
+    assert param.name == "config"
+
+
+def test_returns_none_for_identity_decorator() -> None:
+    """A no-op decorator that attaches no params should return None."""
+    param = _click_param_for_option(lambda f: f)
+    assert param is None

--- a/tests/_utils/_click/test__render_param.py
+++ b/tests/_utils/_click/test__render_param.py
@@ -1,0 +1,90 @@
+# flepimop2: The FLExible Pipeline for Interchangeable MOdel Processing
+# Copyright (C) 2026  Carl Pearson, Joshua Macdonald, Timothy Willard
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Tests for `flepimop2._utils._click._render_param`."""
+
+from pathlib import Path
+
+import click
+import pytest
+
+from flepimop2._utils._click import _render_param
+
+
+def test_argument_string_value() -> None:
+    """A string positional argument should render as a bare token."""
+    param = click.Argument(["config"])
+    assert _render_param(param, "config.yaml") == ["config.yaml"]
+
+
+def test_argument_path_value(tmp_path: Path) -> None:
+    """A Path positional argument should render as its absolute path."""
+    p = tmp_path / "config.yaml"
+    param = click.Argument(["config"])
+    assert _render_param(param, p) == [str(p.absolute())]
+
+
+def test_argument_none_omitted() -> None:
+    """A None positional argument should produce no tokens."""
+    param = click.Argument(["config"])
+    assert _render_param(param, None) == []
+
+
+def test_flag_true_emits_flag_token() -> None:
+    """A truthy flag option should emit the flag token."""
+    param = click.Option(["--dry-run"], is_flag=True, default=False)
+    value: bool = True
+    assert _render_param(param, value) == ["--dry-run"]
+
+
+def test_flag_false_omitted() -> None:
+    """A falsy flag option should produce no tokens."""
+    param = click.Option(["--dry-run"], is_flag=True, default=False)
+    value: bool = False
+    assert _render_param(param, value) == []
+
+
+@pytest.mark.parametrize(
+    ("count", "expected"),
+    [
+        (0, []),
+        (1, ["-v"]),
+        (3, ["-vvv"]),
+    ],
+)
+def test_count_option(count: int, expected: list[str]) -> None:
+    """Count options should render as repeated short flags."""
+    param = click.Option(["-v", "--verbosity"], count=True, default=0)
+    assert _render_param(param, count) == expected
+
+
+def test_regular_option_string() -> None:
+    """A regular option with a string value should produce ['--name', value]."""
+    param = click.Option(["-t", "--target"], default=None)
+    assert _render_param(param, "sim1") == ["--target", "sim1"]
+
+
+def test_regular_option_none_omitted() -> None:
+    """A None regular option should produce no tokens."""
+    param = click.Option(["-t", "--target"], default=None)
+    assert _render_param(param, None) == []
+
+
+def test_regular_option_path_absolute(tmp_path: Path) -> None:
+    """A Path regular option should render as its absolute path."""
+    p = tmp_path / "output"
+    param = click.Option(["--output"], default=None)
+    result = _render_param(param, p)
+    assert result == ["--output", str(p.absolute())]


### PR DESCRIPTION
## Description

Modified the `CliCommand` class to bind the provided CLI arguments to the instance on initialization rather than providing them when executing the command. This allows the `CliCommand` class to be both the representation and the logic for CLI command, rather than just the logic. There are no user facing changes with this change.

No major changes. 

## Related issues

Closes #279.

## Checklist

- [x] I have read through and understand the [pull request process](https://github.com/ACCIDDA/flepimop2?tab=contributing-ov-file#pull-request-process).
- [x] I ran successfully ran CI local via `just ci`.
- [x] I have updated the `CHANGELOG.md` or noted "no major changes" in my commit if the PR is small.
