### PR TITLE
Add note to `CONTRIBUTING.md` about testing assets

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,12 +61,13 @@ Run `just` to automatically format/lint, type check, and run tests before commit
 
 ### Organization
 
-Tests are organized to mirror the source code structure:
+Tests are organized to mirror the source code structure with additional assets for a test file being placed in a directory suffixed with `_assets` to avoid aliasing issues:
 
 ```
 tests/
 |-- {module}/
 |   |-- {submodule}/
+|   |   |-- {function}_assets/     # Assets for a particular test file
 |   |   |-- test_{function}.py     # Tests for individual functions
 |   |   |-- test_{class}_class.py  # Tests for classes
 |   |-- test_{function}.py
@@ -78,6 +79,7 @@ tests/
 - `tests/logging/test_click_handler_class.py` - Tests for the `ClickHandler` class.
 - `tests/_cli/_options/test_get_option.py` - Tests for the `get_option` function.
 - `tests/configuration/test_fixed_parameter_specification_model_class.py` - Tests for the `FixedParameterSpecificationModel` class.
+- `tests/engine/engine_wrapper_assets/` - Additional test assets, configuration files or external code, that are needed by `tests/engine/test_engine_wrapper.py`.
 
 ### Running Tests
 


### PR DESCRIPTION
## Description

Add note to `CONTRIBUTING.md` about testing assets. No major changes.

## Related issues

Closes #204. No major changes.

## Checklist

- [x] I have read through and understand the [pull request process](https://github.com/ACCIDDA/flepimop2?tab=contributing-ov-file#pull-request-process).
- [x] I ran successfully ran CI local via `just ci`.
- [x] I have updated the `CHANGELOG.md` or noted "no major changes" in my commit if the PR is small.
