### PR TITLE
Add `flepimop2 job` CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added help text for CLI arguments that are formatted similarly to click's default formatting for options.
 - Added optional shorthand module configuration support across all module namespaces, allowing config values such as `fixed(0.3)` for modules that implement `from_shorthand`. See [#14](https://github.com/ACCIDDA/flepimop2/issues/14).
 - Added `ConfigurationModel/ModuleBase.patch` method to merge configurations together along with corresponding `flepimop2 patch` CLI for users to utilizing patching via the command line as well as YAML formatting. See [#51](https://github.com/ACCIDDA/flepimop2/issues/51), [#52](https://github.com/ACCIDDA/flepimop2/issues/52), [#289](https://github.com/ACCIDDA/flepimop2/pull/289).
-- Introduced the `JobABC` to execute CLI commands in separate environments along with corresponding "jobs" top level key in configuration and the `ShellJob` module to run a CLI in a subprocess. See [#276](https://github.com/ACCIDDA/flepimop2/issues/276), [#277](https://github.com/ACCIDDA/flepimop2/issues/277), [#278](https://github.com/ACCIDDA/flepimop2/issues/278).
+- Introduced the `JobABC` to execute CLI commands in separate environments along with corresponding "jobs" top level key in configuration and the `ShellJob` module to run a CLI in a subprocess. Job modules can be utilized by end users via the `flepimop2 job` CLI. See [#276](https://github.com/ACCIDDA/flepimop2/issues/276), [#277](https://github.com/ACCIDDA/flepimop2/issues/277), [#278](https://github.com/ACCIDDA/flepimop2/issues/278), [#280](https://github.com/ACCIDDA/flepimop2/issues/280).
 
 ### Changed
 

--- a/docs/assets/batch-jobs-guide/configs/config.yaml
+++ b/docs/assets/batch-jobs-guide/configs/config.yaml
@@ -1,0 +1,36 @@
+---
+engines:
+  - module: wrapper
+    state_change: flow
+    script: model_input/plugins/solve_ivp.py
+systems:
+  - module: wrapper
+    state_change: flow
+    script: model_input/plugins/SIR.py
+    model_state:
+      parameter_names:
+        - s0
+        - i0
+        - r0
+      labels:
+        - S
+        - I
+        - R
+backends:
+  - module: csv
+    root: model_output
+jobs:
+  - module: shell
+    detach: false
+parameters:
+  s0: 990.0
+  i0: 10.0
+  r0: 0.0
+  beta: 0.3
+  gamma: 0.1
+simulate:
+  demo:
+    engine: default
+    system: default
+    backend: default
+    times: 0.0:1.0:60.0

--- a/docs/assets/batch-jobs-guide/configs/extra-jobs.yaml
+++ b/docs/assets/batch-jobs-guide/configs/extra-jobs.yaml
@@ -1,0 +1,40 @@
+---
+engines:
+  - module: wrapper
+    state_change: flow
+    script: model_input/plugins/solve_ivp.py
+systems:
+  - module: wrapper
+    state_change: flow
+    script: model_input/plugins/SIR.py
+    model_state:
+      parameter_names:
+        - s0
+        - i0
+        - r0
+      labels:
+        - S
+        - I
+        - R
+backends:
+  - module: csv
+    root: model_output
+jobs:
+  local:
+    module: shell
+    detach: false
+  detached_local:
+    module: shell
+    detach: true
+parameters:
+  s0: 990.0
+  i0: 10.0
+  r0: 0.0
+  beta: 0.3
+  gamma: 0.1
+simulate:
+  demo:
+    engine: default
+    system: default
+    backend: default
+    times: 0.0:1.0:60.0

--- a/docs/assets/batch-jobs-guide/model_input/plugins/SIR.py
+++ b/docs/assets/batch-jobs-guide/model_input/plugins/SIR.py
@@ -1,0 +1,1 @@
+../../../quickstart-project/model_input/plugins/SIR.py

--- a/docs/assets/batch-jobs-guide/model_input/plugins/solve_ivp.py
+++ b/docs/assets/batch-jobs-guide/model_input/plugins/solve_ivp.py
@@ -1,0 +1,1 @@
+../../../quickstart-project/model_input/plugins/solve_ivp.py

--- a/docs/guides/batch-jobs.md
+++ b/docs/guides/batch-jobs.md
@@ -1,0 +1,131 @@
+# Batch Jobs
+
+This guide shows how to use `flepimop2 job` to dispatch a `simulate` or `process` command to a configured job backend instead of executing it locally. The core idea is simple: rather than running the command directly, you describe *where* to run it in the `jobs` section of your configuration file, then call `flepimop2 job <subcommand>` in place of the subcommand alone.
+
+This guide uses the built-in `shell` job module throughout. The `shell` module is intended for **local testing and debugging only** - it simply spawns a subprocess on the same machine. For real-world workloads you should use a job module suited to your computing environment (for example, one that submits to a Slurm cluster or an HPC queue). The `shell` module is a useful starting point because it requires no external infrastructure: you can confirm that the job plumbing works end-to-end before connecting it to a remote backend.
+
+## 1. Start from the Example Bundle
+
+Download [batch-jobs-guide.zip](../downloads/batch-jobs-guide.zip), unzip it, and enter the project:
+
+```bash
+unzip batch-jobs-guide.zip
+cd batch-jobs-guide
+```
+
+Then create and activate the environment:
+
+```bash
+just venv
+conda activate ./venv
+```
+
+The bundle already includes the wrapper-based SIR model from the quickstart example, a scipy engine plugin, and a ready-to-run configuration with a `shell` job backend.
+
+## 2. Add a `jobs` Block to Your Configuration
+
+A job backend is defined in the top-level `jobs` section, alongside `engines`, `systems`, and `backends`. The simplest form is a single unnamed entry, which flepimop2 selects automatically when no target is specified:
+
+```yaml
+jobs:
+- module: shell
+  detach: false
+```
+
+The `shell` module accepts two optional fields:
+
+| Field | Default | Description |
+|---|---|---|
+| `detach` | `true` | If `true`, the subprocess runs detached in a new session and control returns immediately. If `false`, the call blocks until the subprocess exits. |
+| `cwd` | *(inherit)* | Working directory for the subprocess. |
+| `env` | *(inherit)* | Environment variables for the subprocess. If omitted, the current process environment is inherited. |
+
+Setting `detach: false` is recommended during testing so that output appears inline and the command does not return until the job finishes.
+
+## 3. A Minimal Configuration
+
+Below is a complete, self-contained configuration that includes both a simulation target and a job entry:
+
+```yaml
+--8<-- "assets/batch-jobs-guide/configs/config.yaml"
+```
+
+## 4. Run the Command via `flepimop2 job`
+
+To dispatch the `simulate` command through the configured job backend instead of running it directly, prefix the subcommand with `flepimop2 job`:
+
+```bash
+# Direct execution (runs locally, as before)
+flepimop2 simulate -vv configs/config.yaml
+
+# Dispatched through the job backend
+flepimop2 job simulate -vv configs/config.yaml
+```
+
+Both commands produce the same result with the `shell` module. The difference is that `flepimop2 job simulate` builds a `SimulateCommand` instance, hands it to the configured job backend, and the backend re-invokes `flepimop2 simulate` as a subprocess rather than running the simulation inline.
+
+When the job is submitted, `flepimop2 job` prints a handle that identifies the submitted work unit:
+
+```text
+2026-05-26 16:56:24,480:INFO> Job submitted: shell/0 submitted_at=2026-05-26T20:56:24.
+```
+
+The token before the `/` is the backend name; the token after is the job identifier (a PID for the `shell` module). More capable backends replace the PID with their own opaque identifier (a Slurm job id, an AWS Batch ARN, etc.).
+
+## 5. Select a Named Job Target
+
+If your configuration defines more than one job backend you can give each a name and select among them with `-j` / `--job-target`:
+
+```yaml
+jobs:
+  local:
+    module: shell
+    detach: false
+  detached_local:
+    module: shell
+    detach: true
+```
+
+```bash
+# Use the 'detached_local' entry
+flepimop2 job simulate --job-target detached_local configs/extra-jobs.yaml
+```
+
+When exactly one job backend is defined (including the list shorthand form), `-j` can be omitted and the default entry is used automatically.
+
+## 6. Combine with Inner Command Options
+
+All options accepted by the inner command (`simulate` or `process`) work normally when dispatched through `flepimop2 job`. The `--target` flag, for example, selects the simulation target as usual:
+
+```bash
+flepimop2 job simulate --target hires configs/config.yaml
+flepimop2 job simulate --job-target local --target hires configs/config.yaml
+```
+
+## 7. Validate with `--dry-run`
+
+The `--dry-run` flag runs the job backend's preflight checks — for example, verifying that the `flepimop2` executable is on `PATH` — without actually submitting anything. The inner command is never executed:
+
+```bash
+flepimop2 job simulate -vvv --dry-run configs/config.yaml
+```
+
+Example output:
+
+```text
+2026-05-26 16:59:43,433:INFO> Job backend: flepimop2.job.shell.
+2026-05-26 16:59:43,433:INFO> Command: simulate /Users/twillard/Downloads/batch-jobs-guide/configs/config.yaml --dry-run -vvv.
+2026-05-26 16:59:43,433:INFO> Dry run: preflight checks only, no submission.
+```
+
+Without `--dry-run`, the same `-v` output appears before the job handle is printed, letting you verify the backend and reconstructed command on every real submission too.
+
+## 8. Summary
+
+- Add a `jobs:` block to your configuration file to define one or more job backends.
+- Replace `flepimop2 <subcommand>` with `flepimop2 job <subcommand>` to dispatch through a backend.
+- Use `-j` / `--job-target` to select a named backend when more than one is defined.
+- Use `--dry-run` to validate the job setup without submitting.
+- The `shell` module is the right tool for local testing; use a purpose-built module for remote or production workloads.
+
+For a full list of options run `flepimop2 job --help` or see the [CLI reference](../reference/cli.md#flepimop2-job).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -76,6 +76,7 @@ nav:
       - Vaccination Campaign Scenario Grid: guides/vaccination-campaign-scenario-grid-example.md
       - Generating Scenario Results: guides/scenarios.md
       - Modular Configuration: guides/modular-configuration.md
+      - Batch Jobs: guides/batch-jobs.md
   - Development:
       - Contributing: development/contributing.md
       - Creating An External Provider Package: development/creating-an-external-provider-package.md
@@ -93,6 +94,7 @@ nav:
           - Configuration: reference/api/configuration.md
           - Engine: reference/api/engine.md
           - Exceptions: reference/api/exceptions.md
+          - Job: reference/api/job.md
           - Meta: reference/api/meta.md
           - Module: reference/api/module.md
           - Parameter: reference/api/parameter.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,9 +82,9 @@ orcid = "0009-0001-2486-7931"
 
 [tool.pytest.ini_options]
 testpaths = [
-    "docs/",
-    "src",
+    "src/flepimop2/",
     "tests/",
+    "docs/",
 ]
 addopts = [
     "--import-mode=importlib",

--- a/src/flepimop2/_cli/_cli.py
+++ b/src/flepimop2/_cli/_cli.py
@@ -23,6 +23,7 @@ import click
 
 from flepimop2._cli._build_command import BuildCommand
 from flepimop2._cli._format_command import FormatCommand
+from flepimop2._cli._job_command import job_group
 from flepimop2._cli._patch_command import PatchCommand
 from flepimop2._cli._process_command import ProcessCommand
 from flepimop2._cli._register_command import register_command
@@ -48,3 +49,6 @@ register_command(PatchCommand, cli)
 register_command(ProcessCommand, cli)
 register_command(SimulateCommand, cli)
 register_command(SkeletonCommand, cli)
+
+# Register subgroups
+cli.add_command(job_group)

--- a/src/flepimop2/_cli/_job_command.py
+++ b/src/flepimop2/_cli/_job_command.py
@@ -1,0 +1,76 @@
+# flepimop2: The FLExible Pipeline for Interchangeable MOdel Processing
+# Copyright (C) 2026  Carl Pearson, Joshua Macdonald, Timothy Willard
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""The `flepimop2 job` subcommand group."""
+
+__all__ = ["job_group"]
+
+import sys
+from typing import Any
+
+import click
+
+from flepimop2._cli._cli_command import CliCommand
+from flepimop2._cli._logging import get_script_logger
+from flepimop2._cli._process_command import ProcessCommand
+from flepimop2._cli._register_command import register_command
+from flepimop2._cli._simulate_command import SimulateCommand
+from flepimop2._utils._click import _get_config_target
+from flepimop2.configuration import ConfigurationModel
+from flepimop2.job.abc import build as build_job
+
+
+@click.group(name="job")
+def job_group() -> None:
+    """Dispatch a flepimop2 command to a configured job backend."""
+
+
+def _dispatch_to_job(inner: CliCommand, job_kwargs: dict[str, Any]) -> None:
+    verbosity: int = int(inner.bound_kwargs.get("verbosity", 0))
+    logger = get_script_logger(__name__, verbosity)
+
+    config_path = inner.bound_kwargs.get("config")
+    if config_path is None:
+        click.echo("Error: no config path available on the command.", err=True)
+        sys.exit(1)
+
+    config_model = ConfigurationModel.from_yaml(config_path)
+    job_target = job_kwargs.get("job_target")
+    job = build_job(_get_config_target(config_model.jobs, job_target, "job"))
+    dry_run: bool = bool(inner.bound_kwargs.get("dry_run", False))
+
+    logger.info("Job backend: %s", job.module)
+    logger.info("Command: %s %s", inner.command_name(), " ".join(inner.to_argv()))
+    if dry_run:
+        logger.info("Dry run: preflight checks only, no submission.")
+
+    handle = job.submit(inner, dry_run=dry_run)
+    if handle is not None:
+        logger.info("Job submitted: %s", handle)
+    sys.exit(0)
+
+
+register_command(
+    ProcessCommand,
+    job_group,
+    extra_options=("job_target",),
+    on_invoke=_dispatch_to_job,
+)
+register_command(
+    SimulateCommand,
+    job_group,
+    extra_options=("job_target",),
+    on_invoke=_dispatch_to_job,
+)

--- a/src/flepimop2/_cli/_options.py
+++ b/src/flepimop2/_cli/_options.py
@@ -185,6 +185,15 @@ COMMON_OPTIONS: Final[dict[str, CommonOptionEntry]] = {
         ),
         None,
     ),
+    "job_target": (
+        click.option(
+            "-j",
+            "--job-target",
+            default=None,
+            help="The configured job module to dispatch this command to.",
+        ),
+        None,
+    ),
     "output": (
         click.option(
             "-o",

--- a/src/flepimop2/_cli/_register_command.py
+++ b/src/flepimop2/_cli/_register_command.py
@@ -13,6 +13,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+from collections.abc import Callable, Sequence
 from typing import Any
 
 import click
@@ -38,7 +39,13 @@ class _ArgumentHelpCommand(click.Command):
         super().format_options(ctx, formatter)
 
 
-def register_command(command_cls: type[CliCommand], group: Group) -> None:
+def register_command(
+    command_cls: type[CliCommand],
+    group: Group,
+    *,
+    extra_options: Sequence[str] = (),
+    on_invoke: Callable[[CliCommand, dict[str, Any]], None] | None = None,
+) -> None:
     """
     Register a `CliCommand` subclass as a Click command.
 
@@ -50,23 +57,30 @@ def register_command(command_cls: type[CliCommand], group: Group) -> None:
     Args:
         command_cls: A `CliCommand` subclass to register.
         group: The click `Group` to register the command with.
+        extra_options: Additional option names (from `COMMON_OPTIONS`) to
+            prepend before the command's own options. These are extracted from
+            `kwargs` before the command instance is constructed and passed to
+            `on_invoke` as a separate dict.
+        on_invoke: Optional callback invoked instead of `command_instance()`.
+            Receives the constructed command instance and a dict of the extra
+            kwargs extracted from `extra_options`.
     """
 
-    # Create a wrapper function that instantiates and runs the command
     def command_wrapper(**kwargs: Any) -> None:
+        extra_kwargs = {k: kwargs.pop(k) for k in extra_options if k in kwargs}
         command_instance = command_cls(**kwargs)
-        command_instance()
+        if on_invoke is not None:
+            on_invoke(command_instance, extra_kwargs)
+        else:
+            command_instance()
 
-    # Set the function name and docstring for Click
     command_name = command_cls.command_name()
     command_wrapper.__name__ = command_name
     command_wrapper.__doc__ = command_cls.help_text()
 
-    # Apply the options/arguments in reverse order
-    # (Click decorators are applied bottom-up)
-    for option_name in reversed(command_cls.options()):
+    all_options = [*extra_options, *command_cls.options()]
+    for option_name in reversed(all_options):
         option_decorator = get_option(option_name)
         command_wrapper = option_decorator(command_wrapper)
 
-    # Register the command with the CLI group
     group.command(name=command_name, cls=_ArgumentHelpCommand)(command_wrapper)

--- a/tests/_cli/_register_command/test_register_command.py
+++ b/tests/_cli/_register_command/test_register_command.py
@@ -300,3 +300,48 @@ def test_non_existent_option_raises_key_error() -> None:
         match=r"Unknown option 'non_existent_option'. Available options: .*",
     ):
         register_command(MockCommandWithNonExistentOption, click.Group())
+
+
+def test_extra_options_appear_before_command_options() -> None:
+    """Extra options should be present on the registered command."""
+    test_cli = click.Group()
+    register_command(MockCommand, test_cli, extra_options=("job_target",))
+    param_names = [p.name for p in test_cli.commands["mock"].params]
+    assert "job_target" in param_names
+    assert param_names.index("job_target") < param_names.index("dry_run")
+
+
+def test_extra_options_are_not_passed_to_command_instance() -> None:
+    """Extra kwargs should be stripped before constructing the command."""
+    captured_instance_kwargs: dict[str, object] = {}
+    captured_extra_kwargs: dict[str, object] = {}
+
+    def capture_invoke(instance: CliCommand, extra_kwargs: dict[str, object]) -> None:
+        captured_instance_kwargs.update(instance.bound_kwargs)
+        captured_extra_kwargs.update(extra_kwargs)
+
+    test_cli = click.Group()
+    register_command(
+        MockCommand,
+        test_cli,
+        extra_options=("job_target",),
+        on_invoke=capture_invoke,
+    )
+    runner = CliRunner()
+    runner.invoke(test_cli.commands["mock"], ["-j", "my_job", "--dry-run"])
+    assert "job_target" not in captured_instance_kwargs
+    assert captured_extra_kwargs.get("job_target") == "my_job"
+
+
+def test_on_invoke_is_called_instead_of_command_call() -> None:
+    """When on_invoke is given, it should be called rather than command_instance()."""
+    on_invoke_called = {"called": False}
+
+    def my_invoke(_instance: CliCommand, _extra_kwargs: dict[str, object]) -> None:
+        on_invoke_called["called"] = True
+
+    test_cli = click.Group()
+    register_command(MockCommand, test_cli, on_invoke=my_invoke)
+    runner = CliRunner()
+    runner.invoke(test_cli.commands["mock"], ["--dry-run"])
+    assert on_invoke_called["called"] is True

--- a/tests/_cli/test_job_command.py
+++ b/tests/_cli/test_job_command.py
@@ -1,0 +1,186 @@
+# flepimop2: The FLExible Pipeline for Interchangeable MOdel Processing
+# Copyright (C) 2026  Carl Pearson, Joshua Macdonald, Timothy Willard
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Tests for the `flepimop2 job` CLI group."""
+
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from flepimop2._cli._job_command import job_group
+from flepimop2._cli._simulate_command import SimulateCommand
+from flepimop2.job.abc import JobHandle
+
+
+def _make_minimal_config(config_path: Path, job_name: str = "local") -> None:
+    """Write a minimal config YAML with one shell job entry."""
+    config_path.write_text(
+        f"jobs:\n  {job_name}:\n    module: shell\n    detach: false\n",
+        encoding="utf-8",
+    )
+
+
+def test_job_simulate_dispatches_to_job_backend(tmp_path: Path) -> None:
+    """Invoking `job simulate` should call job.submit(inner_command)."""
+    config_path = tmp_path / "config.yaml"
+    _make_minimal_config(config_path)
+
+    mock_handle = JobHandle(
+        job_id="12345",
+        backend="shell",
+        submitted_at=datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC),
+    )
+    mock_job = MagicMock()
+    mock_job.submit.return_value = mock_handle
+
+    runner = CliRunner()
+    with (
+        patch("flepimop2._cli._job_command.build_job", return_value=mock_job),
+        patch("flepimop2._cli._job_command.ConfigurationModel.from_yaml") as mock_load,
+    ):
+        mock_config = MagicMock()
+        mock_config.jobs = {"local": {"module": "shell", "detach": False}}
+        mock_load.return_value = mock_config
+
+        result = runner.invoke(
+            job_group,
+            ["simulate", str(config_path)],
+        )
+
+    assert mock_job.submit.called
+    assert result.exit_code == 0
+
+
+def test_job_simulate_inner_command_not_executed_locally(tmp_path: Path) -> None:
+    """The inner SimulateCommand.run() must NOT be called when dispatched via job."""
+    config_path = tmp_path / "config.yaml"
+    _make_minimal_config(config_path)
+
+    mock_job = MagicMock()
+    mock_job.submit.return_value = JobHandle(
+        job_id="1",
+        backend="shell",
+        submitted_at=datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC),
+    )
+
+    runner = CliRunner()
+    with (
+        patch("flepimop2._cli._job_command.build_job", return_value=mock_job),
+        patch("flepimop2._cli._job_command.ConfigurationModel.from_yaml") as mock_load,
+        patch("flepimop2._cli._simulate_command.SimulateCommand.run") as mock_run,
+    ):
+        mock_config = MagicMock()
+        mock_config.jobs = {"local": {"module": "shell", "detach": False}}
+        mock_load.return_value = mock_config
+
+        runner.invoke(job_group, ["simulate", str(config_path)])
+
+    mock_run.assert_not_called()
+
+
+def test_job_simulate_passes_inner_command_to_submit(tmp_path: Path) -> None:
+    """The CliCommand instance handed to submit should be a SimulateCommand."""
+    config_path = tmp_path / "config.yaml"
+    _make_minimal_config(config_path)
+
+    captured: dict[str, object] = {}
+    mock_handle = JobHandle(
+        job_id="1",
+        backend="shell",
+        submitted_at=datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC),
+    )
+
+    def capture_submit(cmd: object, **_kwargs: object) -> object:
+        captured["cmd"] = cmd
+        return mock_handle
+
+    mock_job = MagicMock()
+    mock_job.submit.side_effect = capture_submit
+
+    runner = CliRunner()
+    with (
+        patch("flepimop2._cli._job_command.build_job", return_value=mock_job),
+        patch("flepimop2._cli._job_command.ConfigurationModel.from_yaml") as mock_load,
+    ):
+        mock_config = MagicMock()
+        mock_config.jobs = {"local": {"module": "shell", "detach": False}}
+        mock_load.return_value = mock_config
+
+        runner.invoke(job_group, ["simulate", str(config_path)])
+
+    assert isinstance(captured.get("cmd"), SimulateCommand)
+
+
+def test_job_simulate_submits_and_produces_handle(tmp_path: Path) -> None:
+    """`flepimop2 job simulate` should call submit and receive a JobHandle."""
+    config_path = tmp_path / "config.yaml"
+    _make_minimal_config(config_path)
+
+    handle = JobHandle(
+        job_id="99999",
+        backend="shell",
+        submitted_at=datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC),
+    )
+    mock_job = MagicMock()
+    mock_job.submit.return_value = handle
+
+    runner = CliRunner()
+    with (
+        patch("flepimop2._cli._job_command.build_job", return_value=mock_job),
+        patch("flepimop2._cli._job_command.ConfigurationModel.from_yaml") as mock_load,
+    ):
+        mock_config = MagicMock()
+        mock_config.jobs = {"local": {"module": "shell", "detach": False}}
+        mock_load.return_value = mock_config
+
+        result = runner.invoke(job_group, ["simulate", str(config_path)])
+
+    assert result.exit_code == 0
+    mock_job.submit.assert_called_once()
+    submitted_handle = mock_job.submit.call_args[0][0]
+    assert isinstance(submitted_handle, SimulateCommand)
+
+
+def test_job_target_option_selects_named_job(tmp_path: Path) -> None:
+    """-j / --job-target on the subcommand should resolve the named job entry."""
+    config_path = tmp_path / "config.yaml"
+    _make_minimal_config(config_path, job_name="cluster")
+
+    mock_job = MagicMock()
+    mock_job.submit.return_value = JobHandle(
+        job_id="1",
+        backend="shell",
+        submitted_at=datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC),
+    )
+
+    runner = CliRunner()
+    with (
+        patch("flepimop2._cli._job_command.build_job", return_value=mock_job),
+        patch("flepimop2._cli._job_command.ConfigurationModel.from_yaml") as mock_load,
+        patch("flepimop2._cli._job_command._get_config_target") as mock_target,
+    ):
+        mock_config = MagicMock()
+        mock_config.jobs = {"cluster": {"module": "shell"}}
+        mock_load.return_value = mock_config
+        mock_target.return_value = mock_config.jobs["cluster"]
+
+        runner.invoke(
+            job_group,
+            ["simulate", "-j", "cluster", str(config_path)],
+        )
+
+    mock_target.assert_called_once_with(mock_config.jobs, "cluster", "job")

--- a/tests/integration/documentation_batch_jobs/test_batch_jobs.py
+++ b/tests/integration/documentation_batch_jobs/test_batch_jobs.py
@@ -1,0 +1,53 @@
+# flepimop2: The FLExible Pipeline for Interchangeable MOdel Processing
+# Copyright (C) 2026  Carl Pearson, Joshua Macdonald, Timothy Willard
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Integration test for the batch-jobs guide."""
+
+from pathlib import Path
+
+from flepimop2.testing import flepimop2_run, project_skeleton
+
+
+def test_batch_jobs_guide(repo_root: Path, tmp_path: Path) -> None:
+    """
+    Run `flepimop2 job simulate` with the shell backend from the batch-jobs guide.
+
+    This verifies that the guide's config and CLI invocation remain functional.
+    """
+    asset_root = repo_root / "docs/assets/batch-jobs-guide"
+
+    project_skeleton(
+        tmp_path,
+        copy_files={
+            asset_root / "configs/config.yaml": Path("configs/config.yaml"),
+            asset_root / "model_input/plugins/SIR.py": Path(
+                "model_input/plugins/SIR.py"
+            ),
+            asset_root / "model_input/plugins/solve_ivp.py": Path(
+                "model_input/plugins/solve_ivp.py"
+            ),
+        },
+        dependencies=["scipy"],
+    )
+
+    result = flepimop2_run(
+        "job",
+        args=["simulate", "configs/config.yaml"],
+        cwd=tmp_path,
+    )
+    assert result.returncode == 0
+
+    output_files = list((tmp_path / "model_output").glob("*.csv"))
+    assert len(output_files) == 1


### PR DESCRIPTION
## Description

Added the `flepimop2 job` CLI subgroup with `flepimop2 job process` and
`flepimop2 job simulate` subcommands. This CLI command allows a user to
utilize job modules to run a process/simulate command in a remote
environment. Also added a "Batch Jobs" guide to the documentation to
introduce the concept to users with the `ShellJob` module bundled with
`flepimop2`.

## Related issues

Closes #280.

Stacked on #294.

## Checklist

- [x] I have read through and understand the [pull request process](https://github.com/ACCIDDA/flepimop2?tab=contributing-ov-file#pull-request-process).
- [x] I ran successfully ran CI local via `just ci`.
- [x] I have updated the `CHANGELOG.md` or noted "no major changes" in my commit if the PR is small.
