### PR TITLE
Support local archive pattern sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Promoted project scaffolding to a pluggable `pattern` module namespace (`PatternABC` and the bundled `flepimop2.pattern.copy`) and added the `flepimop2 pattern` command, so custom project sources/templates can plug in. See [#250](https://github.com/ACCIDDA/flepimop2/issues/250).
+- Added local zip and tar archives as sources for the bundled `copy` pattern. See [#322](https://github.com/ACCIDDA/flepimop2/issues/322).
 
 ### Changed
 

--- a/src/flepimop2/cli/_options.py
+++ b/src/flepimop2/cli/_options.py
@@ -272,10 +272,10 @@ COMMON_OPTIONS: Final[dict[str, CommonOptionEntry]] = {
         click.option(
             "--source",
             default=None,
-            type=click.Path(exists=True, file_okay=False, path_type=Path),
+            type=click.Path(exists=True, path_type=Path),
             help=(
-                "Directory the pattern copies from. Defaults to the bundled "
-                "project template."
+                "Directory or local zip/tar archive the pattern copies from. "
+                "Defaults to the bundled project template."
             ),
         ),
         None,

--- a/src/flepimop2/cli/_pattern_command.py
+++ b/src/flepimop2/cli/_pattern_command.py
@@ -39,8 +39,9 @@ class PatternCommand(CliCommand):
 
     The `PATH` argument specifies where to create the project. If omitted, the
     project is created in the current working directory. `--module` selects the
-    pattern (default `copy`), and `--source` selects what the `copy` pattern
-    copies from (default the bundled project template). So a bare
+    pattern (default `copy`), and `--source` selects the directory or local
+    zip/tar archive the `copy` pattern copies from (default the bundled project
+    template). So a bare
     `flepimop2 pattern PATH` is shorthand for
     `flepimop2 pattern --module copy --source <bundled template> PATH`; point
     `--source` at another project to pattern off it instead.
@@ -54,6 +55,8 @@ class PatternCommand(CliCommand):
         $ flepimop2 pattern
         # Copy from another project instead of the bundled template
         $ flepimop2 pattern --source path/to/existing-project foobar
+        # Unpack a local project archive
+        $ flepimop2 pattern --source path/to/project.zip foobar
 
     """  # noqa: D301
 
@@ -73,8 +76,8 @@ class PatternCommand(CliCommand):
             dry_run: Whether to perform a dry run.
             module: Pattern module that creates the project; defaults to the
                 bundled `copy` pattern when not supplied.
-            source: Directory the pattern copies from; defaults to the bundled
-                template when not supplied.
+            source: Directory or local zip/tar archive the pattern copies from;
+                defaults to the bundled template when not supplied.
 
         Returns:
             An exit code indicating success or failure.
@@ -94,7 +97,11 @@ class PatternCommand(CliCommand):
         # unrelated content already in the target (for example a virtual
         # environment) does not block it. Also check a new target is writable
         # (click already rejects an existing file path).
-        overwrite = pattern.conflicts(path)
+        try:
+            overwrite = pattern.conflicts(path)
+        except ValueError as error:
+            self.error(str(error))
+            return ExitCode.GENERAL
         if overwrite:
             names = ", ".join(str(p) for p in sorted(overwrite)[:5])
             self.error(

--- a/src/flepimop2/pattern/copy/__init__.py
+++ b/src/flepimop2/pattern/copy/__init__.py
@@ -13,11 +13,17 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
-"""The bundled copy pattern: scaffold a project from the template tree."""
+"""The bundled copy pattern: scaffold a project from a directory or archive."""
 
 __all__ = ["CopyPattern"]
 
-from pathlib import Path
+import stat
+import tarfile
+import tempfile
+import zipfile
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path, PurePosixPath
 
 from flepimop2.pattern.abc import PatternABC
 
@@ -27,31 +33,98 @@ _TEMPLATE_DIR = Path(__file__).parents[2] / "templates" / "skeleton"
 class CopyPattern(PatternABC, module="copy"):
     """Scaffold a project by copying a source tree.
 
-    The `source` directory is copied verbatim into the target. It defaults to the
-    bundled project template, so `flepimop2 pattern` with no `--source` produces
-    the documented quickstart; point `source` at another project to pattern off
-    it instead.
+    The `source` directory or zip/tar archive is copied verbatim into the target.
+    It defaults to the bundled project template, so `flepimop2 pattern` with no
+    `--source` produces the documented quickstart; point `source` at another
+    project or a local archive to pattern off it instead.
     """
 
-    # Directory to copy from; None uses the bundled project template.
+    # Directory or archive to copy from; None uses the bundled project template.
     source: Path | None = None
 
-    def _source_dir(self) -> Path:
+    @staticmethod
+    def _safe_member_path(name: str) -> PurePosixPath:
         """
-        Resolve the directory this pattern copies from.
+        Validate and normalize an archive member path.
+
+        Args:
+            name: Member name stored in an archive.
 
         Returns:
-            `source` if set, otherwise the bundled project template.
+            A normalized relative POSIX path.
 
         Raises:
-            ValueError: If `source` is set but is not a directory.
+            ValueError: If the member could escape the extraction directory.
+        """
+        path = PurePosixPath(name.replace("\\", "/"))
+        if path.is_absolute() or ".." in path.parts:
+            msg = f"archive member escapes the target directory: {name}"
+            raise ValueError(msg)
+        return path
+
+    @classmethod
+    def _unpack_archive(cls, source: Path, destination: Path) -> None:
+        """
+        Safely unpack a local zip or tar archive.
+
+        Args:
+            source: Archive to unpack.
+            destination: Temporary directory receiving the archive contents.
+
+        Raises:
+            ValueError: If the format is unsupported or contains unsafe links or
+                paths.
+        """
+        if zipfile.is_zipfile(source):
+            with zipfile.ZipFile(source) as archive:
+                for zip_member in archive.infolist():
+                    cls._safe_member_path(zip_member.filename)
+                    mode = zip_member.external_attr >> 16
+                    if stat.S_ISLNK(mode):
+                        msg = f"archive links are not supported: {zip_member.filename}"
+                        raise ValueError(msg)
+                archive.extractall(destination)  # noqa: S202
+            return
+        if tarfile.is_tarfile(source):
+            with tarfile.open(source) as archive:
+                for tar_member in archive.getmembers():
+                    cls._safe_member_path(tar_member.name)
+                    if tar_member.issym() or tar_member.islnk():
+                        msg = f"archive links are not supported: {tar_member.name}"
+                        raise ValueError(msg)
+                    if not tar_member.isfile() and not tar_member.isdir():
+                        msg = f"archive member type is not supported: {tar_member.name}"
+                        raise ValueError(msg)
+                archive.extractall(destination, filter="fully_trusted")  # noqa: S202
+            return
+        msg = f"pattern source is not a supported zip or tar archive: {source}"
+        raise ValueError(msg)
+
+    @contextmanager
+    def _source_tree(self) -> Iterator[Path]:
+        """
+        Resolve the directory tree this pattern copies from.
+
+        Yields:
+            `source` when it is a directory, the bundled template when unset, or
+            a temporary extraction directory when `source` is an archive.
+
+        Raises:
+            ValueError: If `source` is missing or is not a supported archive.
         """
         if self.source is None:
-            return _TEMPLATE_DIR
-        if not self.source.is_dir():
-            msg = f"pattern source is not a directory: {self.source}"
+            yield _TEMPLATE_DIR
+            return
+        if self.source.is_dir():
+            yield self.source
+            return
+        if not self.source.is_file():
+            msg = f"pattern source does not exist: {self.source}"
             raise ValueError(msg)
-        return self.source
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            extracted = Path(temporary_directory)
+            self._unpack_archive(self.source, extracted)
+            yield extracted
 
     def _scaffold(self, destination: Path, *, dry_run: bool = False) -> None:
         """
@@ -64,7 +137,8 @@ class CopyPattern(PatternABC, module="copy"):
         if dry_run:
             return
         destination.mkdir(parents=True, exist_ok=True)
-        self._copy_template_tree(self._source_dir(), destination)
+        with self._source_tree() as source:
+            self._copy_template_tree(source, destination)
 
     def plan(self) -> str:
         """
@@ -73,7 +147,8 @@ class CopyPattern(PatternABC, module="copy"):
         Returns:
             A text tree of the source's files and directories.
         """
-        return self._render_tree(self._source_dir())
+        with self._source_tree() as source:
+            return self._render_tree(source)
 
     def conflicts(self, destination: Path) -> list[Path]:
         """
@@ -85,12 +160,12 @@ class CopyPattern(PatternABC, module="copy"):
         Returns:
             Paths, relative to the source, that already exist under `destination`.
         """
-        source = self._source_dir()
         found: list[Path] = []
-        for item in source.rglob("*"):
-            if not item.is_file() or "__pycache__" in item.parts:
-                continue
-            relative = item.relative_to(source)
-            if (destination / relative).exists():
-                found.append(relative)
+        with self._source_tree() as source:
+            for item in source.rglob("*"):
+                if not item.is_file() or "__pycache__" in item.parts:
+                    continue
+                relative = item.relative_to(source)
+                if (destination / relative).exists():
+                    found.append(relative)
         return found

--- a/tests/cli/_pattern_command/test_run.py
+++ b/tests/cli/_pattern_command/test_run.py
@@ -16,6 +16,7 @@
 """Tests for `PatternCommand.run` via the `flepimop2 pattern` CLI."""
 
 import os
+import zipfile
 from pathlib import Path
 
 import pytest
@@ -152,6 +153,34 @@ def test_run_source_option_copies_the_given_tree(tmp_path: Path) -> None:
     assert result.exit_code == ExitCode.OKAY
     assert _relative_files(target) == _relative_files(source)
     assert (target / "sub" / "inner.txt").read_text() == "hi"
+
+
+def test_run_source_option_unpacks_a_local_archive(tmp_path: Path) -> None:
+    """`--source` accepts a local archive as well as a directory."""
+    archive_path = tmp_path / "project.zip"
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("configs/config.yaml", "name: archived")
+    target = tmp_path / "project"
+
+    result = CliRunner().invoke(
+        cli, ["pattern", "--source", str(archive_path), str(target)]
+    )
+
+    assert result.exit_code == ExitCode.OKAY
+    assert (target / "configs" / "config.yaml").read_text() == "name: archived"
+
+
+def test_run_rejects_an_unsupported_source_file(tmp_path: Path) -> None:
+    """An unsupported source file reports a clean command error."""
+    source = tmp_path / "project.txt"
+    source.write_text("not an archive")
+    target = tmp_path / "project"
+
+    result = CliRunner().invoke(cli, ["pattern", "--source", str(source), str(target)])
+
+    assert result.exit_code == ExitCode.GENERAL
+    assert "not a supported zip or tar archive" in result.output
+    assert not target.exists()
 
 
 def test_run_module_short_flag_selects_the_pattern(tmp_path: Path) -> None:

--- a/tests/pattern/test_copy_pattern_class.py
+++ b/tests/pattern/test_copy_pattern_class.py
@@ -15,6 +15,8 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """Tests for `CopyPattern.scaffold`."""
 
+import tarfile
+import zipfile
 from pathlib import Path
 
 import pytest
@@ -79,9 +81,48 @@ def test_source_overrides_the_bundled_template(tmp_path: Path) -> None:
     assert "custom.txt" in CopyPattern(source=source).plan()
 
 
+@pytest.mark.parametrize("archive_type", ["zip", "tar"])
+def test_archive_source_is_unpacked(tmp_path: Path, archive_type: str) -> None:
+    """A local zip or tar source is unpacked into the destination."""
+    source = tmp_path / "source"
+    (source / "nested").mkdir(parents=True)
+    (source / "top.yaml").write_text("x: 1")
+    (source / "nested" / "inner.txt").write_text("hello")
+    archive_path = tmp_path / f"source.{archive_type}"
+    if archive_type == "zip":
+        with zipfile.ZipFile(archive_path, "w") as archive:
+            for path in source.rglob("*"):
+                if path.is_file():
+                    archive.write(path, path.relative_to(source))
+    else:
+        with tarfile.open(archive_path, "w") as archive:
+            for path in source.rglob("*"):
+                archive.add(path, path.relative_to(source), recursive=False)
+
+    destination = tmp_path / "out"
+    pattern = CopyPattern(source=archive_path)
+    pattern.scaffold(destination)
+
+    assert (destination / "top.yaml").read_text() == "x: 1"
+    assert (destination / "nested" / "inner.txt").read_text() == "hello"
+    assert "inner.txt" in pattern.plan()
+
+
+def test_archive_source_rejects_parent_traversal(tmp_path: Path) -> None:
+    """An archive member cannot write outside the destination."""
+    archive_path = tmp_path / "unsafe.zip"
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("../outside.txt", "unsafe")
+
+    with pytest.raises(ValueError, match="escapes the target"):
+        CopyPattern(source=archive_path).scaffold(tmp_path / "out")
+
+    assert not (tmp_path / "outside.txt").exists()
+
+
 def test_a_source_that_is_not_a_directory_is_rejected(tmp_path: Path) -> None:
     """A `source` pointing at a missing path raises rather than scaffolding."""
     pattern = CopyPattern(source=tmp_path / "does_not_exist")
 
-    with pytest.raises(ValueError, match="not a directory"):
+    with pytest.raises(ValueError, match="does not exist"):
         pattern.scaffold(tmp_path / "out")


### PR DESCRIPTION
## Summary

- accept local zip and tar files through `flepimop2 pattern --source`
- safely validate archive paths and reject links or special tar members before extraction
- use archive contents consistently for conflict detection, dry-run plans, and scaffolding
- report unsupported source files as clean CLI errors

URL and git repository sources remain out of core and can be implemented as optional extras providers, as scoped in #322.

## Validation

- `ruff format --check`
- `ruff check --no-fix`
- `mypy`
- pattern and pattern-CLI tests: 26 passed
- full non-integration suite: 577 passed, 2 skipped, 5 deselected, 1 xfailed

Closes #322
