### PR TITLE
Add `JobABC` for submitting batch jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added help text for CLI arguments that are formatted similarly to click's default formatting for options.
 - Added optional shorthand module configuration support across all module namespaces, allowing config values such as `fixed(0.3)` for modules that implement `from_shorthand`. See [#14](https://github.com/ACCIDDA/flepimop2/issues/14).
 - Added `ConfigurationModel/ModuleBase.patch` method to merge configurations together along with corresponding `flepimop2 patch` CLI for users to utilizing patching via the command line as well as YAML formatting. See [#51](https://github.com/ACCIDDA/flepimop2/issues/51), [#52](https://github.com/ACCIDDA/flepimop2/issues/52), [#289](https://github.com/ACCIDDA/flepimop2/pull/289).
+- Introduced the `JobABC` to execute CLI commands in separate environments along with corresponding "jobs" top level key in configuration and the `ShellJob` module to run a CLI in a subprocess. See [#276](https://github.com/ACCIDDA/flepimop2/issues/276), [#277](https://github.com/ACCIDDA/flepimop2/issues/277), [#278](https://github.com/ACCIDDA/flepimop2/issues/278).
 
 ### Changed
 

--- a/src/flepimop2/_utils/_module.py
+++ b/src/flepimop2/_utils/_module.py
@@ -35,7 +35,9 @@ from pydantic import TypeAdapter, ValidationError
 from flepimop2.module import ModuleBase
 from flepimop2.typing import IdentifierString
 
-Namespace = Literal["backend", "engine", "parameter", "process", "scenario", "system"]
+Namespace = Literal[
+    "backend", "engine", "job", "parameter", "process", "scenario", "system"
+]
 
 T = TypeVar("T", bound=ModuleBase)
 SHORTHAND_PATTERN = re.compile(

--- a/src/flepimop2/configuration/_configuration.py
+++ b/src/flepimop2/configuration/_configuration.py
@@ -34,6 +34,7 @@ _CONFIGURATION_SECTION_ORDER: Final[tuple[str, ...]] = (
     "engines",
     "systems",
     "backends",
+    "jobs",
     "process",
     "parameters",
     "scenarios",
@@ -43,6 +44,7 @@ _LIST_VIEW_SECTIONS: Final[tuple[str, ...]] = (
     "engines",
     "systems",
     "backends",
+    "jobs",
     "process",
     "parameters",
     "scenarios",
@@ -77,6 +79,7 @@ class ConfigurationModel(
     process: ModuleGroupModel = Field(default_factory=dict)
     parameters: ParameterGroupModel = Field(default_factory=dict)
     scenarios: ModuleGroupModel = Field(default_factory=dict)
+    jobs: ModuleGroupModel = Field(default_factory=dict)
     simulate: dict[IdentifierString, SimulateSpecificationModel] = Field(
         default_factory=dict
     )
@@ -270,6 +273,7 @@ class ConfigurationModel(
                 "process",
                 "parameters",
                 "scenarios",
+                "jobs",
                 "simulate",
             )
         }
@@ -323,6 +327,11 @@ class ConfigurationModel(
             "scenarios": self._patch_section(
                 self.scenarios,
                 other.scenarios,
+                conflict=conflict,
+            ),
+            "jobs": self._patch_section(
+                self.jobs,
+                other.jobs,
                 conflict=conflict,
             ),
             "simulate": self._patch_section(

--- a/src/flepimop2/job/abc/__init__.py
+++ b/src/flepimop2/job/abc/__init__.py
@@ -1,0 +1,122 @@
+# flepimop2: The FLExible Pipeline for Interchangeable MOdel Processing
+# Copyright (C) 2026  Carl Pearson, Joshua Macdonald, Timothy Willard
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Abstract base class for flepimop2 job runners."""
+
+__all__ = ["JobABC", "JobHandle", "build"]
+
+from abc import abstractmethod
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+
+from flepimop2._utils._module import _build
+from flepimop2.exceptions import Flepimop2ValidationError, ValidationIssue
+from flepimop2.module import ModuleBase
+
+if TYPE_CHECKING:
+    from flepimop2._cli._cli_command import CliCommand
+
+
+@dataclass
+class JobHandle:
+    """A reference to a submitted job.
+
+    Attributes:
+        job_id: Opaque token identifying the job on the backend (PID, Slurm id,
+            ARN, ...).
+        backend: The job module name that produced this handle.
+        submitted_at: When the job was submitted.
+        metadata: Optional backend-specific metadata (partition, queue, ...).
+    """
+
+    job_id: str
+    backend: str
+    submitted_at: datetime = field(default_factory=lambda: datetime.now(tz=UTC))
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def __str__(self) -> str:
+        """Return a short, single-line representation suitable for stdout."""
+        ts = self.submitted_at.strftime("%Y-%m-%dT%H:%M:%S")
+        return f"{self.backend}/{self.job_id} submitted_at={ts}"
+
+
+class JobABC(ModuleBase, module_namespace="job"):
+    """Abstract base class for flepimop2 job runners."""
+
+    def submit(
+        self, command: "CliCommand", *, dry_run: bool = False
+    ) -> JobHandle | None:
+        """Submit `command` for execution on this job backend.
+
+        Runs `_submit_validate` first; if issues are found they are raised as
+        a `Flepimop2ValidationError`. When `dry_run=True` the method returns
+        `None` after validation without actually submitting.
+
+        Args:
+            command: The CLI command instance to submit.
+            dry_run: If `True`, validate only — do not actually submit.
+
+        Returns:
+            A handle for the submitted work unit, or `None` when `dry_run=True`.
+
+        Raises:
+            Flepimop2ValidationError: If `_submit_validate` returns issues.
+        """
+        if (issues := self._submit_validate()) is not None and issues:
+            raise Flepimop2ValidationError(issues)
+        if dry_run:
+            return None
+        return self._submit(command)
+
+    @abstractmethod
+    def _submit(self, command: "CliCommand") -> JobHandle:
+        """Backend-specific submission implementation.
+
+        Args:
+            command: The CLI command instance to submit.
+
+        Returns:
+            A handle for the submitted work unit.
+        """
+        ...
+
+    def _submit_validate(self) -> list[ValidationIssue] | None:  # noqa: PLR6301
+        """Validate that this backend is ready to accept submissions.
+
+        Called by `submit` before delegating to `_submit`. Subclasses may
+        override to perform backend-specific preflight checks (e.g. resolving
+        executables, checking credentials, testing connectivity).
+
+        Returns:
+            A list of `ValidationIssue` objects if validation fails, an empty
+            list if validation passes with no issues, or `None` if not
+            implemented.
+        """
+        return None
+
+
+def build(config: dict[str, Any] | ModuleBase | str) -> JobABC:
+    """Build a `JobABC` from a configuration dictionary.
+
+    Args:
+        config: Configuration dictionary. The dict should contain a
+            'module' key, which will be used to lookup the job module path.
+            The module will have "flepimop2.job." prepended.
+
+    Returns:
+        The constructed job object.
+    """
+    return _build(config, "job", JobABC)  # type: ignore[type-abstract]

--- a/src/flepimop2/job/shell/__init__.py
+++ b/src/flepimop2/job/shell/__init__.py
@@ -1,0 +1,101 @@
+# flepimop2: The FLExible Pipeline for Interchangeable MOdel Processing
+# Copyright (C) 2026  Carl Pearson, Joshua Macdonald, Timothy Willard
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Shell job runner for flepimop2. For development and testing only."""
+
+__all__ = ["ShellJob"]
+
+import shutil
+import subprocess  # noqa: S404
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from pydantic import PrivateAttr
+
+from flepimop2.exceptions import ValidationIssue
+from flepimop2.job.abc import JobABC, JobHandle
+
+if TYPE_CHECKING:
+    from flepimop2._cli._cli_command import CliCommand
+
+
+class ShellJob(JobABC, module="shell"):
+    """Run a command locally via subprocess. For dev/testing — not production.
+
+    Attributes:
+        module: The fully-qualified module name, resolved from `module="shell"` to
+            `"flepimop2.job.shell"`.
+        cwd: Optional working directory for the subprocess.
+        env: Optional environment variables for the subprocess. If `None`,
+            the current process environment is inherited.
+        detach: If `True` (the default), the subprocess runs detached in a new
+            session and control returns immediately. If `False`, the call blocks
+            until the subprocess exits (useful for tests).
+    """
+
+    cwd: Path | None = None
+    env: dict[str, str] | None = None
+    detach: bool = True
+
+    _exe: str | None = PrivateAttr(default=None)
+
+    def _submit_validate(self) -> list[ValidationIssue] | None:
+        """Resolve the `flepimop2` executable and cache it for use in `_submit`.
+
+        Returns:
+            An empty list if the executable is found, or a one-element list
+            containing a `ValidationIssue` if it cannot be located on PATH.
+        """
+        if self._exe is None:
+            self._exe = shutil.which("flepimop2")
+        if self._exe is None:
+            return [
+                ValidationIssue(
+                    msg="Could not locate the 'flepimop2' executable on PATH.",
+                    kind="missing_executable",
+                )
+            ]
+        return []
+
+    def _submit(self, command: "CliCommand") -> JobHandle:
+        """Submit `command` as a local subprocess.
+
+        Args:
+            command: The CLI command instance to run.
+
+        Returns:
+            A handle for the submitted subprocess.
+
+        Raises:
+            FileNotFoundError: If the `flepimop2` executable cannot be found on PATH.
+        """
+        if self._exe is None:
+            self._exe = shutil.which("flepimop2")
+        if self._exe is None:
+            msg = "Could not locate the 'flepimop2' executable on PATH."
+            raise FileNotFoundError(msg)
+        argv = [self._exe, command.command_name(), *command.to_argv()]
+        env: dict[str, str] | None = self.env
+        kwargs: dict[str, Any] = {
+            "cwd": self.cwd,
+            "env": env,
+        }
+        if self.detach:
+            proc = subprocess.Popen(argv, start_new_session=True, **kwargs)  # noqa: S603
+            job_id = str(proc.pid)
+        else:
+            result = subprocess.run(argv, check=False, **kwargs)  # noqa: S603
+            job_id = str(result.returncode)
+        return JobHandle(job_id=job_id, backend="shell")

--- a/tests/job/abc/test_job_handle.py
+++ b/tests/job/abc/test_job_handle.py
@@ -1,0 +1,72 @@
+# flepimop2: The FLExible Pipeline for Interchangeable MOdel Processing
+# Copyright (C) 2026  Carl Pearson, Joshua Macdonald, Timothy Willard
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Tests for `flepimop2.job.abc.JobHandle`."""
+
+from datetime import UTC, datetime
+
+import pytest
+
+from flepimop2.job.abc import JobHandle
+
+
+@pytest.fixture
+def handle() -> JobHandle:
+    """Return a fixed-timestamp JobHandle for use in format tests."""
+    return JobHandle(
+        job_id="42",
+        backend="shell",
+        submitted_at=datetime(2026, 1, 15, 12, 0, 0, tzinfo=UTC),
+    )
+
+
+def test_str_format(handle: JobHandle) -> None:
+    """str() should include the backend, job_id, and submission timestamp."""
+    line = str(handle)
+    assert "shell/42" in line
+    assert "submitted_at=2026-01-15T12:00:00" in line
+
+
+def test_str_is_single_line(handle: JobHandle) -> None:
+    """str() must produce exactly one line (no embedded newlines)."""
+    assert "\n" not in str(handle)
+
+
+def test_metadata_defaults_to_empty_dict() -> None:
+    """Metadata should default to an empty dict, not shared across instances."""
+    h1 = JobHandle(
+        job_id="1",
+        backend="shell",
+        submitted_at=datetime.now(tz=UTC),
+    )
+    h2 = JobHandle(
+        job_id="2",
+        backend="shell",
+        submitted_at=datetime.now(tz=UTC),
+    )
+    h1.metadata["key"] = "value"
+    assert "key" not in h2.metadata
+
+
+def test_metadata_is_stored() -> None:
+    """Metadata passed at construction time should be accessible."""
+    h = JobHandle(
+        job_id="99",
+        backend="slurm",
+        submitted_at=datetime.now(tz=UTC),
+        metadata={"partition": "gpu", "account": "my-alloc"},
+    )
+    assert h.metadata["partition"] == "gpu"
+    assert h.metadata["account"] == "my-alloc"

--- a/tests/job/shell/test_shell_job.py
+++ b/tests/job/shell/test_shell_job.py
@@ -1,0 +1,252 @@
+# flepimop2: The FLExible Pipeline for Interchangeable MOdel Processing
+# Copyright (C) 2026  Carl Pearson, Joshua Macdonald, Timothy Willard
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Tests for `flepimop2.job.shell.ShellJob`."""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from flepimop2.exceptions import Flepimop2ValidationError, ValidationIssue
+from flepimop2.job.abc import JobHandle
+from flepimop2.job.shell import ShellJob
+from flepimop2.typing import ExitCode
+
+_EXE = "/usr/local/bin/flepimop2"
+
+
+def _make_command(argv: list[str]) -> MagicMock:
+    """Return a mock CliCommand whose to_argv() and command_name() are set."""
+    cmd = MagicMock()
+    cmd.command_name.return_value = "simulate"
+    cmd.to_argv.return_value = argv
+    return cmd
+
+
+def test_submit_detached_returns_single_handle() -> None:
+    """Submit in detached mode should return a single JobHandle."""
+    job = ShellJob.model_validate({"module": "flepimop2.job.shell", "detach": True})
+    cmd = _make_command(["--dry-run", "config.yaml"])
+
+    mock_proc = MagicMock()
+    mock_proc.pid = 12345
+
+    with (
+        patch("flepimop2.job.shell.shutil.which", return_value=_EXE),
+        patch("flepimop2.job.shell.subprocess.Popen", return_value=mock_proc),
+    ):
+        handles = job.submit(cmd)
+
+    assert isinstance(handles, JobHandle)
+
+
+def test_submit_detached_uses_pid_as_job_id() -> None:
+    """In detached mode, job_id should be the subprocess PID as a string."""
+    job = ShellJob.model_validate({"module": "flepimop2.job.shell", "detach": True})
+    cmd = _make_command([])
+
+    mock_proc = MagicMock()
+    mock_proc.pid = 99999
+
+    with (
+        patch("flepimop2.job.shell.shutil.which", return_value=_EXE),
+        patch("flepimop2.job.shell.subprocess.Popen", return_value=mock_proc),
+    ):
+        handles = job.submit(cmd)
+
+    assert handles is not None
+    assert handles.job_id == "99999"
+    assert handles.backend == "shell"
+
+
+def test_submit_detached_builds_correct_argv() -> None:
+    """Popen should be called with [exe, command_name, *to_argv()]."""
+    job = ShellJob.model_validate({"module": "flepimop2.job.shell", "detach": True})
+    cmd = _make_command(["--dry-run", "config.yaml"])
+
+    mock_proc = MagicMock()
+    mock_proc.pid = 1
+
+    with (
+        patch("flepimop2.job.shell.shutil.which", return_value=_EXE),
+        patch(
+            "flepimop2.job.shell.subprocess.Popen", return_value=mock_proc
+        ) as mock_popen,
+    ):
+        job.submit(cmd)
+
+    called_argv = mock_popen.call_args[0][0]
+    assert called_argv == [_EXE, "simulate", "--dry-run", "config.yaml"]
+
+
+def test_submit_raises_when_exe_not_found() -> None:
+    """Submit should raise Flepimop2ValidationError when flepimop2 is not on PATH."""
+    job = ShellJob.model_validate({"module": "flepimop2.job.shell", "detach": True})
+    cmd = _make_command([])
+
+    with (
+        patch("flepimop2.job.shell.shutil.which", return_value=None),
+        pytest.raises(Flepimop2ValidationError),
+    ):
+        job.submit(cmd)
+
+
+def test_submit_validate_returns_empty_list_when_exe_found() -> None:
+    """_submit_validate should return [] and cache the exe when found."""
+    job = ShellJob.model_validate({"module": "flepimop2.job.shell"})
+    with patch("flepimop2.job.shell.shutil.which", return_value=_EXE):
+        result = job._submit_validate()
+    assert result == []
+    assert job._exe == _EXE
+
+
+def test_submit_validate_returns_issue_when_exe_missing() -> None:
+    """_submit_validate should return a ValidationIssue when exe not found."""
+    job = ShellJob.model_validate({"module": "flepimop2.job.shell"})
+    with patch("flepimop2.job.shell.shutil.which", return_value=None):
+        result = job._submit_validate()
+    assert result
+    assert isinstance(result[0], ValidationIssue)
+    assert job._exe is None
+
+
+def test_submit_dry_run_returns_none() -> None:
+    """submit(dry_run=True) should validate and return None without submitting."""
+    job = ShellJob.model_validate({"module": "flepimop2.job.shell"})
+    cmd = _make_command([])
+
+    with (
+        patch("flepimop2.job.shell.shutil.which", return_value=_EXE),
+        patch("flepimop2.job.shell.subprocess.Popen") as mock_popen,
+    ):
+        handles = job.submit(cmd, dry_run=True)
+
+    assert handles is None
+    mock_popen.assert_not_called()
+
+
+def test_submit_reuses_cached_exe() -> None:
+    """Submit should not call shutil.which again when _exe is already set."""
+    job = ShellJob.model_validate({"module": "flepimop2.job.shell", "detach": True})
+    job._exe = _EXE
+    cmd = _make_command([])
+
+    mock_proc = MagicMock()
+    mock_proc.pid = 1
+
+    with (
+        patch("flepimop2.job.shell.shutil.which") as mock_which,
+        patch("flepimop2.job.shell.subprocess.Popen", return_value=mock_proc),
+    ):
+        job.submit(cmd)
+
+    mock_which.assert_not_called()
+
+
+def test_submit_detached_starts_new_session() -> None:
+    """Popen must be called with start_new_session=True in detach mode."""
+    job = ShellJob.model_validate({"module": "flepimop2.job.shell", "detach": True})
+    cmd = _make_command([])
+
+    with (
+        patch("flepimop2.job.shell.shutil.which", return_value=_EXE),
+        patch(
+            "flepimop2.job.shell.subprocess.Popen", return_value=MagicMock(pid=1)
+        ) as mock_popen,
+    ):
+        job.submit(cmd)
+
+    assert mock_popen.call_args.kwargs.get("start_new_session") is True
+
+
+def test_submit_detached_passes_cwd_and_env(tmp_path: Path) -> None:
+    """Cwd and env should be forwarded to Popen."""
+    job = ShellJob.model_validate({
+        "module": "flepimop2.job.shell",
+        "detach": True,
+        "cwd": str(tmp_path),
+        "env": {"FLEPIMOP2_ENV": "test"},
+    })
+    cmd = _make_command([])
+
+    with (
+        patch("flepimop2.job.shell.shutil.which", return_value=_EXE),
+        patch(
+            "flepimop2.job.shell.subprocess.Popen", return_value=MagicMock(pid=1)
+        ) as mock_popen,
+    ):
+        job.submit(cmd)
+
+    kwargs = mock_popen.call_args.kwargs
+    assert kwargs["cwd"] == tmp_path
+    assert kwargs["env"] == {"FLEPIMOP2_ENV": "test"}
+
+
+def test_submit_synchronous_returns_single_handle() -> None:
+    """Submit in synchronous mode should also return a `JobHandle`."""
+    job = ShellJob.model_validate({"module": "flepimop2.job.shell", "detach": False})
+    cmd = _make_command([])
+
+    mock_result = MagicMock()
+    mock_result.returncode = 0
+
+    with (
+        patch("flepimop2.job.shell.shutil.which", return_value=_EXE),
+        patch("flepimop2.job.shell.subprocess.run", return_value=mock_result),
+    ):
+        handles = job.submit(cmd)
+
+    assert isinstance(handles, JobHandle)
+
+
+def test_submit_synchronous_uses_returncode_as_job_id() -> None:
+    """In synchronous mode, job_id should be the returncode as a string."""
+    job = ShellJob.model_validate({"module": "flepimop2.job.shell", "detach": False})
+    cmd = _make_command([])
+
+    mock_result = MagicMock()
+    mock_result.returncode = ExitCode.OKAY
+
+    with (
+        patch("flepimop2.job.shell.shutil.which", return_value=_EXE),
+        patch("flepimop2.job.shell.subprocess.run", return_value=mock_result),
+    ):
+        handles = job.submit(cmd)
+
+    assert handles is not None
+    assert handles.job_id == str(int(ExitCode.OKAY))
+    assert handles.backend == "shell"
+
+
+def test_submit_synchronous_does_not_use_popen() -> None:
+    """Synchronous mode must use subprocess.run, not Popen."""
+    job = ShellJob.model_validate({"module": "flepimop2.job.shell", "detach": False})
+    cmd = _make_command([])
+
+    mock_result = MagicMock()
+    mock_result.returncode = 0
+
+    with (
+        patch("flepimop2.job.shell.shutil.which", return_value=_EXE),
+        patch(
+            "flepimop2.job.shell.subprocess.run", return_value=mock_result
+        ) as mock_run,
+        patch("flepimop2.job.shell.subprocess.Popen") as mock_popen,
+    ):
+        job.submit(cmd)
+
+    mock_run.assert_called_once()
+    mock_popen.assert_not_called()


### PR DESCRIPTION
## Description

Added the `JobABC` module type that consumes `CliCommand`s and then runs
them in a separate environment, with future use cases including HPC
environments like on slurm. Also added `jobs` top level configuration
key to correspond to this new module type and the `ShellJob` class that
just launches the command in a subprocess as an example/simple way to
introduce users to jobs.

## Related issues

Closes #276. Closes #277. Closes #278.

## Checklist

- [x] I have read through and understand the [pull request process](https://github.com/ACCIDDA/flepimop2?tab=contributing-ov-file#pull-request-process).
- [x] I ran successfully ran CI local via `just ci`.
- [x] I have updated the `CHANGELOG.md` or noted "no major changes" in my commit if the PR is small.
