### PR TITLE
Create public `flepimop2.yaml` module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added optional shorthand module configuration support across all module namespaces, allowing config values such as `fixed(0.3)` for modules that implement `from_shorthand`. See [#14](https://github.com/ACCIDDA/flepimop2/issues/14).
 - Added `ConfigurationModel/ModuleBase.patch` method to merge configurations together along with corresponding `flepimop2 patch` CLI for users to utilizing patching via the command line as well as YAML formatting. See [#51](https://github.com/ACCIDDA/flepimop2/issues/51), [#52](https://github.com/ACCIDDA/flepimop2/issues/52), [#289](https://github.com/ACCIDDA/flepimop2/pull/289).
 - Introduced the `JobABC` to execute CLI commands in separate environments along with corresponding "jobs" top level key in configuration and the `ShellJob` module to run a CLI in a subprocess. Job modules can be utilized by end users via the `flepimop2 job` CLI. See [#276](https://github.com/ACCIDDA/flepimop2/issues/276), [#277](https://github.com/ACCIDDA/flepimop2/issues/277), [#278](https://github.com/ACCIDDA/flepimop2/issues/278), [#280](https://github.com/ACCIDDA/flepimop2/issues/280).
+- Added a public module, `flepimop2.yaml`, moved from a private module that contains functionality for YAML formatting and interactions.
 
 ### Changed
 

--- a/docs/development/customizing-module-appearances.md
+++ b/docs/development/customizing-module-appearances.md
@@ -35,7 +35,7 @@ An instance like `DemoParameter(values=(0.1, 0.2, 0.3))` will serialize its fiel
 Use `super().to_yaml_data()` as your starting point, then replace individual fields with the structure you want users to see:
 
 ```python
-from flepimop2.configuration import yaml_mapping, yaml_sequence
+from flepimop2.yaml import yaml_mapping, yaml_sequence
 from flepimop2.parameter.abc import ParameterABC
 
 
@@ -77,7 +77,7 @@ metadata: {kind: demo}
 Flow style is usually best for short, simple values. For more complex nested data, developers can keep block style explicitly:
 
 ```python
-from flepimop2.configuration import yaml_mapping, yaml_sequence
+from flepimop2.yaml import yaml_mapping, yaml_sequence
 from flepimop2.parameter.abc import ParameterABC
 
 

--- a/src/flepimop2/configuration/__init__.py
+++ b/src/flepimop2/configuration/__init__.py
@@ -26,9 +26,6 @@ __all__ = [
     "ParameterConfigurationValue",
     "ParameterGroupModel",
     "SimulateSpecificationModel",
-    "YamlSerializableBaseModel",
-    "yaml_mapping",
-    "yaml_sequence",
 ]
 
 from flepimop2.configuration._axes import (
@@ -45,8 +42,3 @@ from flepimop2.configuration._module import (
     ParameterGroupModel,
 )
 from flepimop2.configuration._simulate import SimulateSpecificationModel
-from flepimop2.configuration._yaml import (
-    YamlSerializableBaseModel,
-    yaml_mapping,
-    yaml_sequence,
-)

--- a/src/flepimop2/configuration/_configuration.py
+++ b/src/flepimop2/configuration/_configuration.py
@@ -24,9 +24,9 @@ from flepimop2._utils._dict import _deep_merge_dicts
 from flepimop2.configuration._axes import AxesGroupModel
 from flepimop2.configuration._module import ModuleGroupModel, ParameterGroupModel
 from flepimop2.configuration._simulate import SimulateSpecificationModel
-from flepimop2.configuration._yaml import YamlSerializableBaseModel
 from flepimop2.module import ModuleBase
 from flepimop2.typing import IdentifierString, PatchConflictMode
+from flepimop2.yaml import YamlSerializableBaseModel
 
 _CONFIGURATION_SECTION_ORDER: Final[tuple[str, ...]] = (
     "name",

--- a/src/flepimop2/configuration/_simulate.py
+++ b/src/flepimop2/configuration/_simulate.py
@@ -16,8 +16,8 @@
 from pydantic import BaseModel, ConfigDict, Field
 
 from flepimop2._utils._pydantic import RangeSpec, _to_np_array
-from flepimop2.configuration._yaml import _model_to_yaml_mapping
 from flepimop2.typing import Float64NDArray, IdentifierString
+from flepimop2.yaml import _model_to_yaml_mapping
 
 
 class SimulateSpecificationModel(BaseModel):

--- a/src/flepimop2/module.py
+++ b/src/flepimop2/module.py
@@ -23,8 +23,8 @@ from typing import Any, ClassVar, Literal, Self, cast
 from pydantic import BaseModel, ConfigDict, Field
 
 from flepimop2._utils._dict import _deep_merge_dicts
-from flepimop2.configuration._yaml import _model_to_yaml_mapping
 from flepimop2.typing import PatchConflictMode, RaiseOnMissing, RaiseOnMissingType
+from flepimop2.yaml import _model_to_yaml_mapping
 
 
 class ModuleBase(BaseModel):

--- a/src/flepimop2/yaml.py
+++ b/src/flepimop2/yaml.py
@@ -13,6 +13,17 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""YAML serialization helpers and flow-style wrappers for flepimop2."""
+
+__all__ = [
+    "Flepimop2YamlDumper",
+    "YamlFormattedMapping",
+    "YamlFormattedSequence",
+    "YamlSerializableBaseModel",
+    "yaml_mapping",
+    "yaml_sequence",
+]
+
 from collections import UserDict, UserList
 from collections.abc import Iterable, Mapping
 from pathlib import Path
@@ -49,6 +60,7 @@ class YamlFormattedSequence(UserList[T]):
         *,
         flow_style: bool | None = None,
     ) -> None:
+        """Initialize the sequence wrapper with optional flow-style metadata."""
         super().__init__(values)
         self.flow_style = flow_style
 
@@ -73,6 +85,7 @@ class YamlFormattedMapping(UserDict[K, V]):
         *,
         flow_style: bool | None = None,
     ) -> None:
+        """Initialize the mapping wrapper with optional flow-style metadata."""
         super().__init__(values)
         self.flow_style = flow_style
 

--- a/tests/module/test_to_yaml_data.py
+++ b/tests/module/test_to_yaml_data.py
@@ -15,13 +15,14 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """Examples and tests for overriding `ModuleBase.to_yaml_data`."""
 
-from flepimop2.configuration import (
+from flepimop2.module import ModuleBase
+from flepimop2.yaml import (
+    YamlFormattedMapping,
+    YamlFormattedSequence,
     YamlSerializableBaseModel,
     yaml_mapping,
     yaml_sequence,
 )
-from flepimop2.configuration._yaml import YamlFormattedMapping, YamlFormattedSequence
-from flepimop2.module import ModuleBase
 
 
 class StyledModule(ModuleBase, module="flepimop2.test.styled"):

--- a/tests/yaml/test_yaml_serializable_base_model.py
+++ b/tests/yaml/test_yaml_serializable_base_model.py
@@ -19,7 +19,7 @@ from pathlib import Path
 
 import pytest
 
-from flepimop2.configuration._yaml import (
+from flepimop2.yaml import (
     YamlSerializableBaseModel,
     yaml_mapping,
     yaml_sequence,


### PR DESCRIPTION
## Description

Moved private `flepimop2.configuration._yaml` to `flepimop2.yaml` to:

1. Address circular import issue from `flepimop2.module` importing from both `flepimop2.configuration` and `flepimop2.configuration._yaml`.
2. Provide a clear public API for customizing the appearance of modules in YAML format.

## Related issues

n/a

## Checklist

- [x] I have read through and understand the [pull request process](https://github.com/ACCIDDA/flepimop2?tab=contributing-ov-file#pull-request-process).
- [x] I ran successfully ran CI local via `just ci`.
- [x] I have updated the `CHANGELOG.md` or noted "no major changes" in my commit if the PR is small.
