### PR TITLE
Add metadata properties to `CliCommand` class

### DIFF
--- a/src/flepimop2/_utils/_click.py
+++ b/src/flepimop2/_utils/_click.py
@@ -42,9 +42,13 @@ def _override_or_val(override: T | None, value: U) -> T | U:
     return value if override is None else override
 
 
-def _get_config_target(group: dict[str, T], name: str | None, group_name: str) -> T:
+def _resolve_config_target(
+    group: dict[str, T],
+    name: str | None,
+    group_name: str,
+) -> tuple[str, T]:
     """
-    Get a `T` by name from a group.
+    Resolve a named target from a configuration group.
 
     Args:
         group: The module group to get the target from.
@@ -53,7 +57,7 @@ def _get_config_target(group: dict[str, T], name: str | None, group_name: str) -
         group_name: The name of the group, for error messages.
 
     Returns:
-        The `T` with the specified name.
+        The resolved target name and target value.
 
     Raises:
         click.UsageError: If the group is empty.
@@ -68,6 +72,23 @@ def _get_config_target(group: dict[str, T], name: str | None, group_name: str) -
     if res is None:
         msg = f"Target '{name}' not available from {group.keys()} for '{group_name}'."
         raise BadOptionUsage(option_name="target", message=msg)
+    return name, res
+
+
+def _get_config_target(group: dict[str, T], name: str | None, group_name: str) -> T:
+    """
+    Get a `T` by name from a group.
+
+    Args:
+        group: The module group to get the target from.
+        name: The name of the module target. If `None`, defaults to the first item
+          in group.
+        group_name: The name of the group, for error messages.
+
+    Returns:
+        The `T` with the specified name.
+    """
+    _, res = _resolve_config_target(group, name, group_name)
     return res
 
 

--- a/src/flepimop2/cli/_build_command.py
+++ b/src/flepimop2/cli/_build_command.py
@@ -17,6 +17,8 @@
 
 __all__ = []
 
+from pathlib import Path
+
 from flepimop2.cli._cli_command import CliCommand
 from flepimop2.typing import ExitCode
 
@@ -24,7 +26,7 @@ from flepimop2.typing import ExitCode
 class BuildCommand(CliCommand):
     """Compile and build a model defined in a configuration file."""
 
-    def run(self, *, config: str, dry_run: bool) -> ExitCode:  # type: ignore[override]
+    def run(self, *, config: Path, dry_run: bool) -> ExitCode:  # type: ignore[override]
         """
         Execute the build.
 

--- a/src/flepimop2/cli/_cli_command.py
+++ b/src/flepimop2/cli/_cli_command.py
@@ -86,6 +86,31 @@ class CliCommand(ABC):
         """
         raise NotImplementedError
 
+    @property
+    def target(self) -> str | None:
+        """
+        Get the resolved logical target for this command, if any.
+
+        Commands that do not operate on a named configuration target should use
+        this default implementation. Target-aware commands should override this
+        property and return the resolved configuration entry name.
+        """
+        return None
+
+    @property
+    def config(self) -> Path | None:
+        """
+        Get the primary configuration path for this command, if any.
+
+        Commands that bind the shared `config` argument use this default
+        implementation. Commands that use multiple configuration files or no
+        configuration file should return `None` or override as needed.
+        """
+        value = self.bound_kwargs.get("config")
+        if value is None:
+            return None
+        return Path(value)
+
     @classmethod
     def _literal_options(cls) -> list[str]:
         """

--- a/src/flepimop2/cli/_process_command.py
+++ b/src/flepimop2/cli/_process_command.py
@@ -19,7 +19,7 @@ __all__ = []
 
 from pathlib import Path
 
-from flepimop2._utils._click import _get_config_target
+from flepimop2._utils._click import _resolve_config_target
 from flepimop2.cli._cli_command import CliCommand
 from flepimop2.configuration import ConfigurationModel
 from flepimop2.process.abc import build as build_process
@@ -32,6 +32,22 @@ class ProcessCommand(CliCommand):
 
     The `CONFIG` argument should point to a valid configuration file.
     """
+
+    @property
+    def target(self) -> str | None:
+        """
+        Get the resolved process target name.
+
+        The returned value accounts for the implicit default target used when
+        no `--target` option was provided.
+        """
+        configmodel = ConfigurationModel.from_yaml(self.bound_kwargs["config"])
+        target, _ = _resolve_config_target(
+            configmodel.process,
+            self.bound_kwargs.get("target"),
+            "process",
+        )
+        return target
 
     def run(  # type: ignore[override]
         self,
@@ -53,11 +69,15 @@ class ProcessCommand(CliCommand):
         """
         configmodel = ConfigurationModel.from_yaml(config)
         processconfig = configmodel.process
-        processtarget = _get_config_target(processconfig, target, "process")
+        processtargetname, processtarget = _resolve_config_target(
+            processconfig,
+            target,
+            "process",
+        )
 
         self.info(f"Processing configuration file: {config}")
         self.info(f"Process section: {processconfig}")
-        self.info(f"Process target: {processtarget}")
+        self.info(f"Process target: {processtargetname} => {processtarget}")
 
         process_instance = build_process(processtarget)
         process_instance.execute(dry_run=dry_run)

--- a/src/flepimop2/cli/_simulate_command.py
+++ b/src/flepimop2/cli/_simulate_command.py
@@ -21,6 +21,7 @@ from pathlib import Path
 
 import numpy as np
 
+from flepimop2._utils._click import _resolve_config_target
 from flepimop2.axis import ResolvedShape
 from flepimop2.cli._cli_command import CliCommand
 from flepimop2.configuration import ConfigurationModel
@@ -46,6 +47,22 @@ class SimulateCommand(CliCommand):
     This command runs epidemic simulations specified from a provided configuration file.
     The `CONFIG` argument should point to a valid configuration file.
     """
+
+    @property
+    def target(self) -> str | None:
+        """
+        Get the resolved simulate target name.
+
+        The returned value accounts for the implicit default target used when
+        no `--target` option was provided.
+        """
+        config_model = ConfigurationModel.from_yaml(self.bound_kwargs["config"])
+        target, _ = _resolve_config_target(
+            config_model.simulate,
+            self.bound_kwargs.get("target"),
+            "simulate",
+        )
+        return target
 
     def run(  # type: ignore[override]
         self,

--- a/src/flepimop2/simulator.py
+++ b/src/flepimop2/simulator.py
@@ -17,7 +17,7 @@
 
 __all__ = ["Simulator"]
 
-from flepimop2._utils._click import _get_config_target
+from flepimop2._utils._click import _resolve_config_target
 from flepimop2.axis import AxisCollection
 from flepimop2.backend.abc import BackendABC
 from flepimop2.backend.abc import build as build_backend
@@ -129,7 +129,7 @@ class Simulator:
             The constructed simulator instance.
 
         """
-        simulate_config = _get_config_target(
+        target, simulate_config = _resolve_config_target(
             config_model.simulate,
             target,
             "simulate",

--- a/tests/_utils/_click/test__get_config_target.py
+++ b/tests/_utils/_click/test__get_config_target.py
@@ -22,7 +22,7 @@ Helper for the 'target' click option and handling bad values only knowable at ru
 import pytest
 from click import BadOptionUsage, UsageError
 
-from flepimop2._utils._click import _get_config_target
+from flepimop2._utils._click import _get_config_target, _resolve_config_target
 
 
 @pytest.fixture
@@ -50,6 +50,25 @@ def test_get_config_target_valid(
 ) -> None:
     """Test `_get_config_target` with valid names."""
     result = _get_config_target(sample_group, name, "test")
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    ("name", "expected"),
+    [
+        (None, ("first", 1)),  # Default to first item
+        ("first", ("first", 1)),
+        ("second", ("second", 2)),
+        ("third", ("third", 3)),
+    ],
+)
+def test_resolve_config_target_valid(
+    sample_group: dict[str, int],
+    name: str | None,
+    expected: tuple[str, int],
+) -> None:
+    """Test `_resolve_config_target` returns the resolved name and value."""
+    result = _resolve_config_target(sample_group, name, "test")
     assert result == expected
 
 

--- a/tests/cli/cli_command_class/test_config.py
+++ b/tests/cli/cli_command_class/test_config.py
@@ -1,0 +1,85 @@
+# flepimop2: The FLExible Pipeline for Interchangeable MOdel Processing
+# Copyright (C) 2026  Carl Pearson, Joshua Macdonald, Timothy Willard
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Tests for `CliCommand.config` metadata."""
+
+from pathlib import Path
+
+from flepimop2.cli import CliCommand
+from flepimop2.cli._build_command import BuildCommand
+from flepimop2.cli._format_command import FormatCommand
+from flepimop2.cli._patch_command import PatchCommand
+from flepimop2.cli._process_command import ProcessCommand
+from flepimop2.cli._simulate_command import SimulateCommand
+from flepimop2.cli._skeleton_command import SkeletonCommand
+from flepimop2.typing import ExitCode, PatchConflictMode
+
+
+class _ConfiglessCommand(CliCommand):
+    """Command with no primary configuration path."""
+
+    def run(self) -> ExitCode:  # type: ignore[override]
+        """Execute the command.
+
+        Returns:
+            Exit code.
+        """
+        return ExitCode.OKAY
+
+
+def test_base_config_defaults_to_none() -> None:
+    """Commands should be configless unless they bind a singular config."""
+    assert _ConfiglessCommand().config is None
+
+
+def test_base_config_returns_bound_path(tmp_path: Path) -> None:
+    """The default implementation should return bound Path config values."""
+    config = tmp_path / "config.yaml"
+
+    assert _ConfiglessCommand(config=config).config == config
+
+
+def test_base_config_coerces_bound_string() -> None:
+    """String config values should be exposed as Path instances."""
+    assert _ConfiglessCommand(config="config.yaml").config == Path("config.yaml")
+
+
+def test_singular_config_builtin_commands_return_config(tmp_path: Path) -> None:
+    """Commands that bind `config` should expose it as their primary config path."""
+    config = tmp_path / "config.yaml"
+
+    assert BuildCommand(config=config).config == config
+    assert FormatCommand(config=config).config == config
+    assert ProcessCommand(config=config).config == config
+    assert SimulateCommand(config=config).config == config
+
+
+def test_patch_command_config_is_none(tmp_path: Path) -> None:
+    """PatchCommand has multiple input configs and no singular primary config."""
+    base = tmp_path / "base.yaml"
+    patch = tmp_path / "patch.yaml"
+    command = PatchCommand(
+        configs=(base, patch),
+        dry_run=False,
+        output=None,
+        patch_mode=PatchConflictMode.ERROR,
+    )
+
+    assert command.config is None
+
+
+def test_skeleton_command_config_is_none(tmp_path: Path) -> None:
+    """SkeletonCommand acts on a filesystem path, not a config file."""
+    assert SkeletonCommand(path=tmp_path, dry_run=False).config is None

--- a/tests/cli/cli_command_class/test_target.py
+++ b/tests/cli/cli_command_class/test_target.py
@@ -1,0 +1,144 @@
+# flepimop2: The FLExible Pipeline for Interchangeable MOdel Processing
+# Copyright (C) 2026  Carl Pearson, Joshua Macdonald, Timothy Willard
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Tests for `CliCommand.target` metadata."""
+
+from pathlib import Path
+
+from flepimop2.cli import CliCommand
+from flepimop2.cli._format_command import FormatCommand
+from flepimop2.cli._patch_command import PatchCommand
+from flepimop2.cli._process_command import ProcessCommand
+from flepimop2.cli._simulate_command import SimulateCommand
+from flepimop2.cli._skeleton_command import SkeletonCommand
+from flepimop2.typing import ExitCode
+
+
+class _TargetlessCommand(CliCommand):
+    """Command with no logical configuration target."""
+
+    def run(self) -> ExitCode:  # type: ignore[override]
+        """Execute the command.
+
+        Returns:
+            Exit code.
+        """
+        return ExitCode.OKAY
+
+
+def test_base_target_defaults_to_none() -> None:
+    """Commands should be targetless unless they opt into target metadata."""
+    assert _TargetlessCommand().target is None
+
+
+def test_targetless_builtin_commands_return_none() -> None:
+    """Format, patch, and skeleton commands do not act on named config targets."""
+    assert FormatCommand().target is None
+    assert PatchCommand().target is None
+    assert SkeletonCommand().target is None
+
+
+def test_process_target_returns_explicit_target(tmp_path: Path) -> None:
+    """ProcessCommand.target should return the named process target."""
+    config = tmp_path / "config.yaml"
+    config.write_text(
+        """
+process:
+  preprocess:
+    module: demo.process
+  postprocess:
+    module: demo.process
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    cmd = ProcessCommand(config=config, target="postprocess")
+
+    assert cmd.target == "postprocess"
+
+
+def test_process_target_returns_implicit_default_target(tmp_path: Path) -> None:
+    """ProcessCommand.target should resolve the first process entry by default."""
+    config = tmp_path / "config.yaml"
+    config.write_text(
+        """
+process:
+  preprocess:
+    module: demo.process
+  postprocess:
+    module: demo.process
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    cmd = ProcessCommand(config=config, target=None)
+
+    assert cmd.target == "preprocess"
+
+
+def test_simulate_target_returns_explicit_target(tmp_path: Path) -> None:
+    """SimulateCommand.target should return the named simulate target."""
+    config = tmp_path / "config.yaml"
+    config.write_text(
+        """
+engines:
+  default:
+    module: demo.engine
+systems:
+  default:
+    module: demo.system
+backends:
+  default:
+    module: demo.backend
+simulate:
+  baseline:
+    times: [0.0, 1.0]
+  intervention:
+    times: [0.0, 2.0]
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    cmd = SimulateCommand(config=config, target="intervention")
+
+    assert cmd.target == "intervention"
+
+
+def test_simulate_target_returns_implicit_default_target(tmp_path: Path) -> None:
+    """SimulateCommand.target should resolve the first simulate entry by default."""
+    config = tmp_path / "config.yaml"
+    config.write_text(
+        """
+engines:
+  default:
+    module: demo.engine
+systems:
+  default:
+    module: demo.system
+backends:
+  default:
+    module: demo.backend
+simulate:
+  baseline:
+    times: [0.0, 1.0]
+  intervention:
+    times: [0.0, 2.0]
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    cmd = SimulateCommand(config=config, target=None)
+
+    assert cmd.target == "baseline"

--- a/tests/simulator/test_simulator_class.py
+++ b/tests/simulator/test_simulator_class.py
@@ -98,6 +98,7 @@ def test_simulator_resolves_inputs_and_runs(
     simulator = Simulator.from_configuration_model(config)
     initial_state, params = simulator.resolve_inputs()
 
+    assert simulator.target == "demo"
     assert tuple(initial_state) == ("s0", "i0", "r0")
     np.testing.assert_array_equal(initial_state["s0"].value, np.array([100.0] * 3))
     np.testing.assert_array_equal(initial_state["i0"].value, np.array([1.0] * 3))


### PR DESCRIPTION
## Description

Added `target: str | None` and `config: Path | None` properties to `CliCommand` that provide metadata for job modules that operate on instances of the class.

## Related issues

n/a

## Checklist

- [x] I have read through and understand the [pull request process](https://github.com/ACCIDDA/flepimop2?tab=contributing-ov-file#pull-request-process).
- [x] I ran successfully ran CI local via `just ci`.
- [x] I have updated the `CHANGELOG.md` or noted "no major changes" in my commit if the PR is small.
