### PR TITLE
Let process steps run once per scenario (#252)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Promoted project scaffolding to a pluggable `pattern` module namespace (`PatternABC` and the bundled `flepimop2.pattern.copy`) and added the `flepimop2 pattern` command, so custom project sources/templates can plug in. See [#250](https://github.com/ACCIDDA/flepimop2/issues/250).
 - Added local zip and tar archives as sources for the bundled `copy` pattern. See [#322](https://github.com/ACCIDDA/flepimop2/issues/322).
 - Process steps can declare upstream steps with `depends`, and `flepimop2 process` now runs a step's dependencies first, in dependency order. Unknown references, self-dependencies, and cycles are rejected before anything executes. A step may report its target as already present via `ProcessABC.is_satisfied()`, which makes a re-run a no-op; `-f`/`--force` runs the requested step anyway, and repeating it (`-ff`) forces that step's dependencies too. See [#323](https://github.com/ACCIDDA/flepimop2/issues/323).
+- A process step can name a `scenario`, and then runs once per scenario tuple with that tuple's values substituted into `{name}` placeholders in its configuration. A parameterized step remains a single node in the dependency graph, so a dependent step runs after all of its scenarios. Unknown scenario names are rejected before anything executes. See [#252](https://github.com/ACCIDDA/flepimop2/issues/252).
 
 ### Changed
 

--- a/docs/guides/scenarios.md
+++ b/docs/guides/scenarios.md
@@ -19,3 +19,45 @@ The processing step uses the outputs to create a plot.
     ```r
     --8<-- "assets/plot_scenarios.R"
     ```
+
+## Running a processing step per scenario
+
+Above, one processing step consumes the outputs of every scenario at once. The
+other common shape is the opposite: run the *same* processing step once per
+scenario, with each run given that scenario's values. A process step gets that
+by naming a scenario, exactly as a `simulate` entry does:
+
+```yaml
+scenarios:
+  sweep:
+    module: grid
+    parameters:
+      beta: [0.1, 0.2]
+      gamma: [0.05]
+
+process:
+  fetch:
+    module: shell
+    command: ./fetch_inputs.sh
+  analyze:
+    module: shell
+    depends: [fetch]
+    scenario: sweep
+    command: Rscript
+    args: ["analyze.R", "--beta", "{beta}", "--gamma", "{gamma}"]
+```
+
+`flepimop2 process -t analyze` runs `fetch` once and then `analyze` twice, once
+for `beta=0.1` and once for `beta=0.2`. A `grid` scenario takes the Cartesian
+product of its parameters, so adding a second value for `gamma` above would give
+four runs rather than two.
+
+Scenario values are filled in wherever the step's configuration mentions them as
+`{name}`, in any string field, including inside lists. Only the names the
+scenario actually defines are substituted, so other braces are left alone and a
+command such as `awk '{print $1}'` keeps working. The `module`, `depends`, and
+`scenario` keys describe the step itself and are never rewritten.
+
+A parameterized step stays a single node in the dependency graph. Anything that
+declares `depends: [analyze]` therefore runs after *all* of `analyze`'s
+scenarios have finished, rather than once per scenario.

--- a/src/flepimop2/cli/_process_command.py
+++ b/src/flepimop2/cli/_process_command.py
@@ -23,7 +23,7 @@ from flepimop2._utils._click import _resolve_config_target
 from flepimop2.cli._cli_command import CliCommand
 from flepimop2.configuration import ConfigurationModel
 from flepimop2.process.abc import build as build_process
-from flepimop2.process.abc import resolve_plan
+from flepimop2.process.abc import expand_scenarios, resolve_plan, validate_scenarios
 from flepimop2.typing import ExitCode
 
 # `--force` is a counter so that forcing a step and forcing everything it needs
@@ -127,15 +127,20 @@ class ProcessCommand(CliCommand):
         self.info(f"Process target: {processtargetname} => {processtarget}")
 
         plan = resolve_plan(processconfig, processtargetname)
+        # Scenario references are checked across the whole section before any
+        # step runs, for the same reason `depends` is: a typo should cost
+        # nothing rather than surface partway through a pipeline.
+        validate_scenarios(processconfig, configmodel.scenarios)
         if len(plan) > 1:
             self.info(f"Process plan: {' -> '.join(plan)}")
 
         for step in plan:
-            process_instance = build_process(processconfig[step])
             # One -f forces just the step asked for, leaving its dependencies
             # to their own satisfied-means-skip behaviour; -ff forces those too.
-            process_instance.execute(
-                dry_run=dry_run,
-                force=_should_force(force, step, processtargetname),
-            )
+            forced = _should_force(force, step, processtargetname)
+            configs = expand_scenarios(processconfig[step], configmodel.scenarios)
+            if len(configs) > 1:
+                self.info(f"Step '{step}' runs {len(configs)} scenarios.")
+            for config_ in configs:
+                build_process(config_).execute(dry_run=dry_run, force=forced)
         return ExitCode.OKAY

--- a/src/flepimop2/process/abc/__init__.py
+++ b/src/flepimop2/process/abc/__init__.py
@@ -23,6 +23,7 @@ __all__ = [
     "validate_scenarios",
 ]
 
+import re
 from abc import abstractmethod
 from collections.abc import Mapping
 from typing import Any
@@ -37,6 +38,7 @@ from flepimop2.scenario.abc import build as build_scenario
 # Configuration keys that describe the step itself rather than its work, and so
 # are never rewritten by a scenario.
 _STRUCTURAL_KEYS = frozenset({"module", "depends", "scenario"})
+_PLACEHOLDER_PATTERN = re.compile(r"\{([^{}]+)\}")
 
 
 class ProcessABC(ModuleBase, module_namespace="process"):
@@ -184,10 +186,12 @@ def _substitute(value: object, values: Mapping[str, object]) -> object:
     """
     Rewrite `{name}` placeholders in a configuration value.
 
-    Only the scenario's own names are substituted, and substitution is a plain
-    replacement rather than `str.format`, so braces that are not a scenario name
-    survive untouched. That matters because process steps are frequently shell
-    commands, where `awk '{print $1}'` is ordinary text rather than a template.
+    Only the scenario's own names are substituted, and all placeholders are
+    matched from the original string before replacement. Replacement values are
+    therefore not recursively interpreted as placeholders. Braces that are not
+    a scenario name survive untouched, which matters because process steps are
+    frequently shell commands, where `awk '{print $1}'` is ordinary text rather
+    than a template.
 
     A placeholder always resolves to text, even when it spans the whole value.
     Substituting the raw object instead would look tidier but breaks on the
@@ -218,9 +222,12 @@ def _substitute(value: object, values: Mapping[str, object]) -> object:
         return [_substitute(item, values) for item in value]
     if not isinstance(value, str):
         return value
-    for name, replacement in values.items():
-        value = value.replace("{" + name + "}", str(replacement))
-    return value
+
+    def replace(match: re.Match[str]) -> str:
+        name = match.group(1)
+        return str(values[name]) if name in values else match.group(0)
+
+    return _PLACEHOLDER_PATTERN.sub(replace, value)
 
 
 def _scenario_issues(

--- a/src/flepimop2/process/abc/__init__.py
+++ b/src/flepimop2/process/abc/__init__.py
@@ -15,16 +15,28 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """Abstract base class for flepimop2 processing steps."""
 
-__all__ = ["ProcessABC", "build", "resolve_plan"]
+__all__ = [
+    "ProcessABC",
+    "build",
+    "expand_scenarios",
+    "resolve_plan",
+    "validate_scenarios",
+]
 
 from abc import abstractmethod
+from collections.abc import Mapping
 from typing import Any
 
 from pydantic import Field
 
-from flepimop2._utils._module import _build
+from flepimop2._utils._module import _as_dict, _build
 from flepimop2.exceptions import Flepimop2ValidationError, ValidationIssue
 from flepimop2.module import ModuleBase
+from flepimop2.scenario.abc import build as build_scenario
+
+# Configuration keys that describe the step itself rather than its work, and so
+# are never rewritten by a scenario.
+_STRUCTURAL_KEYS = frozenset({"module", "depends", "scenario"})
 
 
 class ProcessABC(ModuleBase, module_namespace="process"):
@@ -36,10 +48,15 @@ class ProcessABC(ModuleBase, module_namespace="process"):
             must run before this one. These are opaque identifiers, i.e. sibling
             keys of the `process:` section, not filesystem paths: core orders
             steps but does not know what any of them produces.
+        scenario: Optional name of an entry in the top-level `scenarios:`
+            section. When set, the step runs once per scenario, with the
+            scenario's values substituted into this step's configuration (see
+            `expand_scenarios()`).
 
     """
 
     depends: list[str] = Field(default_factory=list)
+    scenario: str | None = None
 
     def execute(self, *, dry_run: bool = False, force: bool = False) -> None:
         """
@@ -138,6 +155,176 @@ def _declared_depends(entry: object) -> list[str]:
         declared = entry.get("depends") or []
         return [declared] if isinstance(declared, str) else list(declared)
     return []
+
+
+def _declared_scenario(entry: object) -> str | None:
+    """
+    Read the `scenario` name off a raw process configuration entry.
+
+    Read from the configuration for the same reason as `_declared_depends()`:
+    every reference can then be checked before any module is imported.
+
+    Args:
+        entry: A single process configuration entry.
+
+    Returns:
+        The declared scenario name, or `None` when the step declares none.
+
+    """
+    if isinstance(entry, ModuleBase):
+        declared = getattr(entry, "scenario", None)
+    elif isinstance(entry, dict):
+        declared = entry.get("scenario")
+    else:
+        return None
+    return declared if isinstance(declared, str) and declared else None
+
+
+def _substitute(value: object, values: Mapping[str, object]) -> object:
+    """
+    Rewrite `{name}` placeholders in a configuration value.
+
+    Only the scenario's own names are substituted, and substitution is a plain
+    replacement rather than `str.format`, so braces that are not a scenario name
+    survive untouched. That matters because process steps are frequently shell
+    commands, where `awk '{print $1}'` is ordinary text rather than a template.
+
+    A placeholder always resolves to text, even when it spans the whole value.
+    Substituting the raw object instead would look tidier but breaks on the
+    commonest field there is: a number dropped into a `list[str]` is rejected by
+    the module's own validation, whereas text is coerced back to whatever the
+    field declares (`"3"` into an `int` field is an `int`).
+
+    Args:
+        value: The configuration value to rewrite.
+        values: The scenario's names and their values.
+
+    Returns:
+        The value with any placeholders resolved.
+
+    Examples:
+        >>> from flepimop2.process.abc import _substitute
+        >>> _substitute("run --beta {beta}", {"beta": 0.3})
+        'run --beta 0.3'
+        >>> _substitute(["--n", "{n}"], {"n": 3})
+        ['--n', '3']
+        >>> _substitute("awk '{print $1}'", {"beta": 0.3})
+        "awk '{print $1}'"
+
+    """
+    if isinstance(value, dict):
+        return {key: _substitute(item, values) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_substitute(item, values) for item in value]
+    if not isinstance(value, str):
+        return value
+    for name, replacement in values.items():
+        value = value.replace("{" + name + "}", str(replacement))
+    return value
+
+
+def _scenario_issues(
+    section: dict[str, Any],
+    scenarios: Mapping[str, Any],
+) -> list[ValidationIssue]:
+    """
+    Collect every bad `scenario` reference in a process section.
+
+    Args:
+        section: The `process` configuration section.
+        scenarios: The top-level `scenarios` section.
+
+    Returns:
+        One issue per step naming a scenario that does not exist.
+
+    """
+    return [
+        ValidationIssue(
+            msg=f"Process step '{name}' names unknown scenario '{declared}'.",
+            kind="unknown_scenario",
+            ctx={"step": name, "scenario": declared, "known": sorted(scenarios)},
+        )
+        for name, entry in section.items()
+        if (declared := _declared_scenario(entry)) is not None
+        and declared not in scenarios
+    ]
+
+
+def validate_scenarios(
+    section: dict[str, Any],
+    scenarios: Mapping[str, Any],
+) -> None:
+    """
+    Check that every step's `scenario` names a defined scenario.
+
+    Run before executing a plan, so that a typo costs nothing rather than
+    surfacing partway through a pipeline. All bad references are reported
+    together, matching how `resolve_plan()` reports `depends` problems.
+
+    Args:
+        section: The `process` configuration section.
+        scenarios: The top-level `scenarios` section.
+
+    Raises:
+        Flepimop2ValidationError: If any step names a scenario that is not
+            defined.
+
+    """
+    if issues := _scenario_issues(section, scenarios):
+        raise Flepimop2ValidationError(issues)
+
+
+def expand_scenarios(
+    entry: dict[str, Any] | ModuleBase | str,
+    scenarios: Mapping[str, Any],
+) -> list[dict[str, Any]]:
+    """
+    Expand one process step into the configurations it should run as.
+
+    A step without a `scenario` yields its own configuration unchanged, so the
+    unparameterized case stays exactly as it was. A step naming a scenario
+    yields one configuration per scenario tuple, with that tuple's values
+    substituted into the step's non-structural fields (see `_substitute()`).
+
+    The fan-out deliberately happens *within* a plan step rather than by
+    multiplying plan entries: `depends` names steps, so keeping a step a single
+    node means a downstream step runs after every scenario of what it depends
+    on, and the dependency contract needs no notion of a per-scenario edge.
+
+    Args:
+        entry: A single process configuration entry.
+        scenarios: The top-level `scenarios` section.
+
+    Returns:
+        The configurations to execute, in scenario order.
+
+    Raises:
+        Flepimop2ValidationError: If the step names a scenario that is not
+            defined.
+
+    """
+    config = _as_dict(entry) if not isinstance(entry, str) else {"module": entry}
+    declared = _declared_scenario(entry)
+    if declared is None:
+        return [config]
+    if declared not in scenarios:
+        raise Flepimop2ValidationError([
+            ValidationIssue(
+                msg=f"Process step names unknown scenario '{declared}'.",
+                kind="unknown_scenario",
+                ctx={"scenario": declared, "known": sorted(scenarios)},
+            )
+        ])
+
+    scenario = build_scenario(scenarios[declared])
+    expanded: list[dict[str, Any]] = []
+    for tuple_ in scenario.scenarios():
+        values = tuple_._asdict()
+        expanded.append({
+            key: value if key in _STRUCTURAL_KEYS else _substitute(value, values)
+            for key, value in config.items()
+        })
+    return expanded
 
 
 def _depends_issues(depends: dict[str, list[str]]) -> list[ValidationIssue]:

--- a/tests/process/test_process_plan.py
+++ b/tests/process/test_process_plan.py
@@ -23,7 +23,14 @@ from flepimop2._utils._click import _click_param_for_option, _render_param
 from flepimop2.cli._options import get_option
 from flepimop2.cli._process_command import _should_force
 from flepimop2.exceptions import Flepimop2ValidationError
-from flepimop2.process.abc import ProcessABC, resolve_plan
+from flepimop2.process.abc import (
+    ProcessABC,
+    build,
+    expand_scenarios,
+    resolve_plan,
+    validate_scenarios,
+)
+from flepimop2.process.shell import ShellProcess
 
 
 def _step(depends: list[str] | None = None) -> dict[str, Any]:
@@ -303,3 +310,158 @@ def test_force_option_renders_back_to_repeated_short_flag() -> None:
     assert _render_param(param, 0) == []
     assert _render_param(param, 1) == ["-f"]
     assert _render_param(param, 2) == ["-ff"]
+
+
+# --- scenario parameterization ------------------------------------------------
+
+
+def _grid(**parameters: list[Any]) -> dict[str, Any]:
+    """
+    Build a grid scenario configuration entry.
+
+    Args:
+        **parameters: Scenario names mapped to the values they take.
+
+    Returns:
+        A scenario configuration entry.
+
+    """
+    return {"module": "grid", "parameters": parameters}
+
+
+def test_a_step_without_a_scenario_is_unchanged() -> None:
+    """The unparameterized case stays exactly one configuration."""
+    entry = {"module": "shell", "command": "run.sh"}
+    assert expand_scenarios(entry, {}) == [entry]
+
+
+def test_a_scenario_expands_a_step_once_per_tuple() -> None:
+    """A step naming a scenario runs once for each of its tuples."""
+    section_entry = {
+        "module": "shell",
+        "command": "run.sh",
+        "args": ["--beta", "{beta}"],
+        "scenario": "sweep",
+    }
+    configs = expand_scenarios(section_entry, {"sweep": _grid(beta=[0.1, 0.2])})
+
+    assert len(configs) == 2
+    assert [c["args"] for c in configs] == [["--beta", "0.1"], ["--beta", "0.2"]]
+
+
+def test_a_grid_scenario_expands_to_its_cartesian_product() -> None:
+    """Two scenario names give one configuration per combination."""
+    entry = {
+        "module": "shell",
+        "command": "run.sh --beta {beta} --gamma {gamma}",
+        "scenario": "sweep",
+    }
+    configs = expand_scenarios(entry, {"sweep": _grid(beta=[0.1, 0.2], gamma=[1, 2])})
+
+    assert [c["command"] for c in configs] == [
+        "run.sh --beta 0.1 --gamma 1",
+        "run.sh --beta 0.1 --gamma 2",
+        "run.sh --beta 0.2 --gamma 1",
+        "run.sh --beta 0.2 --gamma 2",
+    ]
+
+
+def test_substitution_leaves_structural_keys_alone() -> None:
+    """`module`, `depends`, and `scenario` describe the step, not its work."""
+    entry = {
+        "module": "shell",
+        "depends": ["fetch"],
+        "scenario": "sweep",
+        "command": "run.sh {beta}",
+    }
+    (config,) = expand_scenarios(entry, {"sweep": _grid(beta=[0.5])})
+
+    assert config["module"] == "shell"
+    assert config["depends"] == ["fetch"]
+    assert config["scenario"] == "sweep"
+    assert config["command"] == "run.sh 0.5"
+
+
+def test_substitution_survives_shell_brace_syntax() -> None:
+    """Braces that are not a scenario name are ordinary text.
+
+    Process steps are usually shell commands, where `awk '{print $1}'` is
+    perfectly normal, so substitution must not treat every brace as a template.
+    """
+    entry = {
+        "module": "shell",
+        "command": "awk '{print $1}' in.txt --beta {beta}",
+        "scenario": "sweep",
+    }
+    (config,) = expand_scenarios(entry, {"sweep": _grid(beta=[0.5])})
+
+    assert config["command"] == "awk '{print $1}' in.txt --beta 0.5"
+
+
+def test_expanded_configurations_build_into_process_modules() -> None:
+    """The expansion must produce configurations a module actually accepts.
+
+    Substituting as text rather than as the raw object is what makes this hold:
+    a float dropped into `ShellProcess.args` (a `list[str]`) would be rejected.
+    """
+    entry = {
+        "module": "shell",
+        "command": "echo",
+        "args": ["--beta", "{beta}"],
+        "scenario": "sweep",
+    }
+    (config,) = expand_scenarios(entry, {"sweep": _grid(beta=[0.25])})
+    instance = build(config)
+
+    assert isinstance(instance, ShellProcess)
+    assert instance.args == ["--beta", "0.25"]
+
+
+def test_expand_scenarios_rejects_an_unknown_scenario() -> None:
+    """A step naming a scenario that is not defined is an error."""
+    entry = {"module": "shell", "command": "run.sh", "scenario": "nope"}
+    with pytest.raises(Flepimop2ValidationError) as excinfo:
+        expand_scenarios(entry, {"sweep": _grid(beta=[0.1])})
+    assert excinfo.value.issues[0].kind == "unknown_scenario"
+
+
+def test_validate_scenarios_reports_every_bad_reference_at_once() -> None:
+    """Scenario typos are collected like `depends` typos, not raised one by one."""
+    section = {
+        "a": {"module": "shell", "command": "x", "scenario": "missing_one"},
+        "b": {"module": "shell", "command": "y", "scenario": "missing_two"},
+        "c": {"module": "shell", "command": "z"},
+    }
+    with pytest.raises(Flepimop2ValidationError) as excinfo:
+        validate_scenarios(section, {})
+    kinds = [issue.kind for issue in excinfo.value.issues]
+    assert kinds == ["unknown_scenario", "unknown_scenario"]
+
+
+def test_validate_scenarios_accepts_a_sound_section() -> None:
+    """A section whose scenario references all resolve raises nothing."""
+    section = {"a": {"module": "shell", "command": "x", "scenario": "sweep"}}
+    validate_scenarios(section, {"sweep": _grid(beta=[0.1])})
+
+
+def test_scenario_defaults_to_none() -> None:
+    """Declaring no scenario is the common case and needs no configuration."""
+
+    class _Plain3(ProcessABC, module="plain3"):
+        def _process(self, *, dry_run: bool) -> None:  # noqa: ARG002
+            return None
+
+    assert _Plain3().scenario is None
+
+
+def test_a_scenario_step_stays_one_node_in_the_plan() -> None:
+    """Fan-out happens inside a step, so the DAG contract is unchanged.
+
+    A downstream step therefore runs after *every* scenario of what it depends
+    on, and `depends` needs no notion of a per-scenario edge.
+    """
+    section = {
+        "sweep_step": {"module": "shell", "command": "x", "scenario": "sweep"},
+        "collect": {"module": "shell", "command": "y", "depends": ["sweep_step"]},
+    }
+    assert resolve_plan(section) == ["sweep_step", "collect"]

--- a/tests/process/test_process_plan.py
+++ b/tests/process/test_process_plan.py
@@ -398,6 +398,28 @@ def test_substitution_survives_shell_brace_syntax() -> None:
     assert config["command"] == "awk '{print $1}' in.txt --beta 0.5"
 
 
+@pytest.mark.parametrize(
+    "parameters",
+    [
+        {"first": ["{second}"], "second": ["VALUE"]},
+        {"second": ["VALUE"], "first": ["{second}"]},
+    ],
+    ids=["referencing-value-first", "referenced-value-first"],
+)
+def test_substitution_does_not_reinterpret_scenario_values(
+    parameters: dict[str, list[str]],
+) -> None:
+    """Replacement text is preserved regardless of parameter order."""
+    entry = {
+        "module": "shell",
+        "command": "{first} {second}",
+        "scenario": "sweep",
+    }
+    (config,) = expand_scenarios(entry, {"sweep": _grid(**parameters)})
+
+    assert config["command"] == "{second} VALUE"
+
+
 def test_expanded_configurations_build_into_process_modules() -> None:
     """The expansion must produce configurations a module actually accepts.
 


### PR DESCRIPTION
Closes #252.

## What changed

A process step can now name an entry in the top-level `scenarios:` section and runs once per scenario tuple, with that tuple's values substituted into its configuration:

```yaml
scenarios:
  sweep:
    module: grid
    parameters:
      beta: [0.1, 0.2]

process:
  fetch:
    module: shell
    command: ./fetch_inputs.sh
  analyze:
    module: shell
    depends: [fetch]
    scenario: sweep
    command: Rscript
    args: ["analyze.R", "--beta", "{beta}"]
```

`flepimop2 process -t analyze` runs `fetch` once, then `analyze` twice. Verified end to end through the CLI, not just at unit level.

This follows the existing precedent rather than inventing one: `SimulateSpecificationModel` already has a `scenario` field naming a key in `scenarios:`, and `SimulateCommand` already loops `scenario_config.scenarios()`. Process steps now do the same thing.

## Three decisions worth review

**1. Fan-out happens inside a plan step, not by multiplying plan nodes.** `depends` names steps, so if a parameterized step became N nodes, a downstream step would need to say *which* scenario it depends on, which means per-scenario dependency edges and a much larger change to the #323 contract. Keeping it one node means a dependent runs after all of its dependency's scenarios, which is also the intuitive reading. #323's DAG is untouched, and there's a test pinning that.

**2. Substitution is a plain replacement of the scenario's own names, not `str.format`.** Process steps are usually shell commands, and `awk '{print $1}'` is ordinary text there. Going through `str.format` would raise `KeyError` on it. Only names the scenario defines are replaced; every other brace survives. Test included.

**3. A placeholder always resolves to text.** I initially preserved the raw type when a value was exactly one placeholder, which reads nicer (`count: "{n}"` staying an `int`). It's wrong: pydantic **rejects** an `int` inside a `list[str]`, which is precisely `ShellProcess.args`, the most common field this will touch. It coerces the other direction happily (`"3"` into an `int` field is an `int`), so text substitution is strictly safer and loses nothing. There's a test that builds the expanded configs into real `ShellProcess` instances so this cannot regress into a runtime failure.

`module`, `depends`, and `scenario` describe the step rather than its work, so they are never rewritten.

## Validation

Scenario references are checked across the whole section before any step runs, collecting every bad name at once, matching `depends`. Confirmed that a typo aborts before the dependency executes rather than partway through the pipeline.

## Verification

- 20 new tests; `tests/process` + `tests/cli` at 126 passing.
- `ruff format`, `ruff check`, `mypy` (139 files), and doctests all clean.
- Full suite: 538 passed. The 85 failures there are identical on `main` (85 failed / 498 passed) and are a local environment issue, not from this change.
- Documented in `docs/guides/scenarios.md`, which already ended with a process step consuming scenario output, so the per-scenario shape belongs alongside it.