### PR TITLE
Add link to `flepimop2-extras`

### DIFF
--- a/docs/connectors.md
+++ b/docs/connectors.md
@@ -5,5 +5,6 @@
 
 These packages are known to be compatible with `flepimop2`:
 
-- [op_engine](https://accidda.github.io/op_engine/latest/)
-- [op_system](https://accidda.github.io/op_system/latest/)
+- [`flepimop2-extras`](https://github.com/ACCIDDA/flepimop2-extras)
+- [`op_engine`](https://accidda.github.io/op_engine/latest/)
+- [`op_system`](https://accidda.github.io/op_system/latest/)


### PR DESCRIPTION
## Description

Add link to `flepimop2-extras` in documentation.

## Related issues

n/a

## Checklist

- [x] I have read through and understand the [pull request process](https://github.com/ACCIDDA/flepimop2?tab=contributing-ov-file#pull-request-process).
- [x] I ran successfully ran CI local via `just ci`.
- [x] I have updated the `CHANGELOG.md` or noted "no major changes" in my commit if the PR is small.
