### PR TITLE
Add `flepimop2 format`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added ways to specify shape for parameters based on `axes` by changing `ParameterABC.sample` to return a `ParameterValue` that contains both the underlying value as a numpy array as well as shape metadata, and is easily extensible to other metadata and underlying value types in the future. Also added `ModelStateSpecification`, `ParameterRequest` types for systems to advertise their underlying state and request parameters to comply with said state specification. See [#115](https://github.com/ACCIDDA/flepimop2/issues/115), [#133](https://github.com/ACCIDDA/flepimop2/issues/133).
 - Added help text for CLI arguments that are formatted similarly to click's default formatting for options.
 - Added optional shorthand module configuration support across all module namespaces, allowing config values such as `fixed(0.3)` for modules that implement `from_shorthand`. See [#14](https://github.com/ACCIDDA/flepimop2/issues/14).
-- Added `ConfigurationModel/ModuleBase.patch` method to merge configurations together along with corresponding `flepimop2 patch` CLI for users to utilizing patching via the command line. See [#51](https://github.com/ACCIDDA/flepimop2/issues/51), [#52](https://github.com/ACCIDDA/flepimop2/issues/52).
+- Added `ConfigurationModel/ModuleBase.patch` method to merge configurations together along with corresponding `flepimop2 patch` CLI for users to utilizing patching via the command line as well as YAML formatting. See [#51](https://github.com/ACCIDDA/flepimop2/issues/51), [#52](https://github.com/ACCIDDA/flepimop2/issues/52), [#289](https://github.com/ACCIDDA/flepimop2/pull/289).
 
 ### Changed
 

--- a/docs/development/customizing-module-appearances.md
+++ b/docs/development/customizing-module-appearances.md
@@ -1,0 +1,123 @@
+# Customizing Module Appearances
+
+This guide shows how developers can control how a custom module appears when `flepimop2` serializes configuration back to YAML.
+
+There are two layers involved:
+
+- The Python-side representation returned by `ModuleBase.to_yaml_data()`.
+- The YAML formatting hints attached to parts of that representation.
+
+In practice, most external developers will not inherit directly from `ModuleBase`. They will usually inherit from one of the domain ABCs such as `ParameterABC`, `SystemABC`, `EngineABC`, or `BackendABC`. Those classes all inherit from `ModuleBase`, so the same `to_yaml_data()` hook applies there.
+
+In most cases you should override `to_yaml_data()` on that domain-specific subclass. That lets you keep validation and patch behavior unchanged while still adjusting the user-facing YAML shape.
+
+## 1. Start with the Default Behavior
+
+By default, `ModuleBase.to_yaml_data()` returns a YAML-ready mapping based on the module fields. Empty `options` are omitted automatically.
+
+For example:
+
+```python
+from flepimop2.parameter.abc import ParameterABC
+
+
+class DemoParameter(ParameterABC, module="demo"):
+    values: tuple[float, ...]
+
+    def sample(self, *, axes=None, request=None):
+        raise NotImplementedError
+```
+
+An instance like `DemoParameter(values=(0.1, 0.2, 0.3))` will serialize its fields using the default block-style YAML layout unless you override `to_yaml_data()`.
+
+## 2. Override `to_yaml_data()` for User-Facing Control
+
+Use `super().to_yaml_data()` as your starting point, then replace individual fields with the structure you want users to see:
+
+```python
+from flepimop2.configuration import yaml_mapping, yaml_sequence
+from flepimop2.parameter.abc import ParameterABC
+
+
+class LookupParameter(ParameterABC, module="lookup"):
+    values: tuple[float, ...]
+    bounds: tuple[int, int]
+    shape: tuple[str, ...] = ()
+    labels: tuple[str, ...] | None = None
+    metadata: dict[str, str] | None = None
+
+    def sample(self, *, axes=None, request=None):
+        raise NotImplementedError
+
+    def to_yaml_data(self) -> object:
+        data = super().to_yaml_data()
+        assert isinstance(data, dict)
+        data["values"] = yaml_sequence(self.values, flow_style=True)
+        data["bounds"] = yaml_sequence(self.bounds, flow_style=True)
+        if self.labels:
+            data["labels"] = yaml_sequence(self.labels, flow_style=True)
+        if self.metadata:
+            data["metadata"] = yaml_mapping(self.metadata, flow_style=True)
+        return data
+```
+
+This keeps the module fields the same internally, but asks the YAML dumper to render those values inline:
+
+```yaml
+module: lookup
+values: [0.1, 0.2, 0.3]
+bounds: [0, 10]
+shape: [age]
+labels: [0-17, 18-64, 65+]
+metadata: {kind: demo}
+```
+
+## 3. Keep Complex Structures Expanded
+
+Flow style is usually best for short, simple values. For more complex nested data, developers can keep block style explicitly:
+
+```python
+from flepimop2.configuration import yaml_mapping, yaml_sequence
+from flepimop2.parameter.abc import ParameterABC
+
+
+class SeasonalParameter(ParameterABC, module="seasonal"):
+    breakpoints: tuple[float, ...]
+    segments: tuple[dict[str, float | str], ...]
+
+    def sample(self, *, axes=None, request=None):
+        raise NotImplementedError
+
+    def to_yaml_data(self) -> object:
+        data = super().to_yaml_data()
+        assert isinstance(data, dict)
+        data["breakpoints"] = yaml_sequence(self.breakpoints, flow_style=True)
+        data["segments"] = yaml_sequence(
+            (yaml_mapping(segment, flow_style=False) for segment in self.segments),
+            flow_style=False,
+        )
+        return data
+```
+
+That combination keeps the simple `breakpoints` field compact while preserving a more readable block layout for the nested `segments` entries:
+
+```yaml
+module: seasonal
+breakpoints: [0.0, 30.0, 60.0]
+segments:
+- start: 0.1
+  end: 0.2
+  mode: linear
+- start: 0.2
+  end: 0.15
+  mode: hold
+```
+
+## 4. Guidelines
+
+- Prefer overriding `to_yaml_data()` instead of changing `model_dump()` behavior. `patch()` logic still depends on the underlying model data, and mixing formatting rules into the patch representation can create surprising merge behavior.
+- Use `yaml_sequence(..., flow_style=True)` or `yaml_mapping(..., flow_style=True)` for short values that are easier to scan inline.
+- Keep nested or multi-entry structures in block style when readability matters more than compactness.
+- Only change the user-facing shape when it improves clarity. The default serializer is already a reasonable baseline for many modules.
+
+For runnable examples of both flow-style and block-style customization, see `tests/module/test_to_yaml_data.py` in the repository.

--- a/docs/guides/modular-configuration.md
+++ b/docs/guides/modular-configuration.md
@@ -93,52 +93,49 @@ The output is a complete configuration:
 
 ```yaml
 name: modular-sir
-axes: {}
 engines:
-  default:
-    module: wrapper
-    options: null
-    state_change: flow
-    script: model_input/plugins/solve_ivp.py
+- module: wrapper
+  state_change: flow
+  script: model_input/plugins/solve_ivp.py
 systems:
-  default:
-    module: wrapper
-    options: null
-    state_change: flow
-    script: model_input/plugins/SIR.py
-    model_state:
-      parameter_names:
-      - s0
-      - i0
-      - r0
-      labels:
-      - S
-      - I
-      - R
+- module: wrapper
+  state_change: flow
+  script: model_input/plugins/SIR.py
+  model_state:
+    parameter_names:
+    - s0
+    - i0
+    - r0
+    labels:
+    - S
+    - I
+    - R
 backends:
-  default:
-    module: csv
-    options: null
-    root: model_output
-process: {}
+- module: csv
+  root: model_output
 parameters:
-  s0: fixed(999)
-  i0: fixed(1)
-  r0: fixed(0)
-  beta: fixed(0.3)
-  gamma: fixed(0.1)
-scenarios: {}
+  s0: 999.0
+  i0: 2.0
+  r0: 0.0
+  beta: 0.3
+  gamma: 0.1
 simulate:
   demo:
     engine: default
     system: default
     backend: default
     times: 0.0:1.0:60.0
-    params: {}
-    scenario: null
 ```
 
 This is often the fastest way to verify that the pieces you selected produce the config you expect.
+
+If you want to normalize an existing configuration file without rebuilding it, use `flepimop2 format`:
+
+```bash
+flepimop2 format configs/built/baseline.yaml
+```
+
+`flepimop2 patch` already formats the YAML it emits, so `format` is most useful for older hand-edited files or configs produced before the formatter existed.
 
 ## 4. Let `error` Mode Catch Accidental Overlap
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -80,6 +80,7 @@ nav:
       - Contributing: development/contributing.md
       - Creating An External Provider Package: development/creating-an-external-provider-package.md
       - Implementing Custom Engines and Systems: development/implementing-custom-engines-and-systems.md
+      - Customizing Module Appearances: development/customizing-module-appearances.md
       - Pydantic for Modelers: development/pydantic-for-modelers.md
       - Integration Testing: development/integration-testing.md
       - Adding A New CLI Command: development/adding-a-new-cli-command.md

--- a/src/flepimop2/_cli/_cli.py
+++ b/src/flepimop2/_cli/_cli.py
@@ -22,6 +22,7 @@ from typing import Final
 import click
 
 from flepimop2._cli._build_command import BuildCommand
+from flepimop2._cli._format_command import FormatCommand
 from flepimop2._cli._patch_command import PatchCommand
 from flepimop2._cli._process_command import ProcessCommand
 from flepimop2._cli._register_command import register_command
@@ -42,6 +43,7 @@ def cli() -> None:
 
 # Register all commands
 register_command(BuildCommand, cli)
+register_command(FormatCommand, cli)
 register_command(PatchCommand, cli)
 register_command(ProcessCommand, cli)
 register_command(SimulateCommand, cli)

--- a/src/flepimop2/_cli/_format_command.py
+++ b/src/flepimop2/_cli/_format_command.py
@@ -1,0 +1,76 @@
+# flepimop2: The FLExible Pipeline for Interchangeable MOdel Processing
+# Copyright (C) 2026  Carl Pearson, Joshua Macdonald, Timothy Willard
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Format command implementation."""
+
+__all__ = []
+
+from pathlib import Path
+
+import click
+
+from flepimop2._cli._cli_command import CliCommand
+from flepimop2.configuration import ConfigurationModel
+from flepimop2.typing import ExitCode
+
+
+class FormatCommand(CliCommand):
+    """
+    Format a configuration file into flepimop2's normalized YAML style.
+
+    By default this command rewrites the input file in place. Use `--check` to
+    validate formatting without modifying the file, or `--dry-run` to print the
+    formatted configuration to stdout.
+    """
+
+    def run(  # type: ignore[override]
+        self,
+        *,
+        config: Path,
+        dry_run: bool,
+        check: bool,
+    ) -> ExitCode:
+        """
+        Execute configuration formatting.
+
+        Args:
+            config: The configuration file to format.
+            dry_run: Whether to print the formatted configuration to stdout.
+            check: Whether to only verify formatting without writing the file.
+
+        Returns:
+            An exit code indicating success or failure.
+        """
+        try:
+            configuration = ConfigurationModel.from_yaml(config)
+        except ValueError as exc:
+            self.error("%s", exc)
+            return ExitCode.CONFIGURATION
+
+        rendered = configuration.safe_dump()
+        current = config.read_text(encoding="utf-8")
+
+        if check:
+            if current == rendered:
+                return ExitCode.OKAY
+            self.error("%s is not formatted.", config)
+            return ExitCode.GENERAL
+
+        if dry_run:
+            click.echo(rendered, nl=False)
+            return ExitCode.OKAY
+
+        config.write_text(rendered, encoding="utf-8")
+        return ExitCode.OKAY

--- a/src/flepimop2/_cli/_options.py
+++ b/src/flepimop2/_cli/_options.py
@@ -138,6 +138,15 @@ def _argument_help_records(
 # Dictionary of common Click options and arguments
 # These can be requested by command classes to maintain consistency
 COMMON_OPTIONS: Final[dict[str, CommonOptionEntry]] = {
+    "check": (
+        click.option(
+            "--check",
+            is_flag=True,
+            default=False,
+            help="Check whether the configuration is already formatted.",
+        ),
+        None,
+    ),
     "config": (
         click.argument(
             "config",

--- a/src/flepimop2/configuration/__init__.py
+++ b/src/flepimop2/configuration/__init__.py
@@ -26,6 +26,9 @@ __all__ = [
     "ParameterConfigurationValue",
     "ParameterGroupModel",
     "SimulateSpecificationModel",
+    "YamlSerializableBaseModel",
+    "yaml_mapping",
+    "yaml_sequence",
 ]
 
 from flepimop2.configuration._axes import (
@@ -42,3 +45,8 @@ from flepimop2.configuration._module import (
     ParameterGroupModel,
 )
 from flepimop2.configuration._simulate import SimulateSpecificationModel
+from flepimop2.configuration._yaml import (
+    YamlSerializableBaseModel,
+    yaml_mapping,
+    yaml_sequence,
+)

--- a/src/flepimop2/configuration/_configuration.py
+++ b/src/flepimop2/configuration/_configuration.py
@@ -15,7 +15,8 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 from collections.abc import Mapping
 from copy import deepcopy
-from typing import Literal, Self
+from importlib import import_module
+from typing import Final, Literal, Self
 
 from pydantic import BaseModel, Field, model_validator
 
@@ -26,6 +27,26 @@ from flepimop2.configuration._simulate import SimulateSpecificationModel
 from flepimop2.configuration._yaml import YamlSerializableBaseModel
 from flepimop2.module import ModuleBase
 from flepimop2.typing import IdentifierString, PatchConflictMode
+
+_CONFIGURATION_SECTION_ORDER: Final[tuple[str, ...]] = (
+    "name",
+    "axes",
+    "engines",
+    "systems",
+    "backends",
+    "process",
+    "parameters",
+    "scenarios",
+    "simulate",
+)
+_LIST_VIEW_SECTIONS: Final[tuple[str, ...]] = (
+    "engines",
+    "systems",
+    "backends",
+    "process",
+    "parameters",
+    "scenarios",
+)
 
 
 class ConfigurationModel(
@@ -59,6 +80,55 @@ class ConfigurationModel(
     simulate: dict[IdentifierString, SimulateSpecificationModel] = Field(
         default_factory=dict
     )
+
+    def to_yaml_data(self) -> object:
+        """
+        Convert the configuration into its normalized YAML representation.
+
+        This preserves parsing/patching semantics while allowing the emitted
+        YAML to use a more compact, user-facing structure.
+
+        Returns:
+            A YAML-ready representation of the configuration.
+        """
+        data = super().to_yaml_data()
+        if not isinstance(data, dict):
+            return data
+
+        if not data.get("name"):
+            data.pop("name", None)
+
+        if self.parameters:
+            build_parameter = import_module("flepimop2.parameter.abc").build
+            data["parameters"] = {
+                name: build_parameter(parameter).to_yaml_data()
+                if isinstance(parameter, ModuleBase | str)
+                else parameter
+                for name, parameter in self.parameters.items()
+            }
+
+        ordered_data = {}
+        if name := data.get("name"):
+            ordered_data["name"] = name
+
+        for section_name in _CONFIGURATION_SECTION_ORDER[1:]:
+            if not (section := data.get(section_name)):
+                continue
+            if (
+                section_name in _LIST_VIEW_SECTIONS
+                and isinstance(section, dict)
+                and len(section) == 1
+                and "default" in section
+            ):
+                section = [section["default"]]
+            ordered_data[section_name] = section
+
+        ordered_data.update({
+            key: value
+            for key, value in data.items()
+            if key not in _CONFIGURATION_SECTION_ORDER
+        })
+        return ordered_data
 
     @staticmethod
     def _copy_patch_value(value: object) -> object:

--- a/src/flepimop2/configuration/_simulate.py
+++ b/src/flepimop2/configuration/_simulate.py
@@ -16,6 +16,7 @@
 from pydantic import BaseModel, ConfigDict, Field
 
 from flepimop2._utils._pydantic import RangeSpec, _to_np_array
+from flepimop2.configuration._yaml import _model_to_yaml_mapping
 from flepimop2.typing import Float64NDArray, IdentifierString
 
 
@@ -40,6 +41,20 @@ class SimulateSpecificationModel(BaseModel):
     times: RangeSpec
     params: dict[str, float] | None = Field(default_factory=dict)
     scenario: IdentifierString | None = None
+
+    def to_yaml_data(self) -> object:
+        """
+        Convert the simulation specification into YAML-ready Python objects.
+
+        Returns:
+            A YAML-ready representation of the simulation specification.
+        """
+        data = _model_to_yaml_mapping(self)
+        if not data.get("params"):
+            data.pop("params", None)
+        if data.get("scenario") is None:
+            data.pop("scenario", None)
+        return data
 
     @property
     def t_eval(self) -> Float64NDArray:

--- a/src/flepimop2/configuration/_yaml.py
+++ b/src/flepimop2/configuration/_yaml.py
@@ -13,12 +13,229 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+from collections import UserDict, UserList
+from collections.abc import Iterable, Mapping
 from pathlib import Path
-from typing import Any, Self
+from typing import Any, Self, TypeVar
 
 from pydantic import BaseModel
-from yaml import safe_dump as yaml_safe_dump
+from yaml import MappingNode, SafeDumper, SequenceNode
+from yaml import dump as yaml_dump
 from yaml import safe_load as yaml_safe_load
+
+T = TypeVar("T")
+K = TypeVar("K")
+V = TypeVar("V")
+
+
+class YamlFormattedSequence(UserList[T]):
+    """
+    List wrapper that can request a specific YAML flow style.
+
+    Examples:
+        >>> wrapped = YamlFormattedSequence((1, 2), flow_style=True)
+        >>> list(wrapped)
+        [1, 2]
+        >>> wrapped.flow_style
+        True
+    """
+
+    __slots__ = ("flow_style",)
+
+    def __init__(
+        self,
+        values: Iterable[T] = (),
+        *,
+        flow_style: bool | None = None,
+    ) -> None:
+        super().__init__(values)
+        self.flow_style = flow_style
+
+
+class YamlFormattedMapping(UserDict[K, V]):
+    """
+    Dict wrapper that can request a specific YAML flow style.
+
+    Examples:
+        >>> wrapped = YamlFormattedMapping({"a": 1}, flow_style=True)
+        >>> dict(wrapped)
+        {'a': 1}
+        >>> wrapped.flow_style
+        True
+    """
+
+    __slots__ = ("flow_style",)
+
+    def __init__(
+        self,
+        values: Mapping[K, V] | Iterable[tuple[K, V]] = (),
+        *,
+        flow_style: bool | None = None,
+    ) -> None:
+        super().__init__(values)
+        self.flow_style = flow_style
+
+
+def yaml_sequence(
+    values: Iterable[T] = (),
+    *,
+    flow_style: bool | None = None,
+) -> YamlFormattedSequence[T]:
+    """
+    Wrap a sequence with YAML style metadata.
+
+    Module authors can return this from `to_yaml_data()` when a specific
+    subtree should use flow style, e.g. `[a, b, c]`.
+
+    Returns:
+        A sequence wrapper carrying the requested YAML flow-style hint.
+
+    Examples:
+        >>> wrapped = yaml_sequence(("a", "b"), flow_style=True)
+        >>> list(wrapped)
+        ['a', 'b']
+        >>> wrapped.flow_style
+        True
+    """
+    return YamlFormattedSequence(values, flow_style=flow_style)
+
+
+def yaml_mapping(
+    values: Mapping[K, V] | Iterable[tuple[K, V]] = (),
+    *,
+    flow_style: bool | None = None,
+) -> YamlFormattedMapping[K, V]:
+    """
+    Wrap a mapping with YAML style metadata.
+
+    Module authors can return this from `to_yaml_data()` when a specific
+    subtree should use flow style, e.g. `{a: 1, b: 2}`.
+
+    Returns:
+        A mapping wrapper carrying the requested YAML flow-style hint.
+
+    Examples:
+        >>> wrapped = yaml_mapping({"kind": "demo"}, flow_style=True)
+        >>> dict(wrapped)
+        {'kind': 'demo'}
+        >>> wrapped.flow_style
+        True
+    """
+    return YamlFormattedMapping(values, flow_style=flow_style)
+
+
+class Flepimop2YamlDumper(SafeDumper):
+    """Project YAML dumper with support for per-subtree flow-style wrappers."""
+
+
+def _represent_yaml_formatted_sequence(
+    dumper: SafeDumper,
+    data: YamlFormattedSequence[object],
+) -> SequenceNode:
+    """
+    Represent a wrapped sequence using its requested flow style.
+
+    Returns:
+        A YAML sequence node with the requested flow-style setting.
+    """
+    return dumper.represent_sequence(
+        "tag:yaml.org,2002:seq",
+        data.data,
+        flow_style=data.flow_style,
+    )
+
+
+def _represent_yaml_formatted_mapping(
+    dumper: SafeDumper,
+    data: YamlFormattedMapping[object, object],
+) -> MappingNode:
+    """
+    Represent a wrapped mapping using its requested flow style.
+
+    Returns:
+        A YAML mapping node with the requested flow-style setting.
+    """
+    return dumper.represent_mapping(
+        "tag:yaml.org,2002:map",
+        data.data,
+        flow_style=data.flow_style,
+    )
+
+
+Flepimop2YamlDumper.add_representer(
+    YamlFormattedSequence,
+    _represent_yaml_formatted_sequence,
+)
+Flepimop2YamlDumper.add_representer(
+    YamlFormattedMapping,
+    _represent_yaml_formatted_mapping,
+)
+
+
+def _model_to_yaml_mapping(model: BaseModel) -> dict[str, object]:
+    """
+    Convert a Pydantic model to a YAML-ready mapping without dumping it first.
+
+    Returns:
+        A recursively normalized mapping representation of the model.
+
+    Examples:
+        >>> class DemoModel(BaseModel):
+        ...     name: str
+        ...     dims: tuple[int, int]
+        >>> _model_to_yaml_mapping(DemoModel(name="demo", dims=(1, 2)))
+        {'name': 'demo', 'dims': [1, 2]}
+    """
+    data = {
+        field_name: _to_yaml_data(getattr(model, field_name))
+        for field_name in type(model).model_fields
+    }
+    if model.model_extra:
+        data.update({
+            field_name: _to_yaml_data(value)
+            for field_name, value in model.model_extra.items()
+        })
+    return data
+
+
+def _to_yaml_data(value: object) -> object:
+    """
+    Recursively convert models and containers into YAML-ready Python values.
+
+    Returns:
+        A YAML-ready scalar or container.
+
+    Examples:
+        >>> class DemoModel(YamlSerializableBaseModel):
+        ...     name: str
+        >>> _to_yaml_data({
+        ...     "items": yaml_sequence((1, 2), flow_style=True),
+        ...     "model": DemoModel(name="demo"),
+        ... })
+        {'items': [1, 2], 'model': {'name': 'demo'}}
+    """
+    result = value
+    if isinstance(value, BaseModel):
+        formatter = getattr(value, "to_yaml_data", None)
+        if callable(formatter):
+            result = _to_yaml_data(formatter())
+        else:
+            result = _model_to_yaml_mapping(value)
+    elif isinstance(value, YamlFormattedSequence):
+        result = type(value)(
+            (_to_yaml_data(item) for item in value),
+            flow_style=value.flow_style,
+        )
+    elif isinstance(value, YamlFormattedMapping):
+        result = type(value)(
+            ((key, _to_yaml_data(item)) for key, item in value.items()),
+            flow_style=value.flow_style,
+        )
+    elif isinstance(value, list | tuple):
+        result = [_to_yaml_data(item) for item in value]
+    elif isinstance(value, dict):
+        result = {key: _to_yaml_data(item) for key, item in value.items()}
+    return result
 
 
 class YamlSerializableBaseModel(BaseModel):
@@ -45,6 +262,12 @@ class YamlSerializableBaseModel(BaseModel):
 
         Returns:
             An instance of the model.
+
+        Examples:
+            >>> class DemoModel(YamlSerializableBaseModel):
+            ...     name: str
+            >>> DemoModel.safe_load("name: demo")
+            DemoModel(name='demo')
         """
         return cls.model_validate(yaml_safe_load(contents))
 
@@ -69,8 +292,38 @@ class YamlSerializableBaseModel(BaseModel):
 
         Returns:
             The serialized YAML document.
+
+        Examples:
+            >>> class DemoModel(YamlSerializableBaseModel):
+            ...     name: str
+            >>> print(DemoModel(name="demo").safe_dump(), end="")
+            name: demo
         """
-        return yaml_safe_dump(self.model_dump(), sort_keys=False)
+        return yaml_dump(
+            self.to_yaml_data(),
+            Dumper=Flepimop2YamlDumper,
+            default_flow_style=False,
+            sort_keys=False,
+        )
+
+    def to_yaml_data(self) -> object:
+        """
+        Convert the model into YAML-ready Python objects.
+
+        Subclasses can override this method to control both the serialized
+        representation and any YAML style wrappers used by the project dumper.
+
+        Returns:
+            A YAML-ready representation of the model.
+
+        Examples:
+            >>> class DemoModel(YamlSerializableBaseModel):
+            ...     name: str
+            ...     dims: tuple[int, int]
+            >>> DemoModel(name="demo", dims=(1, 2)).to_yaml_data()
+            {'name': 'demo', 'dims': [1, 2]}
+        """
+        return _model_to_yaml_mapping(self)
 
     def to_yaml(self, file: Path, encoding: str = "utf-8", **kwargs: Any) -> None:
         """

--- a/src/flepimop2/module.py
+++ b/src/flepimop2/module.py
@@ -23,6 +23,7 @@ from typing import Any, ClassVar, Literal, Self, cast
 from pydantic import BaseModel, ConfigDict, Field
 
 from flepimop2._utils._dict import _deep_merge_dicts
+from flepimop2.configuration._yaml import _model_to_yaml_mapping
 from flepimop2.typing import PatchConflictMode, RaiseOnMissing, RaiseOnMissingType
 
 
@@ -283,6 +284,21 @@ class ModuleBase(BaseModel):
             msg = f"Option '{name}' not found in module '{self.module}'."
             raise KeyError(msg)
         return opts.get(name, default)
+
+    def to_yaml_data(self) -> object:
+        """
+        Convert the module configuration into YAML-ready Python objects.
+
+        Subclasses can override this to customize just their serialized
+        configuration block without changing patch semantics.
+
+        Returns:
+            A YAML-ready representation of the module configuration.
+        """
+        data = _model_to_yaml_mapping(self)
+        if not data.get("options"):
+            data.pop("options", None)
+        return data
 
     def patch(
         self,

--- a/src/flepimop2/parameter/fixed/__init__.py
+++ b/src/flepimop2/parameter/fixed/__init__.py
@@ -41,6 +41,23 @@ class FixedParameter(ParameterABC, module="fixed"):
     value: float | int | list[Any]
     shape: tuple[IdentifierString, ...] = ()
 
+    def to_yaml_data(self) -> object:
+        """
+        Convert the fixed parameter into YAML-ready Python objects.
+
+        Returns:
+            A bare scalar for simple fixed parameters, otherwise the expanded
+            module configuration mapping.
+        """
+        if (
+            isinstance(self.value, int | float)
+            and not isinstance(self.value, bool)
+            and not self.shape
+            and not self.options
+        ):
+            return self.value
+        return super().to_yaml_data()
+
     @classmethod
     def from_shorthand(cls, shorthand: str) -> Self:
         r"""

--- a/tests/_cli/test_format_command.py
+++ b/tests/_cli/test_format_command.py
@@ -1,0 +1,99 @@
+# flepimop2: The FLExible Pipeline for Interchangeable MOdel Processing
+# Copyright (C) 2026  Carl Pearson, Joshua Macdonald, Timothy Willard
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Tests for the `flepimop2 format` CLI command."""
+
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from flepimop2._cli._cli import cli
+from flepimop2.typing import ExitCode
+
+
+def test_format_command_rewrites_configuration_in_place(tmp_path: Path) -> None:
+    """Formatting should normalize YAML in place by default."""
+    config = tmp_path / "config.yaml"
+    config.write_text(
+        """
+name: ""
+engines:
+  default:
+    module: demo.engine
+    options: {}
+systems: {}
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["format", str(config)],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == ExitCode.OKAY
+    assert not result.output
+    assert config.read_text(encoding="utf-8") == "engines:\n- module: demo.engine\n"
+
+
+def test_format_command_check_fails_when_configuration_would_change(
+    tmp_path: Path,
+) -> None:
+    """Check mode should fail without modifying an unformatted file."""
+    config = tmp_path / "config.yaml"
+    original = """
+name: ""
+engines:
+  default:
+    module: demo.engine
+    options: {}
+""".lstrip()
+    config.write_text(original, encoding="utf-8")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["format", "--check", str(config)],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == ExitCode.GENERAL
+    assert "is not formatted" in result.output
+    assert config.read_text(encoding="utf-8") == original
+
+
+def test_format_command_dry_run_prints_formatted_yaml(tmp_path: Path) -> None:
+    """Dry-run mode should print the normalized YAML without rewriting the file."""
+    config = tmp_path / "config.yaml"
+    original = """
+engines:
+  default:
+    module: demo.engine
+    options: {}
+""".lstrip()
+    config.write_text(original, encoding="utf-8")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["format", "--dry-run", str(config)],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == ExitCode.OKAY
+    assert result.output == "engines:\n- module: demo.engine\n"
+    assert config.read_text(encoding="utf-8") == original

--- a/tests/_cli/test_patch_command.py
+++ b/tests/_cli/test_patch_command.py
@@ -104,28 +104,9 @@ simulate:
     assert result.exit_code == ExitCode.OKAY
     assert safe_load(result.output) == {
         "name": "final",
-        "axes": {},
-        "engines": {
-            "default": {
-                "module": "demo.engine",
-                "options": None,
-            }
-        },
-        "systems": {
-            "default": {
-                "module": "demo.system",
-                "options": None,
-            }
-        },
-        "backends": {
-            "default": {
-                "module": "demo.backend",
-                "options": None,
-            }
-        },
-        "process": {},
-        "parameters": {},
-        "scenarios": {},
+        "engines": [{"module": "demo.engine"}],
+        "systems": [{"module": "demo.system"}],
+        "backends": [{"module": "demo.backend"}],
         "simulate": {
             "main": {
                 "engine": "default",
@@ -136,7 +117,6 @@ simulate:
                     "alpha": 1.0,
                     "beta": 2.0,
                 },
-                "scenario": None,
             }
         },
     }
@@ -210,17 +190,9 @@ parameters:
     assert result.exit_code == ExitCode.OKAY
     assert not result.output
     assert safe_load(output.read_text(encoding="utf-8")) == {
-        "name": None,
-        "axes": {},
-        "engines": {},
-        "systems": {},
-        "backends": {},
-        "process": {},
         "parameters": {
-            "rate": "fixed(2.0)",
+            "rate": 2.0,
         },
-        "scenarios": {},
-        "simulate": {},
     }
 
 
@@ -264,16 +236,8 @@ parameters:
 
     assert result.exit_code == ExitCode.OKAY
     assert safe_load(result.output) == {
-        "name": None,
-        "axes": {},
-        "engines": {},
-        "systems": {},
-        "backends": {},
-        "process": {},
         "parameters": {
-            "rate": "fixed(2.0)",
+            "rate": 2.0,
         },
-        "scenarios": {},
-        "simulate": {},
     }
     assert not output.exists()

--- a/tests/configuration/_yaml/test_yaml_serializable_base_model.py
+++ b/tests/configuration/_yaml/test_yaml_serializable_base_model.py
@@ -19,7 +19,11 @@ from pathlib import Path
 
 import pytest
 
-from flepimop2.configuration._yaml import YamlSerializableBaseModel
+from flepimop2.configuration._yaml import (
+    YamlSerializableBaseModel,
+    yaml_mapping,
+    yaml_sequence,
+)
 
 
 class SimpleModel(YamlSerializableBaseModel):
@@ -35,6 +39,27 @@ class ComplexModel(YamlSerializableBaseModel):
     name: str
     items: list[SimpleModel]
     metadata: dict[str, str]
+
+
+class StyledModel(YamlSerializableBaseModel):
+    """Test model that requests flow-style YAML for specific subtrees."""
+
+    name: str
+    items: list[int]
+    metadata: dict[str, str]
+
+    def to_yaml_data(self) -> object:
+        """
+        Serialize selected subtrees with explicit YAML style wrappers.
+
+        Returns:
+            A YAML-ready mapping with explicit flow-style wrappers.
+        """
+        return {
+            "name": self.name,
+            "items": yaml_sequence(self.items, flow_style=True),
+            "metadata": yaml_mapping(self.metadata, flow_style=True),
+        }
 
 
 @pytest.mark.parametrize(
@@ -91,3 +116,12 @@ def test_yaml_safe_dump_and_safe_load_round_trip(
     dumped = instance.safe_dump()
     loaded = model_class.safe_load(dumped)
     assert loaded == instance
+
+
+def test_yaml_safe_dump_supports_flow_style_wrappers() -> None:
+    """Wrapped subtrees should retain their requested YAML flow style."""
+    instance = StyledModel(name="styled", items=[1, 2], metadata={"a": "b"})
+
+    dumped = instance.safe_dump()
+
+    assert dumped == "name: styled\nitems: [1, 2]\nmetadata: {a: b}\n"

--- a/tests/configuration/configuration_model_class/test_parameter_configuration.py
+++ b/tests/configuration/configuration_model_class/test_parameter_configuration.py
@@ -18,6 +18,7 @@
 from pathlib import Path
 
 import pytest
+from yaml import safe_load
 
 from flepimop2.configuration import ConfigurationModel
 from flepimop2.parameter.abc import build as build_parameter
@@ -49,3 +50,28 @@ def test_configuration_model_from_yaml_accepts_numeric_parameter_values(
     configuration = ConfigurationModel.from_yaml(config_path)
 
     assert configuration.parameters["beta"] == "fixed(0.3)"
+
+
+def test_configuration_model_safe_dump_formats_fixed_shorthand_as_bare_scalar() -> None:
+    """Formatted YAML should collapse simple fixed-parameter shorthand to scalars."""
+    configuration = ConfigurationModel.model_validate({
+        "parameters": {
+            "s0": "fixed(999)",
+            "i0": "fixed(2)",
+            "r0": "fixed(0)",
+            "beta": "fixed(0.3)",
+            "gamma": "fixed(0.1)",
+        }
+    })
+
+    dumped = configuration.safe_dump()
+
+    assert safe_load(dumped) == {
+        "parameters": {
+            "s0": 999.0,
+            "i0": 2.0,
+            "r0": 0.0,
+            "beta": 0.3,
+            "gamma": 0.1,
+        }
+    }

--- a/tests/configuration/configuration_model_class/test_yaml_formatting.py
+++ b/tests/configuration/configuration_model_class/test_yaml_formatting.py
@@ -1,0 +1,144 @@
+# flepimop2: The FLExible Pipeline for Interchangeable MOdel Processing
+# Copyright (C) 2026  Carl Pearson, Joshua Macdonald, Timothy Willard
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Tests for configuration YAML formatting."""
+
+from yaml import safe_load
+
+from flepimop2.configuration import ConfigurationModel
+
+
+def test_configuration_model_safe_dump_omits_empty_sections_and_name() -> None:
+    """Formatted YAML should omit empty top-level sections and blank names."""
+    configuration = ConfigurationModel.model_validate({
+        "name": "",
+        "engines": {
+            "default": {
+                "module": "demo.engine",
+                "options": {},
+            }
+        },
+        "systems": {},
+    })
+
+    dumped = configuration.safe_dump()
+
+    assert safe_load(dumped) == {"engines": [{"module": "demo.engine"}]}
+
+
+def test_configuration_model_safe_dump_list_view_round_trips_default_sections() -> None:
+    """Single default entries should serialize as a one-item list view."""
+    configuration = ConfigurationModel.model_validate({
+        "engines": {
+            "default": {
+                "module": "demo.engine",
+            }
+        }
+    })
+
+    dumped = configuration.safe_dump()
+    loaded = ConfigurationModel.safe_load(dumped)
+
+    assert dumped == "engines:\n- module: demo.engine\n"
+    engine = loaded.engines["default"]
+    assert not isinstance(engine, str)
+    assert engine.module == "demo.engine"
+
+
+def test_configuration_model_safe_dump_omits_empty_simulate_fields() -> None:
+    """Formatted YAML should omit empty `params` and null `scenario` fields."""
+    configuration = ConfigurationModel.model_validate({
+        "engines": {"default": {"module": "demo.engine"}},
+        "systems": {"default": {"module": "demo.system"}},
+        "backends": {"default": {"module": "demo.backend"}},
+        "simulate": {
+            "main": {
+                "times": [0.0, 1.0],
+                "params": {},
+                "scenario": None,
+            }
+        },
+    })
+
+    dumped = configuration.safe_dump()
+
+    assert safe_load(dumped) == {
+        "engines": [{"module": "demo.engine"}],
+        "systems": [{"module": "demo.system"}],
+        "backends": [{"module": "demo.backend"}],
+        "simulate": {
+            "main": {
+                "engine": "default",
+                "system": "default",
+                "backend": "default",
+                "times": [0.0, 1.0],
+            }
+        },
+    }
+
+
+def test_configuration_model_safe_dump_orders_sections_consistently() -> None:
+    """Formatted YAML should emit top-level sections in canonical order."""
+    configuration = ConfigurationModel.model_validate({
+        "simulate": {
+            "main": {
+                "times": [0.0, 1.0],
+            }
+        },
+        "parameters": {
+            "beta": "fixed(0.3)",
+        },
+        "backends": {"default": {"module": "demo.backend"}},
+        "axes": {
+            "age": {
+                "kind": "categorical",
+                "labels": ["child", "adult"],
+            }
+        },
+        "engines": {"default": {"module": "demo.engine"}},
+        "systems": {"default": {"module": "demo.system"}},
+        "name": "demo",
+    })
+
+    dumped = configuration.safe_dump()
+
+    assert dumped.splitlines() == [
+        "name: demo",
+        "axes:",
+        "  age:",
+        "    kind: categorical",
+        "    labels:",
+        "    - child",
+        "    - adult",
+        "    values:",
+        "    - 1",
+        "    - 2",
+        "engines:",
+        "- module: demo.engine",
+        "systems:",
+        "- module: demo.system",
+        "backends:",
+        "- module: demo.backend",
+        "parameters:",
+        "  beta: 0.3",
+        "simulate:",
+        "  main:",
+        "    engine: default",
+        "    system: default",
+        "    backend: default",
+        "    times:",
+        "    - 0.0",
+        "    - 1.0",
+    ]

--- a/tests/integration/documentation_modular_configuration/test_modular_configuration.py
+++ b/tests/integration/documentation_modular_configuration/test_modular_configuration.py
@@ -18,6 +18,7 @@
 import subprocess  # noqa: S404
 from pathlib import Path
 
+import pytest
 from yaml import safe_load
 
 from flepimop2.testing import flepimop2_run, project_skeleton
@@ -74,11 +75,11 @@ def test_modular_configuration_guide(repo_root: Path, tmp_path: Path) -> None:
     assert stdout_result.returncode == 0
     stdout_config = safe_load(stdout_result.stdout)
     assert stdout_config["parameters"] == {
-        "s0": "fixed(999)",
-        "i0": "fixed(1)",
-        "r0": "fixed(0)",
-        "beta": "fixed(0.3)",
-        "gamma": "fixed(0.1)",
+        "s0": 999.0,
+        "i0": 1.0,
+        "r0": 0.0,
+        "beta": 0.3,
+        "gamma": 0.1,
     }
     assert stdout_config["simulate"]["demo"]["backend"] == "default"
 
@@ -122,7 +123,7 @@ def test_modular_configuration_guide(repo_root: Path, tmp_path: Path) -> None:
     assert output_result.returncode == 0
     assert not output_result.stdout
     built_payload = safe_load(built_config.read_text(encoding="utf-8"))
-    assert built_payload["parameters"]["beta"] == "fixed(0.45)"
+    assert built_payload["parameters"]["beta"] == pytest.approx(0.45)
 
     simulate_result = flepimop2_run(
         "simulate",

--- a/tests/module/test_to_yaml_data.py
+++ b/tests/module/test_to_yaml_data.py
@@ -1,0 +1,154 @@
+# flepimop2: The FLExible Pipeline for Interchangeable MOdel Processing
+# Copyright (C) 2026  Carl Pearson, Joshua Macdonald, Timothy Willard
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Examples and tests for overriding `ModuleBase.to_yaml_data`."""
+
+from flepimop2.configuration import (
+    YamlSerializableBaseModel,
+    yaml_mapping,
+    yaml_sequence,
+)
+from flepimop2.configuration._yaml import YamlFormattedMapping, YamlFormattedSequence
+from flepimop2.module import ModuleBase
+
+
+class StyledModule(ModuleBase, module="flepimop2.test.styled"):
+    """Example module that customizes how its YAML subtree is emitted."""
+
+    labels: tuple[str, ...]
+    bounds: tuple[int, int]
+    metadata: dict[str, str] | None = None
+
+    def to_yaml_data(self) -> object:
+        """
+        Serialize selected fields with explicit YAML style wrappers.
+
+        Returns:
+            A YAML-ready mapping with flow-style wrappers for selected fields.
+        """
+        data = super().to_yaml_data()
+        assert isinstance(data, dict)
+        data["labels"] = yaml_sequence(self.labels, flow_style=True)
+        data["bounds"] = yaml_sequence(self.bounds, flow_style=True)
+        if self.metadata:
+            data["metadata"] = yaml_mapping(self.metadata, flow_style=True)
+        return data
+
+
+class MixedStyleModule(ModuleBase, module="flepimop2.test.mixed-style"):
+    """Example module that mixes flow-style and block-style YAML output."""
+
+    title: str
+    dims: tuple[int, int]
+    steps: tuple[dict[str, str], ...]
+
+    def to_yaml_data(self) -> object:
+        """
+        Serialize simple values inline while keeping complex structures expanded.
+
+        Returns:
+            A YAML-ready mapping with both flow-style and block-style wrappers.
+        """
+        data = super().to_yaml_data()
+        assert isinstance(data, dict)
+        data["dims"] = yaml_sequence(self.dims, flow_style=True)
+        data["steps"] = yaml_sequence(
+            (yaml_mapping(step, flow_style=False) for step in self.steps),
+            flow_style=False,
+        )
+        return data
+
+
+class ModuleDocument(YamlSerializableBaseModel):
+    """Simple wrapper model for testing module YAML output."""
+
+    module: StyledModule
+
+
+def test_module_to_yaml_data_override_can_customize_field_styles() -> None:
+    """Module overrides can replace fields with explicit YAML style wrappers."""
+    module = StyledModule(
+        labels=("susceptible", "infected"),
+        bounds=(0, 10),
+        metadata={"kind": "demo"},
+    )
+
+    data = module.to_yaml_data()
+
+    assert isinstance(data, dict)
+    assert data["module"] == "flepimop2.test.styled"
+    assert "options" not in data
+    assert isinstance(data["labels"], YamlFormattedSequence)
+    assert isinstance(data["bounds"], YamlFormattedSequence)
+    assert isinstance(data["metadata"], YamlFormattedMapping)
+    assert data == {
+        "module": "flepimop2.test.styled",
+        "labels": ["susceptible", "infected"],
+        "bounds": [0, 10],
+        "metadata": {"kind": "demo"},
+    }
+
+
+def test_module_to_yaml_data_override_changes_rendered_yaml() -> None:
+    """Module overrides should affect the final YAML representation."""
+    document = ModuleDocument(
+        module=StyledModule(
+            labels=("susceptible", "infected"),
+            bounds=(0, 10),
+            metadata={"kind": "demo"},
+        )
+    )
+
+    dumped = document.safe_dump()
+
+    assert dumped == (
+        "module:\n"
+        "  module: flepimop2.test.styled\n"
+        "  labels: [susceptible, infected]\n"
+        "  bounds: [0, 10]\n"
+        "  metadata: {kind: demo}\n"
+    )
+
+
+def test_module_to_yaml_data_override_can_preserve_block_style() -> None:
+    """Module overrides can keep complex collections expanded in block style."""
+
+    class MixedStyleDocument(YamlSerializableBaseModel):
+        module: MixedStyleModule
+
+    document = MixedStyleDocument(
+        module=MixedStyleModule(
+            title="pipeline",
+            dims=(2, 3),
+            steps=(
+                {"name": "prepare", "tool": "demo.prepare"},
+                {"name": "simulate", "tool": "demo.simulate"},
+            ),
+        )
+    )
+
+    dumped = document.safe_dump()
+
+    assert dumped == (
+        "module:\n"
+        "  module: flepimop2.test.mixed-style\n"
+        "  title: pipeline\n"
+        "  dims: [2, 3]\n"
+        "  steps:\n"
+        "  - name: prepare\n"
+        "    tool: demo.prepare\n"
+        "  - name: simulate\n"
+        "    tool: demo.simulate\n"
+    )

--- a/tests/parameter/test_fixed_parameter_class.py
+++ b/tests/parameter/test_fixed_parameter_class.py
@@ -19,8 +19,10 @@ from typing import Any
 
 import numpy as np
 import pytest
+from yaml import safe_load
 
 from flepimop2.axis import AxisCollection
+from flepimop2.configuration import ConfigurationModel
 from flepimop2.parameter.abc import ParameterRequest
 from flepimop2.parameter.fixed import FixedParameter
 
@@ -112,3 +114,49 @@ def test_fixed_parameter_rejects_value_with_incompatible_resolved_shape() -> Non
         ),
     ):
         FixedParameter(value=[0.1, 0.2], shape=("age",)).sample(axes=axes)
+
+
+def test_fixed_parameter_to_yaml_data_collapses_simple_scalar() -> None:
+    """Simple scalar fixed parameters should serialize as bare numeric values."""
+    parameter = FixedParameter(value=0.3)
+
+    assert parameter.to_yaml_data() == pytest.approx(0.3)
+
+
+def test_fixed_parameter_to_yaml_data_keeps_expanded_mapping_when_shaped() -> None:
+    """Shaped fixed parameters should keep the expanded module configuration."""
+    parameter = FixedParameter(value=0.3, shape=("age",))
+
+    assert parameter.to_yaml_data() == {
+        "module": "flepimop2.parameter.fixed",
+        "value": 0.3,
+        "shape": ["age"],
+    }
+
+
+def test_fixed_parameter_to_yaml_data_keeps_expanded_mapping_with_options() -> None:
+    """Fixed parameters with options should keep the expanded module configuration."""
+    parameter = FixedParameter(value=0.3, options={"source": "demo"})
+
+    assert parameter.to_yaml_data() == {
+        "module": "flepimop2.parameter.fixed",
+        "options": {"source": "demo"},
+        "value": 0.3,
+        "shape": [],
+    }
+
+
+def test_configuration_model_safe_dump_uses_bare_scalar_for_simple_fixed() -> None:
+    """Configuration YAML should emit simple fixed parameters as bare numbers."""
+    configuration = ConfigurationModel.model_validate({
+        "parameters": {
+            "beta": {
+                "module": "fixed",
+                "value": 0.3,
+            }
+        }
+    })
+
+    dumped = configuration.safe_dump()
+
+    assert safe_load(dumped) == {"parameters": {"beta": 0.3}}


### PR DESCRIPTION

## Description

Added the `flepimop2 format` CLI to provide a CLI interface for formatting configuration files. It wraps the YAML formatting API, namely `ModuleBase.to_yaml_data` (and associated helpers) to allow for customized YAML structured outputs. Also incorporated formatting into the `flepimop2 patch` CLI.

## Related issues

Closes #162.

## Checklist

- [x] I have read through and understand the [pull request process](https://github.com/ACCIDDA/flepimop2?tab=contributing-ov-file#pull-request-process).
- [x] I ran successfully ran CI local via `just ci`.
- [x] I have updated the `CHANGELOG.md` or noted "no major changes" in my commit if the PR is small.
