### PR TITLE
Add `job list/status` CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `ConfigurationModel/ModuleBase.patch` method to merge configurations together along with corresponding `flepimop2 patch` CLI for users to utilizing patching via the command line as well as YAML formatting. See [#51](https://github.com/ACCIDDA/flepimop2/issues/51), [#52](https://github.com/ACCIDDA/flepimop2/issues/52), [#289](https://github.com/ACCIDDA/flepimop2/pull/289).
 - Introduced the `JobABC` to execute CLI commands in separate environments along with corresponding "jobs" top level key in configuration and the `ShellJob` module to run a CLI in a subprocess. Job modules can be utilized by end users via the `flepimop2 job` CLI. See [#276](https://github.com/ACCIDDA/flepimop2/issues/276), [#277](https://github.com/ACCIDDA/flepimop2/issues/277), [#278](https://github.com/ACCIDDA/flepimop2/issues/278), [#280](https://github.com/ACCIDDA/flepimop2/issues/280).
 - Added a public modules, `flepimop2.cli` and `flepimop2.yaml`, moved from a private modules.
+- Added a private caching mechanism to store intermediate results that can be later pulled from for user convenience. See [#293](https://github.com/ACCIDDA/flepimop2/issues/293).
+- Added `flepimop2 job list/status` CLI commands to inspect job results. See [#298](https://github.com/ACCIDDA/flepimop2/issues/298).
 
 ### Changed
 

--- a/docs/guides/batch-jobs.md
+++ b/docs/guides/batch-jobs.md
@@ -67,10 +67,10 @@ Both commands produce the same result with the `shell` module. The difference is
 When the job is submitted, `flepimop2 job` prints a handle that identifies the submitted work unit:
 
 ```text
-2026-05-26 16:56:24,480:INFO> Job submitted: shell/0 submitted_at=2026-05-26T20:56:24.
+2026-05-26 16:56:24,480:INFO> Job submitted: shell-0 submitted_at=2026-05-26T20:56:24.
 ```
 
-The token before the `/` is the backend name; the token after is the job identifier (a PID for the `shell` module). More capable backends replace the PID with their own opaque identifier (a Slurm job id, an AWS Batch ARN, etc.).
+The token before the `-` is the backend name and the token after is the job identifier (a PID for the `shell` module). More capable backends replace the PID with their own opaque identifier (a Slurm job id, an AWS Batch ARN, etc.). This `<backend>-<job_id>` form is also the key you pass to `flepimop2 job status`.
 
 ## 5. Select a Named Job Target
 
@@ -98,13 +98,56 @@ When exactly one job backend is defined (including the list shorthand form), `-j
 All options accepted by the inner command (`simulate` or `process`) work normally when dispatched through `flepimop2 job`. The `--target` flag, for example, selects the simulation target as usual:
 
 ```bash
-flepimop2 job simulate --target hires configs/config.yaml
-flepimop2 job simulate --job-target local --target hires configs/config.yaml
+flepimop2 job simulate --target demo configs/config.yaml
+flepimop2 job simulate --job-target local --target demo configs/extra-jobs.yaml
 ```
 
-## 7. Validate with `--dry-run`
+## 7. Track Submitted Jobs
 
-The `--dry-run` flag runs the job backend's preflight checks — for example, verifying that the `flepimop2` executable is on `PATH` — without actually submitting anything. The inner command is never executed:
+Each real submission (anything that is not a `--dry-run`) is recorded locally so you can check on it later with `flepimop2 job list` and `flepimop2 job status`. flepimop2 remembers both the job handle and the exact settings of the backend that launched it, so a later status check can rebuild the same backend without you having to point back at (a possibly renamed or edited) configuration file.
+
+If you are launching a throwaway or debugging job and do not want it recorded, pass `--no-cache`:
+
+```bash
+flepimop2 job simulate --no-cache configs/config.yaml
+```
+
+## 8. List Jobs
+
+`flepimop2 job list` prints every cached job and its current status:
+
+```bash
+flepimop2 job list
+```
+
+```text
+shell-0 submitted_at=2026-05-26T20:56:24 status=successful
+```
+
+Finished jobs are kept, so the list doubles as a record of recent work. To stay fast, `list` only re-queries the backend for jobs whose last-known status was still unfinished - never-checked, `pending`, or `running`. Jobs already known to be finished are reported from their last recorded status.
+
+## 9. Check Job Status
+
+To inspect a single job, pass its identifier to `flepimop2 job status`. The identifier is either the `<backend>-<job_id>` key shown by `list`, or a bare job id when it is unambiguous:
+
+```bash
+flepimop2 job status shell-0
+# or, equivalently when unambiguous:
+flepimop2 job status 0
+```
+
+```text
+shell-0 submitted_at=2026-05-26T20:56:24 status=successful
+  returncode: 0
+```
+
+The indented lines are backend-specific `detail`. The `shell` module reports the subprocess `returncode` for blocking submissions. More capable backends (Slurm, AWS Batch, ...) can surface queue position, node assignment, accounting, and so on.
+
+A note on the `shell` module's detached mode: once a detached subprocess has exited, the operating system has already reaped it, so its exit code can no longer be recovered. Such jobs are reported as `finished_unknown` rather than `successful` or `failed`. Use `detach: false` during testing if you need a definite success/failure result.
+
+## 10. Validate with `--dry-run`
+
+The `--dry-run` flag runs the job backend's preflight checks - for example, verifying that the `flepimop2` executable is on `PATH` - and lets the backend perform all of the work leading up to a submission (assembling the command, and for more capable backends rendering batch scripts or staging inputs) before stopping just short of the actual submission. Nothing is submitted, the inner command is never executed, and no handle is cached. The backend then reports exactly what it *would* have submitted:
 
 ```bash
 flepimop2 job simulate -vvv --dry-run configs/config.yaml
@@ -114,18 +157,22 @@ Example output:
 
 ```text
 2026-05-26 16:59:43,433:INFO> Job backend: flepimop2.job.shell.
-2026-05-26 16:59:43,433:INFO> Command: simulate /Users/twillard/Downloads/batch-jobs-guide/configs/config.yaml --dry-run -vvv.
-2026-05-26 16:59:43,433:INFO> Dry run: preflight checks only, no submission.
+2026-05-26 16:59:43,433:INFO> Command: simulate /.../batch-jobs-guide/configs/config.yaml --dry-run -vvv.
+2026-05-26 16:59:43,433:INFO> Dry run, would have submitted: command="/.../batch-jobs-guide/venv/bin/flepimop2 simulate /.../batch-jobs-guide/configs/config.yaml --dry-run -vvv" details={'mode': 'blocking'}.
 ```
+
+The `command` is the exact command the backend skipped - `flepimop2 ...` for the `shell` module, or something like `sbatch ...` for a Slurm backend. Backends can also report extra `details` (here, the subprocess `mode`, a Slurm backend might list the partition or the generated script path).
 
 Without `--dry-run`, the same `-v` output appears before the job handle is printed, letting you verify the backend and reconstructed command on every real submission too.
 
-## 8. Summary
+## 11. Summary
 
 - Add a `jobs:` block to your configuration file to define one or more job backends.
 - Replace `flepimop2 <subcommand>` with `flepimop2 job <subcommand>` to dispatch through a backend.
 - Use `-j` / `--job-target` to select a named backend when more than one is defined.
+- Submitted jobs are recorded locally so they can be tracked later or use `--no-cache` to skip recording a one-off job.
+- Use `flepimop2 job list` to see all jobs and `flepimop2 job status <job-id>` to inspect one.
 - Use `--dry-run` to validate the job setup without submitting.
-- The `shell` module is the right tool for local testing; use a purpose-built module for remote or production workloads.
+- The `shell` module is the right tool for local testing, but use a purpose-built module for remote or production workloads.
 
 For a full list of options run `flepimop2 job --help` or see the [CLI reference](../reference/cli.md#flepimop2-job).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -91,6 +91,7 @@ nav:
           - Abcs: reference/api/abcs.md
           - Axis: reference/api/axis.md
           - Backend: reference/api/backend.md
+          - Cli: reference/api/cli.md
           - Configuration: reference/api/configuration.md
           - Engine: reference/api/engine.md
           - Exceptions: reference/api/exceptions.md
@@ -104,6 +105,7 @@ nav:
           - System: reference/api/system.md
           - Testing: reference/api/testing.md
           - Typing: reference/api/typing.md
+          - Yaml: reference/api/yaml.md
       - CLI: reference/cli.md
   - Connectors: connectors.md
   - Changelog: changelog.md

--- a/src/flepimop2/_cache.py
+++ b/src/flepimop2/_cache.py
@@ -1,0 +1,367 @@
+# flepimop2: The FLExible Pipeline for Interchangeable MOdel Processing
+# Copyright (C) 2026  Carl Pearson, Joshua Macdonald, Timothy Willard
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Persistent on-disk cache for flepimop2, e.g. submitted job handles.
+
+The cache lives in a `.flepimop2_cache/` directory rooted at the current
+working directory and is namespaced by general task. For job tracking the
+layout is::
+
+    .flepimop2_cache/
+      job/
+        handles/
+          <backend>-<job_id>.json   # one cached job per file
+        summary.json                # rollup for quick listing
+
+All contents are JSON, (de)serialized via `pydantic` so we get validation for
+free. Only the resolved job module's configuration is cached alongside each
+handle, which is enough to rebuild the exact `JobABC` instance that launched
+the job when later checking its status.
+"""
+
+__all__ = [
+    "CachedJob",
+    "JobCacheSummary",
+    "JobSummaryEntry",
+    "load_job",
+    "load_jobs",
+    "load_summary",
+    "save_job",
+    "update_summary_status",
+]
+
+import re
+from collections.abc import Iterator
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Final
+
+from pydantic import BaseModel, Field, RootModel
+
+from flepimop2.job.abc import JobHandle
+
+_CACHE_DIRNAME: Final[str] = ".flepimop2_cache"
+_JOB_NAMESPACE: Final[str] = "job"
+_NONWORD: Final[re.Pattern[str]] = re.compile(r"[^A-Za-z0-9._-]+")
+
+
+def _cache_root(start: Path | None = None) -> Path:
+    """Return the root `.flepimop2_cache` directory.
+
+    The returned path is not guaranteed to exist; it is created lazily by the
+    functions that write into it.
+
+    Args:
+        start: The directory to root the cache in. Defaults to the current
+            working directory.
+
+    Returns:
+        The path to the cache root (not necessarily created yet).
+
+    Examples:
+        >>> from pathlib import Path
+        >>> from flepimop2._cache import _cache_root
+        >>> _cache_root(Path("/tmp/project"))
+        PosixPath('/tmp/project/.flepimop2_cache')
+    """
+    base = Path.cwd() if start is None else start
+    return base / _CACHE_DIRNAME
+
+
+def _job_handles_dir(start: Path | None = None) -> Path:
+    """Return the directory holding cached individual job handle files.
+
+    Args:
+        start: The directory to root the cache in. Defaults to the current
+            working directory.
+
+    Returns:
+        The path to the `job/handles` directory (not necessarily created yet).
+
+    Examples:
+        >>> from pathlib import Path
+        >>> from flepimop2._cache import _job_handles_dir
+        >>> _job_handles_dir(Path("/tmp/project"))
+        PosixPath('/tmp/project/.flepimop2_cache/job/handles')
+    """
+    return _cache_root(start) / _JOB_NAMESPACE / "handles"
+
+
+def _summary_path(start: Path | None = None) -> Path:
+    """Return the path to the job cache summary file.
+
+    Args:
+        start: The directory to root the cache in. Defaults to the current
+            working directory.
+
+    Returns:
+        The path to `job/summary.json` (not necessarily created yet).
+
+    Examples:
+        >>> from pathlib import Path
+        >>> from flepimop2._cache import _summary_path
+        >>> _summary_path(Path("/tmp/project"))
+        PosixPath('/tmp/project/.flepimop2_cache/job/summary.json')
+    """
+    return _cache_root(start) / _JOB_NAMESPACE / "summary.json"
+
+
+def _job_key(handle: JobHandle) -> str:
+    """Build a stable, filesystem-safe key for a job handle.
+
+    The key is `<backend>-<job_id>` with any character outside
+    `[A-Za-z0-9._-]` collapsed to a single underscore, so it is safe to use as
+    a file name.
+
+    Args:
+        handle: The job handle to derive a key from.
+
+    Returns:
+        A `<backend>-<job_id>` key with unsafe characters replaced.
+
+    Examples:
+        >>> from flepimop2.job.abc import JobHandle
+        >>> from flepimop2._cache import _job_key
+        >>> _job_key(JobHandle(job_id="42", backend="shell"))
+        'shell-42'
+        >>> _job_key(JobHandle(job_id="1/2 3", backend="slurm"))
+        'slurm-1_2_3'
+    """
+    raw = f"{handle.backend}-{handle.job_id}"
+    return _NONWORD.sub("_", raw)
+
+
+class CachedJob(BaseModel):
+    """A submitted job handle plus the config needed to recreate its backend.
+
+    Attributes:
+        key: Stable, filesystem-safe identifier for this cached job.
+        handle: The handle returned when the job was submitted.
+        job_config: The resolved job module configuration (a `model_dump()` of
+            the `JobABC` instance) sufficient to rebuild the exact backend via
+            `flepimop2.job.abc.build`.
+    """
+
+    key: str
+    handle: JobHandle
+    job_config: dict[str, Any]
+
+
+class JobSummaryEntry(BaseModel):
+    """A lightweight summary of a cached job for quick listing.
+
+    Attributes:
+        key: Stable identifier matching the corresponding `CachedJob`.
+        backend: The job module name that produced the handle.
+        job_id: The backend job identifier.
+        submitted_at: When the job was submitted.
+        status: The last-known lifecycle status, if it has been refreshed.
+    """
+
+    key: str
+    backend: str
+    job_id: str
+    submitted_at: datetime
+    status: str | None = None
+
+
+class JobCacheSummary(RootModel[list[JobSummaryEntry]]):
+    """A rollup of all cached jobs, persisted as `job/summary.json`.
+
+    Modeled as a `pydantic` root model whose root is the list of summary
+    entries, so the on-disk JSON is a bare array rather than an object wrapping
+    a `jobs` key. The list is exposed via `jobs` and the usual sequence
+    protocols.
+    """
+
+    root: list[JobSummaryEntry] = Field(default_factory=list)
+
+    @property
+    def jobs(self) -> list[JobSummaryEntry]:
+        """The summary entries, keyed implicitly by their `key` field."""
+        return self.root
+
+    def __iter__(self) -> Iterator[JobSummaryEntry]:  # type: ignore[override]
+        """Iterate over the summary entries.
+
+        Returns:
+            An iterator over the summary entries.
+        """
+        return iter(self.root)
+
+    def __len__(self) -> int:
+        """Return the number of summary entries."""
+        return len(self.root)
+
+
+def _read_summary(start: Path | None = None) -> JobCacheSummary:
+    """Read the job cache summary, returning an empty summary if absent.
+
+    Args:
+        start: The directory to root the cache in. Defaults to the current
+            working directory.
+
+    Returns:
+        The parsed summary, or an empty `JobCacheSummary` if none exists.
+    """
+    path = _summary_path(start)
+    if not path.is_file():
+        return JobCacheSummary()
+    return JobCacheSummary.model_validate_json(path.read_text())
+
+
+def _write_summary(summary: JobCacheSummary, start: Path | None = None) -> None:
+    """Write the job cache summary, creating parent directories as needed.
+
+    Args:
+        summary: The summary to serialize to `job/summary.json`.
+        start: The directory to root the cache in. Defaults to the current
+            working directory.
+    """
+    path = _summary_path(start)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(summary.model_dump_json(indent=2))
+
+
+def save_job(
+    handle: JobHandle,
+    job_config: dict[str, Any],
+    *,
+    start: Path | None = None,
+) -> CachedJob:
+    """Persist a submitted job handle and its backend configuration.
+
+    Writes an individual handle file under `job/handles/` and refreshes the
+    matching entry in `job/summary.json`.
+
+    Args:
+        handle: The handle returned when the job was submitted.
+        job_config: The resolved job module configuration, as produced by
+            `JobABC.model_dump()`.
+        start: The directory to root the cache in. Defaults to the current
+            working directory.
+
+    Returns:
+        The `CachedJob` that was written.
+    """
+    key = _job_key(handle)
+    cached = CachedJob(key=key, handle=handle, job_config=job_config)
+
+    handles_dir = _job_handles_dir(start)
+    handles_dir.mkdir(parents=True, exist_ok=True)
+    (handles_dir / f"{key}.json").write_text(cached.model_dump_json(indent=2))
+
+    summary = _read_summary(start)
+    entry = JobSummaryEntry(
+        key=key,
+        backend=handle.backend,
+        job_id=handle.job_id,
+        submitted_at=handle.submitted_at,
+    )
+    summary.root = [j for j in summary.root if j.key != key]
+    summary.root.append(entry)
+    _write_summary(summary, start)
+
+    return cached
+
+
+def load_summary(start: Path | None = None) -> JobCacheSummary:
+    """Load the job cache summary.
+
+    The summary is a lightweight rollup of all cached jobs (including each
+    job's last-known status) that callers can scan without reading every
+    individual handle file.
+
+    Args:
+        start: The directory to root the cache in. Defaults to the current
+            working directory.
+
+    Returns:
+        The summary, or an empty summary if the cache does not yet exist. Entries
+        are sorted by submission time (oldest first).
+    """
+    summary = _read_summary(start)
+    summary.root.sort(key=lambda e: e.submitted_at)
+    return summary
+
+
+def load_jobs(start: Path | None = None) -> list[CachedJob]:
+    """Load every cached job, sorted by submission time (oldest first).
+
+    Args:
+        start: The directory to root the cache in. Defaults to the current
+            working directory.
+
+    Returns:
+        The cached jobs. Empty if the cache does not yet exist.
+    """
+    handles_dir = _job_handles_dir(start)
+    if not handles_dir.is_dir():
+        return []
+    jobs = [
+        CachedJob.model_validate_json(path.read_text())
+        for path in sorted(handles_dir.glob("*.json"))
+    ]
+    return sorted(jobs, key=lambda c: c.handle.submitted_at)
+
+
+def load_job(key: str, start: Path | None = None) -> CachedJob | None:
+    """Load a single cached job by key.
+
+    Args:
+        key: The `<backend>-<job_id>` key (as stored). A bare `job_id` is also
+            accepted and matched when unambiguous.
+        start: The directory to root the cache in. Defaults to the current
+            working directory.
+
+    Returns:
+        The matching `CachedJob`, or `None` if no unambiguous match exists.
+    """
+    handles_dir = _job_handles_dir(start)
+    if not handles_dir.is_dir():
+        return None
+
+    exact = handles_dir / f"{_NONWORD.sub('_', key)}.json"
+    if exact.is_file():
+        return CachedJob.model_validate_json(exact.read_text())
+
+    matches = [c for c in load_jobs(start) if c.handle.job_id == key]
+    if len(matches) == 1:
+        return matches[0]
+    return None
+
+
+def update_summary_status(
+    key: str,
+    status: str,
+    *,
+    start: Path | None = None,
+) -> None:
+    """Patch the last-known status of a cached job in the summary file.
+
+    Args:
+        key: The cached job key to update.
+        status: The new last-known status string.
+        start: The directory to root the cache in. Defaults to the current
+            working directory.
+    """
+    summary = _read_summary(start)
+    changed = False
+    for entry in summary.jobs:
+        if entry.key == key:
+            entry.status = status
+            changed = True
+    if changed:
+        _write_summary(summary, start)

--- a/src/flepimop2/cli/_job_command.py
+++ b/src/flepimop2/cli/_job_command.py
@@ -22,13 +22,17 @@ from typing import Any
 
 import click
 
+from flepimop2 import _cache
 from flepimop2._utils._click import _get_config_target
 from flepimop2.cli._cli_command import CliCommand
+from flepimop2.cli._job_list_command import JobListCommand
+from flepimop2.cli._job_status_command import JobStatusCommand
 from flepimop2.cli._logging import get_script_logger
 from flepimop2.cli._process_command import ProcessCommand
 from flepimop2.cli._register_command import register_command
 from flepimop2.cli._simulate_command import SimulateCommand
 from flepimop2.configuration import ConfigurationModel
+from flepimop2.job.abc import JobDryRun
 from flepimop2.job.abc import build as build_job
 
 
@@ -56,21 +60,32 @@ def _dispatch_to_job(inner: CliCommand, job_kwargs: dict[str, Any]) -> None:
     if dry_run:
         logger.info("Dry run: preflight checks only, no submission.")
 
-    handle = job.submit(inner, dry_run=dry_run)
-    if handle is not None:
-        logger.info("Job submitted: %s", handle)
+    no_cache: bool = bool(job_kwargs.get("no_cache"))
+    if no_cache:
+        logger.debug("Skipping job cache (--no-cache).")
+
+    result = job.submit(inner, dry_run=dry_run)
+    if isinstance(result, JobDryRun):
+        logger.info("Dry run, would have submitted: %s", result)
+    else:
+        logger.info("Job submitted: %s", result)
+        if not no_cache:
+            cached_job = _cache.save_job(result, job.model_dump())
+            logger.debug("Job cached to: %s", cached_job.key)
     sys.exit(0)
 
 
 register_command(
     ProcessCommand,
     job_group,
-    extra_options=("job_target",),
+    extra_options=("job_target", "no_cache"),
     on_invoke=_dispatch_to_job,
 )
 register_command(
     SimulateCommand,
     job_group,
-    extra_options=("job_target",),
+    extra_options=("job_target", "no_cache"),
     on_invoke=_dispatch_to_job,
 )
+register_command(JobListCommand, job_group)
+register_command(JobStatusCommand, job_group)

--- a/src/flepimop2/cli/_job_list_command.py
+++ b/src/flepimop2/cli/_job_list_command.py
@@ -1,0 +1,106 @@
+# flepimop2: The FLExible Pipeline for Interchangeable MOdel Processing
+# Copyright (C) 2026  Carl Pearson, Joshua Macdonald, Timothy Willard
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""The `flepimop2 job list` command."""
+
+__all__ = []
+
+from typing import Any
+
+import click
+
+from flepimop2 import _cache
+from flepimop2.cli._cli_command import CliCommand
+from flepimop2.job.abc import JobStatus
+from flepimop2.job.abc import build as build_job
+from flepimop2.typing import ExitCode
+
+
+class JobListCommand(CliCommand):
+    """
+    List submitted jobs and their current status.
+
+    Reads jobs cached under `.flepimop2_cache/job/` (recorded when they were
+    submitted via `flepimop2 job <subcommand>`) and prints a line per job.
+    Finished jobs are retained, so this is also a record of recently completed
+    work.
+
+    To stay fast, the command only re-queries the backend for jobs whose
+    last-known status (read from `summary.json`) was unfinished - i.e. never
+    checked, pending, or running. Jobs already known to be finished are reported
+    from the cached summary without contacting the backend again.
+    """
+
+    def run(self, **kwargs: Any) -> ExitCode:
+        """
+        List cached jobs, refreshing only those not yet known to be finished.
+
+        Returns:
+            An exit code indicating success.
+        """
+        del kwargs
+        summary = _cache.load_summary()
+        if not summary.jobs:
+            click.echo("No jobs found.")
+            return ExitCode.OKAY
+
+        for entry in summary.jobs:
+            last_known = self._parse_status(entry.status)
+            if last_known is not None and last_known.is_finished:
+                click.echo(
+                    f"{entry.backend}-{entry.job_id} "
+                    f"submitted_at={entry.submitted_at:%Y-%m-%dT%H:%M:%S} "
+                    f"status={last_known.value}"
+                )
+                continue
+            self._refresh_and_echo(entry.key)
+        return ExitCode.OKAY
+
+    def _refresh_and_echo(self, key: str) -> None:
+        """Re-query one cached job from its backend and print its status."""
+        cached = _cache.load_job(key)
+        if cached is None:
+            self.warning("Cached job '%s' is missing its handle file.", key)
+            return
+        try:
+            job = build_job(cached.job_config)
+            result = job.status(cached.handle)
+            _cache.update_summary_status(cached.key, result.status.value)
+            click.echo(str(result))
+        except Exception as exc:  # noqa: BLE001
+            self.warning("Could not refresh job '%s': %s", key, exc)
+            click.echo(f"{cached.handle} status=unknown")
+
+    @staticmethod
+    def _parse_status(value: str | None) -> JobStatus | None:
+        """Parse a summary status string into a `JobStatus`, if recognized.
+
+        Args:
+            value: The stored status string, or `None` if never refreshed.
+
+        Returns:
+            The matching `JobStatus`, or `None` if absent or unrecognized.
+        """
+        if value is None:
+            return None
+        try:
+            return JobStatus(value)
+        except ValueError:
+            return None
+
+    @classmethod
+    def command_name(cls) -> str:
+        """Return the command name used within the `job` group."""
+        return "list"

--- a/src/flepimop2/cli/_job_status_command.py
+++ b/src/flepimop2/cli/_job_status_command.py
@@ -1,0 +1,74 @@
+# flepimop2: The FLExible Pipeline for Interchangeable MOdel Processing
+# Copyright (C) 2026  Carl Pearson, Joshua Macdonald, Timothy Willard
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""The `flepimop2 job status` command."""
+
+__all__ = []
+
+import click
+from typing_extensions import override
+
+from flepimop2 import _cache
+from flepimop2.cli._cli_command import CliCommand
+from flepimop2.job.abc import build as build_job
+from flepimop2.typing import ExitCode
+
+
+class JobStatusCommand(CliCommand):
+    """
+    Show the status of a single submitted job.
+
+    Looks up a job cached under `.flepimop2_cache/job/` by its identifier,
+    rebuilds the exact job backend that launched it from the cached
+    configuration, queries the backend, and prints the job's current status
+    along with any backend-specific detail.
+    """
+
+    @override
+    def run(  # type: ignore[override]
+        self, *, job_id: str, **kwargs: object
+    ) -> ExitCode:
+        """
+        Report the status of the cached job identified by `job_id`.
+
+        Args:
+            job_id: The `<backend>-<job_id>` key or bare job id to inspect.
+            **kwargs: Additional Click-supplied options (unused).
+
+        Returns:
+            An exit code: `OKAY` on success, `GENERAL` if the job is unknown.
+        """
+        del kwargs
+        cached = _cache.load_job(job_id)
+        if cached is None:
+            self.error("No cached job found for '%s'.", job_id)
+            return ExitCode.GENERAL
+
+        self.info("Rebuilding job backend from cached configuration: %s", cached.key)
+        job = build_job(cached.job_config)
+        result = job.status(cached.handle)
+        _cache.update_summary_status(cached.key, result.status.value)
+
+        # The status result is the command's primary output, so it is written
+        # to stdout directly rather than through the (verbosity-gated) logger.
+        click.echo(str(result))
+        for name, value in result.detail.items():
+            click.echo(f"  {name}: {value}")
+        return ExitCode.OKAY
+
+    @classmethod
+    def command_name(cls) -> str:
+        """Return the command name used within the `job` group."""
+        return "status"

--- a/src/flepimop2/cli/_options.py
+++ b/src/flepimop2/cli/_options.py
@@ -185,12 +185,37 @@ COMMON_OPTIONS: Final[dict[str, CommonOptionEntry]] = {
         ),
         None,
     ),
+    "job_id": (
+        click.argument(
+            "job_id",
+            required=True,
+            type=str,
+        ),
+        (
+            "Identifier of a submitted job to inspect. Accepts either the "
+            "`<backend>-<job_id>` key shown by `flepimop2 job list` or a bare "
+            "job id when it is unambiguous."
+        ),
+    ),
     "job_target": (
         click.option(
             "-j",
             "--job-target",
             default=None,
             help="The configured job module to dispatch this command to.",
+        ),
+        None,
+    ),
+    "no_cache": (
+        click.option(
+            "--no-cache",
+            is_flag=True,
+            default=False,
+            help=(
+                "Do not record the submitted job handle in the local job "
+                "cache. Useful for one-off or debugging submissions that "
+                "should not appear in `flepimop2 job list`."
+            ),
         ),
         None,
     ),

--- a/src/flepimop2/job/abc/__init__.py
+++ b/src/flepimop2/job/abc/__init__.py
@@ -15,12 +15,21 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """Abstract base class for flepimop2 job runners."""
 
-__all__ = ["JobABC", "JobHandle", "build"]
+__all__ = [
+    "JobABC",
+    "JobDryRun",
+    "JobHandle",
+    "JobStatus",
+    "JobStatusResult",
+    "build",
+]
 
 from abc import abstractmethod
-from dataclasses import dataclass, field
 from datetime import UTC, datetime
+from enum import StrEnum
 from typing import TYPE_CHECKING, Any
+
+from pydantic import BaseModel, Field
 
 from flepimop2._utils._module import _build
 from flepimop2.exceptions import Flepimop2ValidationError, ValidationIssue
@@ -30,13 +39,15 @@ if TYPE_CHECKING:
     from flepimop2.cli import CliCommand
 
 
-@dataclass
-class JobHandle:
+class JobHandle(BaseModel):
     """A reference to a submitted job.
 
+    Modeled with `pydantic` so handles can be serialized to and parsed from
+    JSON (with validation) for persistent caching.
+
     Attributes:
-        job_id: Opaque token identifying the job on the backend (PID, Slurm id,
-            ARN, ...).
+        job_id: Opaque token identifying the job on the backend
+            (PID, Slurm id, ARN, ...).
         backend: The job module name that produced this handle.
         submitted_at: When the job was submitted.
         metadata: Optional backend-specific metadata (partition, queue, ...).
@@ -44,13 +55,81 @@ class JobHandle:
 
     job_id: str
     backend: str
-    submitted_at: datetime = field(default_factory=lambda: datetime.now(tz=UTC))
-    metadata: dict[str, Any] = field(default_factory=dict)
+    submitted_at: datetime = Field(default_factory=lambda: datetime.now(tz=UTC))
+    metadata: dict[str, Any] = Field(default_factory=dict)
 
     def __str__(self) -> str:
         """Return a short, single-line representation suitable for stdout."""
         ts = self.submitted_at.strftime("%Y-%m-%dT%H:%M:%S")
-        return f"{self.backend}/{self.job_id} submitted_at={ts}"
+        return f"{self.backend}-{self.job_id} submitted_at={ts}"
+
+
+class JobStatus(StrEnum):
+    """The lifecycle state of a submitted job.
+
+    Attributes:
+        PENDING: The job has been accepted but has not started running.
+        RUNNING: The job is currently executing.
+        SUCCESSFUL: The job finished and is believed to have succeeded.
+        FAILED: The job finished and is believed to have failed.
+        FINISHED_UNKNOWN: The job finished but its success or failure could not
+            be determined (e.g. a detached subprocess whose exit code can no
+            longer be recovered).
+    """
+
+    PENDING = "pending"
+    RUNNING = "running"
+    SUCCESSFUL = "successful"
+    FAILED = "failed"
+    FINISHED_UNKNOWN = "finished_unknown"
+
+    @property
+    def is_finished(self) -> bool:
+        """Whether this status represents a terminal (finished) state."""
+        return self in {
+            JobStatus.SUCCESSFUL,
+            JobStatus.FAILED,
+            JobStatus.FINISHED_UNKNOWN,
+        }
+
+
+class JobStatusResult(JobHandle):
+    """The status of a submitted job.
+
+    A `JobHandle` enriched with the job's current lifecycle `status` and an
+    optional, backend-specific `detail` payload.
+
+    Attributes:
+        status: The current lifecycle state of the job.
+        detail: Optional backend-specific status details (exit code, queue
+            position, node assignment, ...).
+    """
+
+    status: JobStatus
+    detail: dict[str, Any] = Field(default_factory=dict)
+
+    def __str__(self) -> str:
+        """Return a short, single-line representation suitable for stdout."""
+        return f"{super().__str__()} status={self.status.value}"
+
+
+class JobDryRun(BaseModel):
+    """A description of the submission a dry run skipped.
+
+    Returned by `JobABC.submit` (in place of a `JobHandle`) when `dry_run` is
+    requested, so the caller can report exactly what *would* have been submitted
+    without actually submitting it.
+
+    Attributes:
+        command: The command the backend would have run, rendered for display
+            (e.g. `flepimop2 simulate ...` for the shell backend, or
+            `sbatch ...` for a Slurm backend).
+        details: Optional backend-specific specifics about the skipped submission
+            (working directory, partition, generated script path, ...).
+    """
+
+    command: str
+    details: dict[str, str] = Field(default_factory=dict)
 
 
 class JobABC(ModuleBase, module_namespace="job"):
@@ -58,38 +137,52 @@ class JobABC(ModuleBase, module_namespace="job"):
 
     def submit(
         self, command: "CliCommand", *, dry_run: bool = False
-    ) -> JobHandle | None:
+    ) -> JobHandle | JobDryRun:
         """Submit `command` for execution on this job backend.
 
         Runs `_submit_validate` first; if issues are found they are raised as
-        a `Flepimop2ValidationError`. When `dry_run=True` the method returns
-        `None` after validation without actually submitting.
+        a `Flepimop2ValidationError`. The `dry_run` flag is forwarded to
+        `_submit` so that backends can perform all of the work leading up to a
+        submission (rendering batch scripts, staging files, resolving
+        resources, ...) and then stop just before the submission itself,
+        returning a `JobDryRun` that describes what would have been submitted.
 
         Args:
             command: The CLI command instance to submit.
-            dry_run: If `True`, validate only — do not actually submit.
+            dry_run: If `True`, perform preflight work but do not actually
+                submit.
 
         Returns:
-            A handle for the submitted work unit, or `None` when `dry_run=True`.
+            A `JobHandle` for the submitted work unit, or a `JobDryRun`
+            describing the skipped submission when `dry_run=True`.
 
         Raises:
             Flepimop2ValidationError: If `_submit_validate` returns issues.
         """
         if (issues := self._submit_validate()) is not None and issues:
             raise Flepimop2ValidationError(issues)
-        if dry_run:
-            return None
-        return self._submit(command)
+        return self._submit(command, dry_run=dry_run)
 
     @abstractmethod
-    def _submit(self, command: "CliCommand") -> JobHandle:
+    def _submit(
+        self, command: "CliCommand", *, dry_run: bool = False
+    ) -> JobHandle | JobDryRun:
         """Backend-specific submission implementation.
+
+        Implementations should perform all preparatory work (rendering batch
+        scripts, staging inputs, resolving resources, ...) regardless of
+        `dry_run`, and only skip the final, irreversible submission step when
+        `dry_run` is `True`, returning a `JobDryRun` that describes what would
+        have been submitted in that case.
 
         Args:
             command: The CLI command instance to submit.
+            dry_run: If `True`, do everything except the actual submission and
+                return a `JobDryRun`.
 
         Returns:
-            A handle for the submitted work unit.
+            A `JobHandle` for the submitted work unit, or a `JobDryRun`
+            describing the skipped submission when `dry_run=True`.
         """
         ...
 
@@ -97,6 +190,51 @@ class JobABC(ModuleBase, module_namespace="job"):
         """Validate that this backend is ready to accept submissions.
 
         Called by `submit` before delegating to `_submit`. Subclasses may
+        override to perform backend-specific preflight checks (e.g. resolving
+        executables, checking credentials, testing connectivity).
+
+        Returns:
+            A list of `ValidationIssue` objects if validation fails, an empty
+            list if validation passes with no issues, or `None` if not
+            implemented.
+        """
+        return None
+
+    def status(self, handle: JobHandle) -> JobStatusResult:
+        """Query the status of a previously submitted job.
+
+        Runs `_status_validate` first; if issues are found they are raised as
+        a `Flepimop2ValidationError`. Otherwise delegates to `_status`.
+
+        Args:
+            handle: The handle returned when the job was submitted.
+
+        Returns:
+            A `JobStatusResult` describing the job's current state.
+
+        Raises:
+            Flepimop2ValidationError: If `_status_validate` returns issues.
+        """
+        if (issues := self._status_validate()) is not None and issues:
+            raise Flepimop2ValidationError(issues)
+        return self._status(handle)
+
+    @abstractmethod
+    def _status(self, handle: JobHandle) -> JobStatusResult:
+        """Backend-specific status implementation.
+
+        Args:
+            handle: The handle returned when the job was submitted.
+
+        Returns:
+            A `JobStatusResult` describing the job's current state.
+        """
+        ...
+
+    def _status_validate(self) -> list[ValidationIssue] | None:  # noqa: PLR6301
+        """Validate that this backend is ready to report job status.
+
+        Called by `status` before delegating to `_status`. Subclasses may
         override to perform backend-specific preflight checks (e.g. resolving
         executables, checking credentials, testing connectivity).
 

--- a/src/flepimop2/job/shell/__init__.py
+++ b/src/flepimop2/job/shell/__init__.py
@@ -17,6 +17,8 @@
 
 __all__ = ["ShellJob"]
 
+import os
+import shlex
 import shutil
 import subprocess  # noqa: S404
 from pathlib import Path
@@ -25,7 +27,13 @@ from typing import TYPE_CHECKING, Any
 from pydantic import PrivateAttr
 
 from flepimop2.exceptions import ValidationIssue
-from flepimop2.job.abc import JobABC, JobHandle
+from flepimop2.job.abc import (
+    JobABC,
+    JobDryRun,
+    JobHandle,
+    JobStatus,
+    JobStatusResult,
+)
 
 if TYPE_CHECKING:
     from flepimop2.cli import CliCommand
@@ -69,14 +77,22 @@ class ShellJob(JobABC, module="shell"):
             ]
         return []
 
-    def _submit(self, command: "CliCommand") -> JobHandle:
+    def _submit(
+        self, command: "CliCommand", *, dry_run: bool = False
+    ) -> JobHandle | JobDryRun:
         """Submit `command` as a local subprocess.
+
+        Resolves the executable and assembles the argv regardless of `dry_run`;
+        when `dry_run` is `True` it stops just before spawning the subprocess
+        and returns a `JobDryRun` describing the command it would have run.
 
         Args:
             command: The CLI command instance to run.
+            dry_run: If `True`, prepare the command but do not spawn it.
 
         Returns:
-            A handle for the submitted subprocess.
+            A handle for the submitted subprocess, or a `JobDryRun` describing
+            the skipped subprocess when `dry_run=True`.
 
         Raises:
             FileNotFoundError: If the `flepimop2` executable cannot be found on PATH.
@@ -92,10 +108,64 @@ class ShellJob(JobABC, module="shell"):
             "cwd": self.cwd,
             "env": env,
         }
+        if dry_run:
+            details: dict[str, str] = {
+                "mode": "detached" if self.detach else "blocking"
+            }
+            if self.cwd is not None:
+                details["cwd"] = str(self.cwd)
+            return JobDryRun(command=shlex.join(argv), details=details)
         if self.detach:
             proc = subprocess.Popen(argv, start_new_session=True, **kwargs)  # noqa: S603
             job_id = str(proc.pid)
+            metadata: dict[str, Any] = {"mode": "detached"}
         else:
             result = subprocess.run(argv, check=False, **kwargs)  # noqa: S603
             job_id = str(result.returncode)
-        return JobHandle(job_id=job_id, backend="shell")
+            metadata = {"mode": "blocking", "returncode": result.returncode}
+        return JobHandle(job_id=job_id, backend="shell", metadata=metadata)
+
+    def _status(self, handle: JobHandle) -> JobStatusResult:  # noqa: PLR6301
+        """Report the status of a previously submitted shell job.
+
+        For blocking submissions the handle's `job_id` is the subprocess return
+        code, so the status is derived directly from it. For detached
+        submissions the `job_id` is a PID, which is probed for liveness with
+        `os.kill(pid, 0)`:
+
+        - A live PID reports `RUNNING`.
+        - A `ProcessLookupError` means the process has already exited; because a
+          detached process cannot be reaped here, its exit code is unknown and
+          the status is reported as `FINISHED_UNKNOWN`.
+        - A `PermissionError` means the PID exists but is owned by another user,
+          so it is still considered `RUNNING`.
+
+        Args:
+            handle: The handle returned when the job was submitted.
+
+        Returns:
+            A `JobStatusResult` describing the job's current state.
+        """
+        detail = {}
+        if handle.metadata.get("mode") == "blocking":
+            returncode = int(handle.metadata.get("returncode", handle.job_id))
+            status = JobStatus.SUCCESSFUL if returncode == 0 else JobStatus.FAILED
+            detail = {"returncode": returncode}
+        else:
+            pid = int(handle.job_id)
+            try:
+                os.kill(pid, 0)
+            except ProcessLookupError:
+                status = JobStatus.FINISHED_UNKNOWN
+            except PermissionError:
+                status = JobStatus.RUNNING
+            else:
+                status = JobStatus.RUNNING
+        return JobStatusResult(
+            job_id=handle.job_id,
+            backend=handle.backend,
+            submitted_at=handle.submitted_at,
+            metadata=handle.metadata,
+            status=status,
+            detail=detail,
+        )

--- a/tests/cli/test_job_command.py
+++ b/tests/cli/test_job_command.py
@@ -15,15 +15,31 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """Tests for the `flepimop2 job` CLI group."""
 
+from collections.abc import Iterator
 from datetime import UTC, datetime
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import pytest
 from click.testing import CliRunner
 
 from flepimop2.cli._job_command import job_group
 from flepimop2.cli._simulate_command import SimulateCommand
-from flepimop2.job.abc import JobHandle
+from flepimop2.job.abc import JobDryRun, JobHandle
+
+
+@pytest.fixture(autouse=True)
+def save_job_mock() -> Iterator[MagicMock]:
+    """Stub out job-handle caching so dispatch tests don't touch the real cache.
+
+    Caching is exercised separately by the `_cache` tests; here we only care
+    about dispatch behavior, and the mocked job objects cannot be serialized.
+
+    Yields:
+        The mock standing in for `_cache.save_job`.
+    """
+    with patch("flepimop2.cli._job_command._cache.save_job") as mock:
+        yield mock
 
 
 def _make_minimal_config(config_path: Path, job_name: str = "local") -> None:
@@ -63,6 +79,41 @@ def test_job_simulate_dispatches_to_job_backend(tmp_path: Path) -> None:
 
     assert mock_job.submit.called
     assert result.exit_code == 0
+
+
+def test_job_simulate_dry_run_reports_and_does_not_cache(
+    tmp_path: Path, save_job_mock: MagicMock
+) -> None:
+    """A dry-run dispatch reports the skipped command and caches nothing."""
+    config_path = tmp_path / "config.yaml"
+    _make_minimal_config(config_path)
+
+    mock_job = MagicMock()
+    mock_job.submit.return_value = JobDryRun(
+        command="flepimop2 simulate config.yaml --dry-run",
+        details={"mode": "blocking"},
+    )
+
+    runner = CliRunner()
+    with (
+        patch("flepimop2.cli._job_command.build_job", return_value=mock_job),
+        patch("flepimop2.cli._job_command.ConfigurationModel.from_yaml") as mock_load,
+    ):
+        mock_config = MagicMock()
+        mock_config.jobs = {"local": {"module": "shell", "detach": False}}
+        mock_load.return_value = mock_config
+
+        result = runner.invoke(
+            job_group,
+            ["simulate", "-vv", "--dry-run", str(config_path)],
+        )
+
+    assert result.exit_code == 0
+    _, kwargs = mock_job.submit.call_args
+    assert kwargs["dry_run"] is True
+    assert "would have submitted" in result.output
+    assert "flepimop2 simulate config.yaml --dry-run" in result.output
+    save_job_mock.assert_not_called()
 
 
 def test_job_simulate_inner_command_not_executed_locally(tmp_path: Path) -> None:

--- a/tests/integration/documentation_batch_jobs/test_batch_jobs.py
+++ b/tests/integration/documentation_batch_jobs/test_batch_jobs.py
@@ -51,3 +51,25 @@ def test_batch_jobs_guide(repo_root: Path, tmp_path: Path) -> None:
 
     output_files = list((tmp_path / "model_output").glob("*.csv"))
     assert len(output_files) == 1
+
+    # Submitting through the shell backend caches a handle and a summary.
+    cache_dir = tmp_path / ".flepimop2_cache" / "job"
+    handle_files = list((cache_dir / "handles").glob("*.json"))
+    assert len(handle_files) == 1
+    assert (cache_dir / "summary.json").is_file()
+
+    # `job list` reports the cached shell job with a resolved status.
+    list_result = flepimop2_run("job", args=["list"], cwd=tmp_path)
+    assert list_result.returncode == 0
+    assert "shell-" in list_result.stdout
+
+    # The config uses `detach: false`, so the blocking job's return code yields
+    # a definite, successful status.
+    assert "status=successful" in list_result.stdout
+
+    # `job status` reconstructs the backend from the cached config and reports
+    # the same job. The handle file is named `<backend>-<job_id>.json`.
+    job_key = handle_files[0].stem
+    status_result = flepimop2_run("job", args=["status", job_key], cwd=tmp_path)
+    assert status_result.returncode == 0
+    assert "status=successful" in status_result.stdout

--- a/tests/job/abc/test_job_dry_run.py
+++ b/tests/job/abc/test_job_dry_run.py
@@ -1,0 +1,33 @@
+# flepimop2: The FLExible Pipeline for Interchangeable MOdel Processing
+# Copyright (C) 2026  Carl Pearson, Joshua Macdonald, Timothy Willard
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Tests for `flepimop2.job.abc.JobDryRun`."""
+
+from flepimop2.job.abc import JobDryRun
+
+
+def test_details_default_to_empty() -> None:
+    """`details` defaults to an empty dict and is per-instance."""
+    a = JobDryRun(command="a")
+    b = JobDryRun(command="b")
+    a.details["partition"] = "gpu"
+    assert b.details == {}
+
+
+def test_json_roundtrip() -> None:
+    """A `JobDryRun` survives a JSON round-trip."""
+    dry_run = JobDryRun(command="sbatch run.sh", details={"partition": "gpu"})
+    restored = JobDryRun.model_validate_json(dry_run.model_dump_json())
+    assert restored == dry_run

--- a/tests/job/abc/test_job_handle.py
+++ b/tests/job/abc/test_job_handle.py
@@ -35,7 +35,7 @@ def handle() -> JobHandle:
 def test_str_format(handle: JobHandle) -> None:
     """str() should include the backend, job_id, and submission timestamp."""
     line = str(handle)
-    assert "shell/42" in line
+    assert "shell-42" in line
     assert "submitted_at=2026-01-15T12:00:00" in line
 
 

--- a/tests/job/abc/test_job_status.py
+++ b/tests/job/abc/test_job_status.py
@@ -1,0 +1,59 @@
+# flepimop2: The FLExible Pipeline for Interchangeable MOdel Processing
+# Copyright (C) 2026  Carl Pearson, Joshua Macdonald, Timothy Willard
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Tests for `flepimop2.job.abc.JobStatus` and `JobStatusResult`."""
+
+from datetime import UTC, datetime
+
+import pytest
+
+from flepimop2.job.abc import JobHandle, JobStatus, JobStatusResult
+
+_FINISHED_STATUSES = frozenset({
+    JobStatus.SUCCESSFUL,
+    JobStatus.FAILED,
+    JobStatus.FINISHED_UNKNOWN,
+})
+
+
+@pytest.mark.parametrize("status", list(JobStatus))
+def test_is_finished(status: JobStatus) -> None:
+    """Terminal statuses report `is_finished`; in-flight ones do not."""
+    assert status.is_finished is (status in _FINISHED_STATUSES)
+
+
+def test_status_result_is_a_handle() -> None:
+    """A `JobStatusResult` carries all handle fields plus a status."""
+    result = JobStatusResult(
+        job_id="42",
+        backend="shell",
+        submitted_at=datetime(2026, 1, 15, 12, 0, 0, tzinfo=UTC),
+        status=JobStatus.RUNNING,
+    )
+    assert isinstance(result, JobHandle)
+    assert result.status is JobStatus.RUNNING
+    assert "status=running" in str(result)
+
+
+def test_status_result_json_roundtrip() -> None:
+    """A `JobStatusResult` survives a JSON round-trip (for caching)."""
+    result = JobStatusResult(
+        job_id="1",
+        backend="shell",
+        status=JobStatus.SUCCESSFUL,
+        detail={"returncode": 0},
+    )
+    restored = JobStatusResult.model_validate_json(result.model_dump_json())
+    assert restored == result

--- a/tests/job/shell/test_shell_job.py
+++ b/tests/job/shell/test_shell_job.py
@@ -21,7 +21,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from flepimop2.exceptions import Flepimop2ValidationError, ValidationIssue
-from flepimop2.job.abc import JobHandle
+from flepimop2.job.abc import JobDryRun, JobHandle, JobStatus
 from flepimop2.job.shell import ShellJob
 from flepimop2.typing import ExitCode
 
@@ -67,7 +67,7 @@ def test_submit_detached_uses_pid_as_job_id() -> None:
     ):
         handles = job.submit(cmd)
 
-    assert handles is not None
+    assert isinstance(handles, JobHandle)
     assert handles.job_id == "99999"
     assert handles.backend == "shell"
 
@@ -123,8 +123,8 @@ def test_submit_validate_returns_issue_when_exe_missing() -> None:
     assert job._exe is None
 
 
-def test_submit_dry_run_returns_none() -> None:
-    """submit(dry_run=True) should validate and return None without submitting."""
+def test_submit_dry_run_returns_dry_run() -> None:
+    """submit(dry_run=True) should validate and describe, but not submit."""
     job = ShellJob.model_validate({"module": "flepimop2.job.shell"})
     cmd = _make_command([])
 
@@ -132,10 +132,33 @@ def test_submit_dry_run_returns_none() -> None:
         patch("flepimop2.job.shell.shutil.which", return_value=_EXE),
         patch("flepimop2.job.shell.subprocess.Popen") as mock_popen,
     ):
-        handles = job.submit(cmd, dry_run=True)
+        result = job.submit(cmd, dry_run=True)
 
-    assert handles is None
+    assert isinstance(result, JobDryRun)
     mock_popen.assert_not_called()
+
+
+def test_submit_dry_run_describes_command() -> None:
+    """A dry run performs preflight work and reports the command it would run."""
+    job = ShellJob.model_validate({"module": "flepimop2.job.shell"})
+    cmd = _make_command(["config.yaml"])
+
+    with (
+        patch("flepimop2.job.shell.shutil.which", return_value=_EXE) as mock_which,
+        patch("flepimop2.job.shell.subprocess.Popen") as mock_popen,
+        patch("flepimop2.job.shell.subprocess.run") as mock_run,
+    ):
+        result = job.submit(cmd, dry_run=True)
+
+    assert isinstance(result, JobDryRun)
+    # The argv is assembled from the resolved executable and the command...
+    mock_which.assert_called()
+    cmd.to_argv.assert_called()
+    assert result.command == f"{_EXE} simulate config.yaml"
+    assert result.details["mode"] == "detached"
+    # ...but nothing is actually launched.
+    mock_popen.assert_not_called()
+    mock_run.assert_not_called()
 
 
 def test_submit_reuses_cached_exe() -> None:
@@ -226,7 +249,7 @@ def test_submit_synchronous_uses_returncode_as_job_id() -> None:
     ):
         handles = job.submit(cmd)
 
-    assert handles is not None
+    assert isinstance(handles, JobHandle)
     assert handles.job_id == str(int(ExitCode.OKAY))
     assert handles.backend == "shell"
 
@@ -250,3 +273,60 @@ def test_submit_synchronous_does_not_use_popen() -> None:
 
     mock_run.assert_called_once()
     mock_popen.assert_not_called()
+
+
+def _shell_job() -> ShellJob:
+    """Build a concrete ShellJob for status tests.
+
+    Returns:
+        A `ShellJob` with default settings.
+    """
+    return ShellJob.model_validate({"module": "flepimop2.job.shell"})
+
+
+def test_status_blocking_zero_returncode_is_successful() -> None:
+    """A blocking job with returncode 0 reports SUCCESSFUL."""
+    handle = JobHandle(
+        job_id="0",
+        backend="shell",
+        metadata={"mode": "blocking", "returncode": 0},
+    )
+    result = _shell_job().status(handle)
+    assert result.status is JobStatus.SUCCESSFUL
+    assert result.detail["returncode"] == 0
+
+
+def test_status_blocking_nonzero_returncode_is_failed() -> None:
+    """A blocking job with a nonzero returncode reports FAILED."""
+    handle = JobHandle(
+        job_id="1",
+        backend="shell",
+        metadata={"mode": "blocking", "returncode": 1},
+    )
+    result = _shell_job().status(handle)
+    assert result.status is JobStatus.FAILED
+    assert result.detail["returncode"] == 1
+
+
+def test_status_detached_live_pid_is_running() -> None:
+    """A detached job whose PID is alive reports RUNNING."""
+    handle = JobHandle(job_id="12345", backend="shell", metadata={"mode": "detached"})
+    with patch("flepimop2.job.shell.os.kill", return_value=None):
+        result = _shell_job().status(handle)
+    assert result.status is JobStatus.RUNNING
+
+
+def test_status_detached_dead_pid_is_finished_unknown() -> None:
+    """A detached job whose PID is gone reports FINISHED_UNKNOWN (exit unknown)."""
+    handle = JobHandle(job_id="12345", backend="shell", metadata={"mode": "detached"})
+    with patch("flepimop2.job.shell.os.kill", side_effect=ProcessLookupError):
+        result = _shell_job().status(handle)
+    assert result.status is JobStatus.FINISHED_UNKNOWN
+
+
+def test_status_detached_foreign_pid_is_running() -> None:
+    """A detached job whose PID is owned by another user reports RUNNING."""
+    handle = JobHandle(job_id="12345", backend="shell", metadata={"mode": "detached"})
+    with patch("flepimop2.job.shell.os.kill", side_effect=PermissionError):
+        result = _shell_job().status(handle)
+    assert result.status is JobStatus.RUNNING

--- a/tests/test__cache.py
+++ b/tests/test__cache.py
@@ -1,0 +1,112 @@
+# flepimop2: The FLExible Pipeline for Interchangeable MOdel Processing
+# Copyright (C) 2026  Carl Pearson, Joshua Macdonald, Timothy Willard
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Tests for the `flepimop2._cache` job-handle cache."""
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+from flepimop2 import _cache
+from flepimop2.job.abc import JobHandle
+
+
+def _handle(job_id: str, when: int = 0) -> JobHandle:
+    """Build a fixed-timestamp handle whose ordering follows `when`.
+
+    Args:
+        job_id: The backend job identifier.
+        when: Seconds offset applied to the submission timestamp, controlling
+            relative ordering between handles.
+
+    Returns:
+        A `JobHandle` for the `shell` backend.
+    """
+    return JobHandle(
+        job_id=job_id,
+        backend="shell",
+        submitted_at=datetime(2026, 1, 1, 0, 0, when, tzinfo=UTC),
+    )
+
+
+def test_save_and_load_job_roundtrips(tmp_path: Path) -> None:
+    """A saved job should load back with its handle and config intact."""
+    handle = _handle("42")
+    config = {"module": "flepimop2.job.shell", "detach": False}
+
+    _cache.save_job(handle, config, start=tmp_path)
+    loaded = _cache.load_job("shell-42", start=tmp_path)
+
+    assert loaded is not None
+    assert loaded.handle == handle
+    assert loaded.job_config == config
+
+
+def test_load_job_by_bare_id_when_unambiguous(tmp_path: Path) -> None:
+    """A bare job id should resolve when only one job has it."""
+    _cache.save_job(_handle("7"), {"module": "shell"}, start=tmp_path)
+    loaded = _cache.load_job("7", start=tmp_path)
+    assert loaded is not None
+    assert loaded.handle.job_id == "7"
+
+
+def test_save_job_writes_handle_and_summary(tmp_path: Path) -> None:
+    """Saving a job writes both its handle file and a summary entry."""
+    _cache.save_job(_handle("1"), {"module": "shell"}, start=tmp_path)
+
+    handle_file = tmp_path / ".flepimop2_cache/job/handles/shell-1.json"
+    summary_file = tmp_path / ".flepimop2_cache/job/summary.json"
+    assert handle_file.is_file()
+    assert summary_file.is_file()
+
+    summary = _cache.load_summary(start=tmp_path)
+    assert [e.key for e in summary.jobs] == ["shell-1"]
+    assert summary.jobs[0].status is None
+
+
+def test_load_jobs_sorted_by_submission_time(tmp_path: Path) -> None:
+    """Cached jobs are returned oldest-first regardless of save order."""
+    _cache.save_job(_handle("late", when=30), {"module": "shell"}, start=tmp_path)
+    _cache.save_job(_handle("early", when=10), {"module": "shell"}, start=tmp_path)
+
+    ids = [c.handle.job_id for c in _cache.load_jobs(start=tmp_path)]
+    assert ids == ["early", "late"]
+
+
+def test_update_summary_status(tmp_path: Path) -> None:
+    """Updating a summary status persists for later reads."""
+    _cache.save_job(_handle("1"), {"module": "shell"}, start=tmp_path)
+    _cache.update_summary_status("shell-1", "successful", start=tmp_path)
+
+    summary = _cache.load_summary(start=tmp_path)
+    assert summary.jobs[0].status == "successful"
+
+
+def test_load_jobs_empty_when_no_cache(tmp_path: Path) -> None:
+    """Loading from a directory without a cache yields no jobs."""
+    assert _cache.load_jobs(start=tmp_path) == []
+    assert _cache.load_job("shell-1", start=tmp_path) is None
+    assert _cache.load_summary(start=tmp_path).jobs == []
+
+
+def test_summary_serializes_as_bare_array(tmp_path: Path) -> None:
+    """The root-model summary is persisted as a JSON array, not an object."""
+    _cache.save_job(_handle("1"), {"module": "shell"}, start=tmp_path)
+
+    raw = (tmp_path / ".flepimop2_cache/job/summary.json").read_text()
+    assert raw.lstrip().startswith("[")
+
+    summary = _cache.load_summary(start=tmp_path)
+    assert len(summary) == 1
+    assert [e.key for e in summary] == ["shell-1"]


### PR DESCRIPTION
## Description

Added `flepimop2 job list/status` CLIs to list currently running jobs as well as introspect their status more closely. Also required the implementation of a `.flepimop2_cache` to store results that can be pulled up for users.

## Related issues

Closes #293. Closes #298.

## Checklist

- [x] I have read through and understand the [pull request process](https://github.com/ACCIDDA/flepimop2?tab=contributing-ov-file#pull-request-process).
- [x] I ran successfully ran CI local via `just ci`.
- [x] I have updated the `CHANGELOG.md` or noted "no major changes" in my commit if the PR is small.
