### PR TITLE
Add config-declared process dependencies and DAG execution (#323)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Promoted project scaffolding to a pluggable `pattern` module namespace (`PatternABC` and the bundled `flepimop2.pattern.copy`) and added the `flepimop2 pattern` command, so custom project sources/templates can plug in. See [#250](https://github.com/ACCIDDA/flepimop2/issues/250).
 - Added local zip and tar archives as sources for the bundled `copy` pattern. See [#322](https://github.com/ACCIDDA/flepimop2/issues/322).
+- Process steps can declare upstream steps with `depends`, and `flepimop2 process` now runs a step's dependencies first, in dependency order. Unknown references, self-dependencies, and cycles are rejected before anything executes. A step may report its target as already present via `ProcessABC.is_satisfied()`, which makes a re-run a no-op; `--force` runs the requested step anyway. See [#323](https://github.com/ACCIDDA/flepimop2/issues/323).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Promoted project scaffolding to a pluggable `pattern` module namespace (`PatternABC` and the bundled `flepimop2.pattern.copy`) and added the `flepimop2 pattern` command, so custom project sources/templates can plug in. See [#250](https://github.com/ACCIDDA/flepimop2/issues/250).
 - Added local zip and tar archives as sources for the bundled `copy` pattern. See [#322](https://github.com/ACCIDDA/flepimop2/issues/322).
-- Process steps can declare upstream steps with `depends`, and `flepimop2 process` now runs a step's dependencies first, in dependency order. Unknown references, self-dependencies, and cycles are rejected before anything executes. A step may report its target as already present via `ProcessABC.is_satisfied()`, which makes a re-run a no-op; `--force` runs the requested step anyway. See [#323](https://github.com/ACCIDDA/flepimop2/issues/323).
+- Process steps can declare upstream steps with `depends`, and `flepimop2 process` now runs a step's dependencies first, in dependency order. Unknown references, self-dependencies, and cycles are rejected before anything executes. A step may report its target as already present via `ProcessABC.is_satisfied()`, which makes a re-run a no-op; `-f`/`--force` runs the requested step anyway, and repeating it (`-ff`) forces that step's dependencies too. See [#323](https://github.com/ACCIDDA/flepimop2/issues/323).
 
 ### Changed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,6 +57,10 @@ We use [`ruff`](https://docs.astral.sh/ruff/) for both formatting and linting:
 
 Run `just` to automatically format/lint, type check, and run tests before committing. If you only want formatting/linting, run `just ruff`.
 
+### CLI options
+
+Give every option added to `flepimop2.cli._options.COMMON_OPTIONS` **both** a short and a long flag, e.g. `click.option("-f", "--force", ...)`. Short flags are what users reach for interactively, and a counted option depends on having one: commands are re-dispatched to job backends by rendering their bound options back into argv, and `_render_param` renders a counter by repeating its *short* flag, so a counted option without one renders unusably.
+
 ## Testing
 
 ### Organization

--- a/src/flepimop2/cli/_options.py
+++ b/src/flepimop2/cli/_options.py
@@ -187,13 +187,15 @@ COMMON_OPTIONS: Final[dict[str, CommonOptionEntry]] = {
     ),
     "force": (
         click.option(
+            "-f",
             "--force",
-            is_flag=True,
-            default=False,
+            count=True,
+            default=0,
             help=(
                 "Run the requested step even when its target is already "
-                "present. Dependencies are left alone, so forcing a step does "
-                "not re-run everything upstream of it."
+                "present. Given once, dependencies are left alone, so forcing "
+                "a step does not re-run everything upstream of it; repeat it "
+                "(-ff) to force the step's dependencies as well."
             ),
         ),
         None,

--- a/src/flepimop2/cli/_options.py
+++ b/src/flepimop2/cli/_options.py
@@ -185,6 +185,19 @@ COMMON_OPTIONS: Final[dict[str, CommonOptionEntry]] = {
         ),
         None,
     ),
+    "force": (
+        click.option(
+            "--force",
+            is_flag=True,
+            default=False,
+            help=(
+                "Run the requested step even when its target is already "
+                "present. Dependencies are left alone, so forcing a step does "
+                "not re-run everything upstream of it."
+            ),
+        ),
+        None,
+    ),
     "job_id": (
         click.argument(
             "job_id",

--- a/src/flepimop2/cli/_process_command.py
+++ b/src/flepimop2/cli/_process_command.py
@@ -23,6 +23,7 @@ from flepimop2._utils._click import _resolve_config_target
 from flepimop2.cli._cli_command import CliCommand
 from flepimop2.configuration import ConfigurationModel
 from flepimop2.process.abc import build as build_process
+from flepimop2.process.abc import resolve_plan
 from flepimop2.typing import ExitCode
 
 
@@ -55,14 +56,23 @@ class ProcessCommand(CliCommand):
         config: Path,
         dry_run: bool,
         target: str | None = None,
+        force: bool = False,
     ) -> ExitCode:
         """
-        Execute the processing step.
+        Execute the processing step and anything it depends on.
+
+        The requested step's `depends` are resolved first, so asking for one
+        step also runs whatever it needs, in dependency order. A step that
+        reports its target already satisfied is skipped, which is what makes
+        re-running a pipeline cheap.
 
         Args:
             config: Path to the configuration file.
             dry_run: Whether dry run mode is enabled.
             target: Optional target process config to use.
+            force: Run the requested step even when its target is already
+                present. Dependencies keep their normal skip behaviour, so
+                forcing a transform does not re-fetch its inputs.
 
         Returns:
             An exit code indicating success or failure.
@@ -79,6 +89,16 @@ class ProcessCommand(CliCommand):
         self.info(f"Process section: {processconfig}")
         self.info(f"Process target: {processtargetname} => {processtarget}")
 
-        process_instance = build_process(processtarget)
-        process_instance.execute(dry_run=dry_run)
+        plan = resolve_plan(processconfig, processtargetname)
+        if len(plan) > 1:
+            self.info(f"Process plan: {' -> '.join(plan)}")
+
+        for step in plan:
+            process_instance = build_process(processconfig[step])
+            # Only the step actually asked for is forced; its dependencies keep
+            # their own satisfied-means-skip behaviour.
+            process_instance.execute(
+                dry_run=dry_run,
+                force=force and step == processtargetname,
+            )
         return ExitCode.OKAY

--- a/src/flepimop2/cli/_process_command.py
+++ b/src/flepimop2/cli/_process_command.py
@@ -26,6 +26,41 @@ from flepimop2.process.abc import build as build_process
 from flepimop2.process.abc import resolve_plan
 from flepimop2.typing import ExitCode
 
+# `--force` is a counter so that forcing a step and forcing everything it needs
+# are separate asks: one `-f` re-runs the step you named, a second also re-runs
+# its dependencies.
+_FORCE_TARGET = 1
+_FORCE_DEPENDENCIES = 2
+
+
+def _should_force(force: int, step: str, target: str | None) -> bool:
+    """
+    Decide whether one step of a plan runs regardless of being satisfied.
+
+    Args:
+        force: How many times `--force` was given.
+        step: The plan step being considered.
+        target: The step the user actually asked for.
+
+    Returns:
+        True if this step should run even when its target already exists.
+
+    Examples:
+        >>> from flepimop2.cli._process_command import _should_force
+        >>> _should_force(0, "transform", "transform")
+        False
+        >>> _should_force(1, "transform", "transform")
+        True
+        >>> _should_force(1, "fetch", "transform")
+        False
+        >>> _should_force(2, "fetch", "transform")
+        True
+
+    """
+    if force >= _FORCE_DEPENDENCIES:
+        return True
+    return force >= _FORCE_TARGET and step == target
+
 
 class ProcessCommand(CliCommand):
     """
@@ -56,7 +91,7 @@ class ProcessCommand(CliCommand):
         config: Path,
         dry_run: bool,
         target: str | None = None,
-        force: bool = False,
+        force: int = 0,
     ) -> ExitCode:
         """
         Execute the processing step and anything it depends on.
@@ -70,9 +105,11 @@ class ProcessCommand(CliCommand):
             config: Path to the configuration file.
             dry_run: Whether dry run mode is enabled.
             target: Optional target process config to use.
-            force: Run the requested step even when its target is already
-                present. Dependencies keep their normal skip behaviour, so
-                forcing a transform does not re-fetch its inputs.
+            force: How much of the plan to run regardless of whether its
+                targets are already present. `0` skips satisfied steps, `1`
+                (`-f`) forces only the requested step, so forcing a transform
+                does not re-fetch its inputs, and `2` or more (`-ff`) forces
+                its dependencies too.
 
         Returns:
             An exit code indicating success or failure.
@@ -95,10 +132,10 @@ class ProcessCommand(CliCommand):
 
         for step in plan:
             process_instance = build_process(processconfig[step])
-            # Only the step actually asked for is forced; its dependencies keep
-            # their own satisfied-means-skip behaviour.
+            # One -f forces just the step asked for, leaving its dependencies
+            # to their own satisfied-means-skip behaviour; -ff forces those too.
             process_instance.execute(
                 dry_run=dry_run,
-                force=force and step == processtargetname,
+                force=_should_force(force, step, processtargetname),
             )
         return ExitCode.OKAY

--- a/src/flepimop2/process/abc/__init__.py
+++ b/src/flepimop2/process/abc/__init__.py
@@ -15,10 +15,12 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """Abstract base class for flepimop2 processing steps."""
 
-__all__ = ["ProcessABC", "build"]
+__all__ = ["ProcessABC", "build", "resolve_plan"]
 
 from abc import abstractmethod
 from typing import Any
+
+from pydantic import Field
 
 from flepimop2._utils._module import _build
 from flepimop2.exceptions import Flepimop2ValidationError, ValidationIssue
@@ -26,15 +28,33 @@ from flepimop2.module import ModuleBase
 
 
 class ProcessABC(ModuleBase, module_namespace="process"):
-    """Abstract base class for flepimop2 processing steps."""
+    """
+    Abstract base class for flepimop2 processing steps.
 
-    def execute(self, *, dry_run: bool = False) -> None:
+    Attributes:
+        depends: Names of process steps in the same configuration section that
+            must run before this one. These are opaque identifiers, i.e. sibling
+            keys of the `process:` section, not filesystem paths: core orders
+            steps but does not know what any of them produces.
+
+    """
+
+    depends: list[str] = Field(default_factory=list)
+
+    def execute(self, *, dry_run: bool = False, force: bool = False) -> None:
         """
         Execute a processing step.
+
+        A step whose target is already satisfied is skipped, so re-running a
+        pipeline costs nothing rather than repeating work. `force` overrides
+        that, giving a target the three states it needs: absent, present, and
+        present-with-force.
 
         Args:
             dry_run: If True, the process will not actually execute but will simulate
                 execution.
+            force: If True, run even when `is_satisfied()` reports that the
+                target is already present.
 
         Raises:
             Flepimop2ValidationError: If validation fails during a dry run.
@@ -43,7 +63,28 @@ class ProcessABC(ModuleBase, module_namespace="process"):
             if result:
                 raise Flepimop2ValidationError(result)
             return None
+        if not force and self.is_satisfied():
+            return None
         return self._process(dry_run=dry_run)
+
+    def is_satisfied(self) -> bool:  # noqa: PLR6301
+        """
+        Report whether this step's target already exists.
+
+        Override this in a module that produces a durable target (a fetched
+        file, a transformed dataset) so that re-running the pipeline skips work
+        already done. The default is `False`, i.e. always run, which is correct
+        for a step with no persistent target.
+
+        Core deliberately does not inspect the target itself: only the module
+        knows what it produces and what counts as fresh, so cache-freshness and
+        provenance policy live with the provider rather than here.
+
+        Returns:
+            True if the step can be skipped, otherwise False.
+
+        """
+        return False
 
     @abstractmethod
     def _process(self, *, dry_run: bool) -> None:
@@ -74,3 +115,182 @@ def build(config: dict[str, Any] | ModuleBase | str) -> ProcessABC:
 
     """
     return _build(config, "process", ProcessABC)  # type: ignore[type-abstract]
+
+
+def _declared_depends(entry: object) -> list[str]:
+    """
+    Read the `depends` list off a raw process configuration entry.
+
+    Read from the configuration rather than from a built `ProcessABC` so that
+    the whole graph can be validated before any module is imported: a typo in a
+    `depends` name should not require every module in the section to load first.
+
+    Args:
+        entry: A single process configuration entry.
+
+    Returns:
+        The declared dependency names, or an empty list when none are declared.
+
+    """
+    if isinstance(entry, ModuleBase):
+        return list(getattr(entry, "depends", []) or [])
+    if isinstance(entry, dict):
+        declared = entry.get("depends") or []
+        return [declared] if isinstance(declared, str) else list(declared)
+    return []
+
+
+def _depends_issues(depends: dict[str, list[str]]) -> list[ValidationIssue]:
+    """
+    Collect every problem with the declared dependency references.
+
+    Every reference is checked rather than stopping at the first bad one, so a
+    mis-wired configuration takes a single pass to fix.
+
+    Args:
+        depends: Mapping of step name to the names it declares a dependency on.
+
+    Returns:
+        One issue per bad reference; empty when the references are sound.
+
+    """
+    issues: list[ValidationIssue] = []
+    for name, upstream in depends.items():
+        for dep in upstream:
+            if dep == name:
+                issues.append(
+                    ValidationIssue(
+                        msg=f"Process step '{name}' depends on itself.",
+                        kind="self_dependency",
+                        ctx={"step": name},
+                    )
+                )
+            elif dep not in depends:
+                issues.append(
+                    ValidationIssue(
+                        msg=f"Process step '{name}' depends on unknown step '{dep}'.",
+                        kind="unknown_dependency",
+                        ctx={"step": name, "depends": dep, "known": sorted(depends)},
+                    )
+                )
+    return issues
+
+
+def _narrow_to_target(
+    depends: dict[str, list[str]],
+    target: str,
+) -> dict[str, list[str]]:
+    """
+    Reduce the graph to a target and everything it transitively needs.
+
+    Args:
+        depends: Mapping of step name to the names it declares a dependency on.
+        target: The step being planned for.
+
+    Returns:
+        The subgraph containing `target` and its transitive dependencies.
+
+    Raises:
+        KeyError: If `target` is not a step in the graph.
+
+    """
+    if target not in depends:
+        msg = f"Process step '{target}' not found in {sorted(depends)}."
+        raise KeyError(msg)
+    wanted: set[str] = set()
+    stack = [target]
+    while stack:
+        name = stack.pop()
+        if name in wanted:
+            continue
+        wanted.add(name)
+        stack.extend(depends[name])
+    return {name: up for name, up in depends.items() if name in wanted}
+
+
+def _topological_order(depends: dict[str, list[str]]) -> list[str]:
+    """
+    Order steps so that each one follows everything it depends on.
+
+    Kahn's algorithm over the declared edges. Ties are broken by the order the
+    steps appear in the configuration, so a plan is reproducible between runs
+    and reads the way the file does.
+
+    Args:
+        depends: Mapping of step name to the names it declares a dependency on.
+
+    Returns:
+        The step names in dependency order.
+
+    Raises:
+        Flepimop2ValidationError: If the declared dependencies form a cycle.
+
+    """
+    order = list(depends)
+    remaining = {name: set(upstream) for name, upstream in depends.items()}
+    plan: list[str] = []
+    while remaining:
+        ready = [name for name in order if name in remaining and not remaining[name]]
+        if not ready:
+            cycle = sorted(remaining)
+            raise Flepimop2ValidationError([
+                ValidationIssue(
+                    msg=f"Process steps form a dependency cycle: {', '.join(cycle)}.",
+                    kind="dependency_cycle",
+                    ctx={"steps": cycle},
+                )
+            ])
+        for name in ready:
+            plan.append(name)
+            del remaining[name]
+        for upstream in remaining.values():
+            upstream.difference_update(ready)
+    return plan
+
+
+def resolve_plan(
+    section: dict[str, Any],
+    target: str | None = None,
+) -> list[str]:
+    """
+    Resolve a process configuration section into an execution order.
+
+    Validates every `depends` reference, rejects cycles, and returns the step
+    names in dependency order. When `target` is given, the plan is narrowed to
+    that step and its transitive dependencies, so asking for one step still runs
+    what it needs.
+
+    All problems are collected and reported together, rather than failing on the
+    first one, so a mis-wired configuration takes one pass to fix.
+
+    A `target` that is not a step in `section` raises `KeyError`.
+
+    Args:
+        section: The `process` configuration section, mapping step name to entry.
+        target: Optional step to plan for. `None` plans the whole section.
+
+    Returns:
+        Step names in an order where every step follows its dependencies.
+
+    Raises:
+        Flepimop2ValidationError: If a `depends` name is unknown, a step depends
+            on itself, or the declared dependencies form a cycle.
+
+    Examples:
+        >>> from flepimop2.process.abc import resolve_plan
+        >>> section = {
+        ...     "transform": {"module": "shell", "depends": ["fetch"]},
+        ...     "fetch": {"module": "shell"},
+        ... }
+        >>> resolve_plan(section)
+        ['fetch', 'transform']
+        >>> resolve_plan(section, target="fetch")
+        ['fetch']
+
+    """
+    depends = {name: _declared_depends(entry) for name, entry in section.items()}
+    if issues := _depends_issues(depends):
+        raise Flepimop2ValidationError(issues)
+    if target is not None:
+        depends = _narrow_to_target(depends, target)
+    return _topological_order(depends)

--- a/tests/process/test_process_plan.py
+++ b/tests/process/test_process_plan.py
@@ -1,0 +1,208 @@
+# flepimop2: The FLExible Pipeline for Interchangeable MOdel Processing
+# Copyright (C) 2026  Carl Pearson, Joshua Macdonald, Timothy Willard
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Tests for process dependency declaration, planning, and the no-op contract."""
+
+from typing import Any
+
+import pytest
+
+from flepimop2.exceptions import Flepimop2ValidationError
+from flepimop2.process.abc import ProcessABC, resolve_plan
+
+
+def _step(depends: list[str] | None = None) -> dict[str, Any]:
+    """
+    Build a minimal process configuration entry.
+
+    Args:
+        depends: Optional dependency names to declare on the step.
+
+    Returns:
+        A process configuration entry.
+
+    """
+    config: dict[str, Any] = {"module": "shell", "command": "true"}
+    if depends is not None:
+        config["depends"] = depends
+    return config
+
+
+# --- planning -----------------------------------------------------------------
+
+
+def test_resolve_plan_orders_dependencies_first() -> None:
+    """A step is planned after everything it declares a dependency on."""
+    section = {"transform": _step(["fetch"]), "fetch": _step()}
+    assert resolve_plan(section) == ["fetch", "transform"]
+
+
+def test_resolve_plan_orders_a_chain() -> None:
+    """Transitive dependencies are ordered, not just direct ones."""
+    section = {"c": _step(["b"]), "b": _step(["a"]), "a": _step()}
+    assert resolve_plan(section) == ["a", "b", "c"]
+
+
+def test_resolve_plan_without_dependencies_keeps_config_order() -> None:
+    """Independent steps stay in the order the configuration lists them.
+
+    Ties are broken by configuration order so a plan is reproducible between
+    runs and reads the way the file does.
+    """
+    section = {"b": _step(), "a": _step(), "c": _step()}
+    assert resolve_plan(section) == ["b", "a", "c"]
+
+
+def test_resolve_plan_narrows_to_a_target_and_its_upstream() -> None:
+    """Asking for one step plans that step plus what it needs, nothing else."""
+    section = {
+        "fetch": _step(),
+        "transform": _step(["fetch"]),
+        "unrelated": _step(),
+    }
+    assert resolve_plan(section, target="transform") == ["fetch", "transform"]
+    assert resolve_plan(section, target="fetch") == ["fetch"]
+
+
+def test_resolve_plan_accepts_a_scalar_depends() -> None:
+    """A single dependency may be written without a list."""
+    section = {"transform": {"module": "shell", "depends": "fetch"}, "fetch": _step()}
+    assert resolve_plan(section) == ["fetch", "transform"]
+
+
+def test_resolve_plan_of_an_empty_section_is_empty() -> None:
+    """An empty process section plans nothing rather than erroring."""
+    assert resolve_plan({}) == []
+
+
+# --- validation ---------------------------------------------------------------
+
+
+def test_resolve_plan_rejects_an_unknown_dependency() -> None:
+    """A `depends` name that is not a sibling step is reported, with context."""
+    with pytest.raises(Flepimop2ValidationError) as excinfo:
+        resolve_plan({"transform": _step(["nope"])})
+    issues = excinfo.value.issues
+    assert len(issues) == 1
+    assert issues[0].kind == "unknown_dependency"
+    assert issues[0].ctx is not None
+    assert issues[0].ctx["depends"] == "nope"
+
+
+def test_resolve_plan_rejects_a_self_dependency() -> None:
+    """A step depending on itself is its own error, not a generic cycle."""
+    with pytest.raises(Flepimop2ValidationError) as excinfo:
+        resolve_plan({"loop": _step(["loop"])})
+    assert excinfo.value.issues[0].kind == "self_dependency"
+
+
+def test_resolve_plan_rejects_a_cycle() -> None:
+    """Mutually dependent steps are rejected before anything executes."""
+    section = {"a": _step(["b"]), "b": _step(["a"])}
+    with pytest.raises(Flepimop2ValidationError) as excinfo:
+        resolve_plan(section)
+    issue = excinfo.value.issues[0]
+    assert issue.kind == "dependency_cycle"
+    assert issue.ctx is not None
+    assert issue.ctx["steps"] == ["a", "b"]
+
+
+def test_resolve_plan_rejects_a_longer_cycle() -> None:
+    """A cycle through an intermediate step is detected too."""
+    section = {"a": _step(["c"]), "b": _step(["a"]), "c": _step(["b"])}
+    with pytest.raises(Flepimop2ValidationError) as excinfo:
+        resolve_plan(section)
+    assert excinfo.value.issues[0].kind == "dependency_cycle"
+
+
+def test_resolve_plan_reports_every_bad_reference_at_once() -> None:
+    """All reference problems are collected, so one pass fixes the config."""
+    section = {"a": _step(["missing_one"]), "b": _step(["missing_two"])}
+    with pytest.raises(Flepimop2ValidationError) as excinfo:
+        resolve_plan(section)
+    kinds = [issue.kind for issue in excinfo.value.issues]
+    assert kinds == ["unknown_dependency", "unknown_dependency"]
+
+
+def test_resolve_plan_rejects_an_unknown_target() -> None:
+    """Planning for a step that does not exist is a KeyError, not a bad plan."""
+    with pytest.raises(KeyError):
+        resolve_plan({"fetch": _step()}, target="nope")
+
+
+# --- the no-op contract -------------------------------------------------------
+
+
+class _CountingProcess(ProcessABC, module="counting"):
+    """A process that records how many times it actually ran."""
+
+    satisfied: bool = False
+    runs: int = 0
+
+    def is_satisfied(self) -> bool:
+        """
+        Report the satisfaction state this instance was configured with.
+
+        Returns:
+            Whether the step should be treated as already done.
+
+        """
+        return self.satisfied
+
+    def _process(self, *, dry_run: bool) -> None:
+        """Count a real execution."""
+        if not dry_run:
+            self.runs += 1
+
+
+def test_execute_runs_when_the_target_is_absent() -> None:
+    """The default contract is to run: no target, no skipping."""
+    process = _CountingProcess(satisfied=False)
+    process.execute()
+    assert process.runs == 1
+
+
+def test_execute_skips_when_the_target_is_satisfied() -> None:
+    """A satisfied step is a no-op, which is what makes re-runs cheap."""
+    process = _CountingProcess(satisfied=True)
+    process.execute()
+    assert process.runs == 0
+
+
+def test_execute_force_overrides_satisfaction() -> None:
+    """`force` is the third state: present, but run anyway."""
+    process = _CountingProcess(satisfied=True)
+    process.execute(force=True)
+    assert process.runs == 1
+
+
+def test_is_satisfied_defaults_to_false() -> None:
+    """A step with no durable target always runs."""
+
+    class _Plain(ProcessABC, module="plain"):
+        def _process(self, *, dry_run: bool) -> None:  # noqa: ARG002
+            return None
+
+    assert _Plain().is_satisfied() is False
+
+
+def test_depends_defaults_to_empty() -> None:
+    """Declaring no dependencies is the common case and needs no config."""
+
+    class _Plain2(ProcessABC, module="plain2"):
+        def _process(self, *, dry_run: bool) -> None:  # noqa: ARG002
+            return None
+
+    assert _Plain2().depends == []

--- a/tests/process/test_process_plan.py
+++ b/tests/process/test_process_plan.py
@@ -19,6 +19,9 @@ from typing import Any
 
 import pytest
 
+from flepimop2._utils._click import _click_param_for_option, _render_param
+from flepimop2.cli._options import get_option
+from flepimop2.cli._process_command import _should_force
 from flepimop2.exceptions import Flepimop2ValidationError
 from flepimop2.process.abc import ProcessABC, resolve_plan
 
@@ -63,6 +66,58 @@ def test_resolve_plan_without_dependencies_keeps_config_order() -> None:
     """
     section = {"b": _step(), "a": _step(), "c": _step()}
     assert resolve_plan(section) == ["b", "a", "c"]
+
+
+def test_resolve_plan_orders_multiple_dependencies_before_their_dependent() -> None:
+    """A step with several dependencies runs after all of them.
+
+    The dependencies are mutually independent, so their relative order is only
+    required to follow the configuration; what must hold is that every one of
+    them precedes the step that declares them.
+    """
+    section = {
+        "combine": _step(["fetch_b", "fetch_a", "fetch_c"]),
+        "fetch_a": _step(),
+        "fetch_b": _step(),
+        "fetch_c": _step(),
+    }
+    plan = resolve_plan(section)
+
+    assert plan[-1] == "combine"
+    # Independent steps keep configuration order rather than the order they
+    # happen to be named in `depends`.
+    assert plan[:-1] == ["fetch_a", "fetch_b", "fetch_c"]
+
+
+def test_resolve_plan_orders_a_diamond() -> None:
+    """A step reachable by two paths runs once, after both of them."""
+    section = {
+        "report": _step(["left", "right"]),
+        "left": _step(["base"]),
+        "right": _step(["base"]),
+        "base": _step(),
+    }
+    plan = resolve_plan(section)
+
+    assert plan.count("base") == 1
+    assert plan.index("base") < plan.index("left")
+    assert plan.index("base") < plan.index("right")
+    assert plan.index("left") < plan.index("report")
+    assert plan.index("right") < plan.index("report")
+
+
+def test_resolve_plan_narrows_past_multiple_dependencies() -> None:
+    """Narrowing to a step pulls in every branch it needs, and nothing else."""
+    section = {
+        "combine": _step(["fetch_a", "fetch_b"]),
+        "fetch_a": _step(),
+        "fetch_b": _step(),
+        "unrelated": _step(),
+    }
+    plan = resolve_plan(section, target="combine")
+
+    assert plan == ["fetch_a", "fetch_b", "combine"]
+    assert "unrelated" not in plan
 
 
 def test_resolve_plan_narrows_to_a_target_and_its_upstream() -> None:
@@ -206,3 +261,45 @@ def test_depends_defaults_to_empty() -> None:
             return None
 
     assert _Plain2().depends == []
+
+
+# --- the --force counter ------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("force", "expected"),
+    [
+        (0, (False, False)),
+        (1, (True, False)),
+        (2, (True, True)),
+        (3, (True, True)),
+    ],
+)
+def test_force_counter_selects_how_much_of_the_plan_is_forced(
+    force: int,
+    expected: tuple[bool, bool],
+) -> None:
+    """`-f` forces the requested step, `-ff` its dependencies as well.
+
+    Separating the two keeps the common case cheap: re-running a transform
+    should not re-download everything upstream of it unless asked.
+    """
+    target_forced, dependency_forced = expected
+    assert _should_force(force, "transform", "transform") is target_forced
+    assert _should_force(force, "fetch", "transform") is dependency_forced
+
+
+def test_force_option_renders_back_to_repeated_short_flag() -> None:
+    """A counted `--force` must survive being re-rendered as argv.
+
+    Commands are re-dispatched to job backends by rendering their bound options
+    back into tokens, and `_render_param` renders a counter using its *short*
+    flag. Without `-f` the option would render as `-forceforce`, so the
+    shorthand is what makes the counter round-trip.
+    """
+    param = _click_param_for_option(get_option("force"))
+    assert param is not None
+    assert "-f" in param.opts
+    assert _render_param(param, 0) == []
+    assert _render_param(param, 1) == ["-f"]
+    assert _render_param(param, 2) == ["-ff"]


### PR DESCRIPTION
Draft, because #323 left three design questions open and this answers them. The code is complete and green; the point of the draft is to review the **contract** before flepimop2-extras #16 and #22 build on it.

## The three questions, answered

Each answer is the least-committal option I could find that still supports the motivating `fetch -> transform` pipeline.

**1. Is `depends` declared on the process configuration, the process module, or a separate run plan?**

On the process configuration entry, naming sibling keys of the `process:` section, typed as a field on `ProcessABC` so it validates and documents itself. No new config section, no separate run-plan concept. `ModuleBase` is `extra="allow"`, so a `depends` key already flowed through untyped; this just makes it explicit.

```yaml
process:
  fetch:
    module: shell
    command: curl
  transform:
    module: shell
    depends: [fetch]
```

**2. Are targets opaque identifiers or filesystem paths?**

Opaque. `depends` names steps, never files. Core orders steps and never learns what any of them produces, which keeps filesystem semantics in the providers, where the issue wanted them.

**3. Does core own topological execution only, or also cache freshness and provenance?**

Execution only. A step answers `is_satisfied()` for itself and core skips it; core never inspects a target, because only the module knows what it produces and what counts as fresh. The `depends` metadata is preserved for the status and provenance reporting the issue anticipates, but nothing here interprets it.

## What this gives you

- `resolve_plan()` validates every reference, rejects self-dependencies and cycles, and returns steps in dependency order. Problems are collected and reported together rather than one per run.
- Validation reads the **raw config**, so a typo in a `depends` name is caught without importing every module in the section first.
- Ties break by configuration order, so a plan is reproducible between runs and reads the way the file does.
- Asking for one step plans that step plus its transitive dependencies: `flepimop2 process --target transform` fetches first.
- `execute(force=)` gives a target the three states the issue names: absent, present, present-with-force. **Only the step actually requested is forced**; dependencies keep their own skip behaviour, so forcing a transform does not re-download its inputs. That felt like the least surprising choice, but it is a judgment call worth confirming.

## Verification

- 596 tests pass, 19 of them new (planning, ordering, narrowing, all three validation failures, and the no-op/force contract)
- `ruff format --check`, `ruff check --no-fix`: clean
- `mypy` (strict): clean
- the `resolve_plan` doctest passes

## Not in scope

Provider-specific fetching and transforms stay in flepimop2-extras, per the issue. Nothing here reads or writes a file target.

Closes #323
